### PR TITLE
General fixes and some code rework

### DIFF
--- a/Autumn/ActionSystem/ActionHandler.cs
+++ b/Autumn/ActionSystem/ActionHandler.cs
@@ -328,7 +328,7 @@ internal class ActionHandler
                 if (window is not MainWindowContext mainContext)
                     return;
 
-                ChangeHandler.ChangeHideMultiple(mainContext.CurrentScene!.History, mainContext.CurrentScene.SelectedObjects, "IsVisible");
+                ChangeHandler.ChangeHideMultiple(mainContext.CurrentScene!.History, mainContext.CurrentScene.SelectedObjects);
             },
             enabled: window =>
                 window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjects.Any() && mainContext.IsSceneFocused

--- a/Autumn/FileSystems/RomFSHandler.cs
+++ b/Autumn/FileSystems/RomFSHandler.cs
@@ -1605,7 +1605,7 @@ internal partial class RomFSHandler
                     );
             }
         }
-        if (currentObj.Name != "Mario")
+        if (currentObj.Type != StageObjType.Start)
             currentObjectNodes.Add("l_id", new(BYAMLNodeType.Int, currentId));
 
         if (currentObj.Children != null && currentObj.Children.Any())

--- a/Autumn/GUI/ChangeHandler.cs
+++ b/Autumn/GUI/ChangeHandler.cs
@@ -141,19 +141,13 @@ internal static class ChangeHandler
 
     public static bool ChangeHideMultiple(
         ChangeHistory history,
-        IEnumerable<ISceneObj> sList,
-        string name
+        IEnumerable<ISceneObj> sList
     )
     {
-        FieldInfo? field = sList.FirstOrDefault()?.GetType().GetField(name);
-
-        if (field is null)
-            return false;
-
         List<bool> current = new();
         foreach (ISceneObj obj in sList)
         {
-            current.Add((bool)field.GetValue(obj)!);
+            current.Add(obj.IsVisible);
         }
         Change change =
         new(
@@ -162,7 +156,7 @@ internal static class ChangeHandler
                 int i = 0;
                 foreach (ISceneObj obj in sList)
                 {
-                    field.SetValue(obj, current[i]);
+                    obj.IsVisible =  current[i];
                     i++;
                 }
             },
@@ -171,7 +165,7 @@ internal static class ChangeHandler
                 int i = 0;
                 foreach (ISceneObj obj in sList)
                 {
-                    field.SetValue(obj, !current[i]);
+                    obj.IsVisible = !current[i];
                     i++;
                 }
             }

--- a/Autumn/GUI/Dialogs/EditChildrenDialog.cs
+++ b/Autumn/GUI/Dialogs/EditChildrenDialog.cs
@@ -13,9 +13,8 @@ namespace Autumn.GUI.Dialogs;
 /// <summary>
 /// A dialog that allows the user to set and unset objects as children of another.
 /// </summary>
-internal class EditChildrenDialog
+internal class EditChildrenDialog(MainWindowContext _window)
 {
-    private readonly MainWindowContext _window;
 
     private bool _isOpened = false;
     private string _name = string.Empty;
@@ -28,11 +27,11 @@ internal class EditChildrenDialog
 
     Vector2 dimensions = new(800, 450);
 
-    public EditChildrenDialog(MainWindowContext window, StageObj stageObj)
+
+    public void Open(StageObj stageObj)
     {
+
         Reset();
-        dimensions *= window.ScalingFactor;
-        _window = window;
         _parent = stageObj;
 
         if (_parent.Children is not null)
@@ -43,18 +42,19 @@ internal class EditChildrenDialog
 
         _sceneObjs = _window.CurrentScene!.EnumerateSceneObjs();
         _name = _parent.Name;
+        _isOpened = true;
     }
-
-    public void Open() => _isOpened = true;
 
     /// <summary>
     /// Resets all values from this dialog to their defaults.
     /// </summary>
     public void Reset()
     {
-        dimensions = new(800, 450);
+        dimensions = new Vector2(800, 450) * _window.ScalingFactor;
         _name = string.Empty;
         _parent = null;
+        _oldChildren = new();
+        _newChildren = new();
         _selectedObjs[0].Clear();
         _selectedObjs[1].Clear();
         _isOpened = false;

--- a/Autumn/GUI/Editors/ObjectWindow.cs
+++ b/Autumn/GUI/Editors/ObjectWindow.cs
@@ -101,10 +101,10 @@ internal class ObjectWindow(MainWindowContext window)
 
                 if (ImGui.Button(obj.IsVisible ? "\uF06E" : "\uF070", new(ImGui.GetColumnWidth(), default))) // Hide / Show
                 {
-                    ChangeHandler.ChangeFieldValue(
+                    ChangeHandler.ChangePropertyValue(
                         window.CurrentScene.History,
                         obj,
-                        "isVisible",
+                        "IsVisible",
                         obj.IsVisible,
                         !obj.IsVisible
                     );

--- a/Autumn/GUI/Editors/PropertiesWindow.cs
+++ b/Autumn/GUI/Editors/PropertiesWindow.cs
@@ -367,7 +367,7 @@ internal class PropertiesWindow(MainWindowContext window)
                                     );
                                 }
 
-				                ImGui.SameLine(default, style.ItemSpacing.X / 2);
+                                ImGui.SameLine(default, style.ItemSpacing.X / 2);
                                 if (ImGui.Button("\uf127##" + pName))
                                 {
                                     window.CurrentScene.Stage.GetStageFile(StageFileType.Map).UnlinkChild(stageObj);

--- a/Autumn/GUI/Editors/StageParamsWindow.cs
+++ b/Autumn/GUI/Editors/StageParamsWindow.cs
@@ -19,7 +19,6 @@ internal class ParametersWindow(MainWindowContext window)
     int musicIdx = 0;
     public bool FogEnabled = false;
     int selectedfog = -1;
-    Vector3 col = new();
     public bool LightEnabled = false;
     StageLight? selectedlight;
     int lightIdx;
@@ -582,7 +581,7 @@ internal class ParametersWindow(MainWindowContext window)
 
                 ImGui.Text("Constant 5");
                 ImGui.SameLine();
-                ImGuiWidgets.SetPropertyWidthGen("Constant 5", A, B);
+                ImGui.SetNextItemWidth(ImGuiWidgets.SetPropertyWidthGen("Constant 5", 22, 30) - 24 * window.ScalingFactor);
                 ImGui.ColorEdit4("##Constant 5", ref ColorEdit, _colorEditFlags);
                 if (ColorEdit != selectedlight.ConstantColors[5])
                 {

--- a/Autumn/GUI/Editors/StageWindow.cs
+++ b/Autumn/GUI/Editors/StageWindow.cs
@@ -75,7 +75,7 @@ internal class StageWindow
                     ImGui.TableNextRow();
                     ImGui.TableSetColumnIndex(0);
 
-                    if (ImGui.Selectable(name, false, ImGuiSelectableFlags.SpanAllColumns))
+                    if (ImGui.Selectable(name +$"##{name}{scenario}", false, ImGuiSelectableFlags.SpanAllColumns))
                     {
                         Scene? scene = window.Scenes.Find(scene =>
                             scene.Stage.Name == name && scene.Stage.Scenario == scenario
@@ -131,7 +131,7 @@ internal class StageWindow
                     ImGui.TableNextRow();
                     ImGui.TableSetColumnIndex(0);
 
-                    if (ImGui.Selectable(_stage.Stage + _stage.Scenario, false))
+                    if (ImGui.Selectable(_stage.Stage + $"##{_stage.Stage}{_stage.Scenario}", false))
                     {
                         Scene? scene = window.Scenes.Find(scene =>
                             scene.Stage.Name == _stage.Stage && scene.Stage.Scenario == _stage.Scenario

--- a/Autumn/GUI/Windows/MainWindowContext.cs
+++ b/Autumn/GUI/Windows/MainWindowContext.cs
@@ -7,6 +7,7 @@ using Autumn.GUI.Dialogs;
 using Autumn.GUI.Editors;
 using Autumn.Rendering;
 using Autumn.Rendering.Gizmo;
+using Autumn.Storage;
 using ImGuiNET;
 using SceneGL.GLHelpers;
 using Silk.NET.OpenGL;
@@ -26,7 +27,7 @@ internal class MainWindowContext : WindowContext
     public GLTaskScheduler GLTaskScheduler { get; } = new();
 
     public bool IsTransformActive => _sceneWindow.IsTransformActive;
-    public bool IsSceneFocused => _sceneWindow.IsWindowFocused;
+    public bool IsSceneFocused => _sceneWindow.IsWindowFocused || IsFocused;
 
     private bool _isFirstFrame = true;
 
@@ -34,7 +35,7 @@ internal class MainWindowContext : WindowContext
     private readonly ClosingDialog _closingDialog;
     private readonly NewStageObjDialog _newStageObjDialog;
     private SettingsDialog _settingsDialog;
-    public EditChildrenDialog? _editChildrenDialog;
+    public EditChildrenDialog _editChildrenDialog;
 
     private readonly StageWindow _stageWindow;
     private readonly ObjectWindow _objectWindow;
@@ -55,6 +56,7 @@ internal class MainWindowContext : WindowContext
         _closingDialog = new(this);
         _newStageObjDialog = new(this);
         _welcomeDialog = new(this);
+        _editChildrenDialog = new(this);
         _settingsDialog = new(this);
 
         // Initialize editors:
@@ -178,7 +180,7 @@ internal class MainWindowContext : WindowContext
             _addStageDialog.Render();
             _closingDialog.Render();
             _newStageObjDialog.Render();
-            _editChildrenDialog?.Render();
+            _editChildrenDialog.Render();
             _welcomeDialog.Render();
             _settingsDialog.Render();
 
@@ -232,7 +234,8 @@ internal class MainWindowContext : WindowContext
         _paramsWindow.SelectedSwitch = i;
         _paramsWindow.CurrentTab = 0;
     }
-
+    internal void SetupChildrenDialog(StageObj stageObj) => _editChildrenDialog.Open(stageObj);
+    
     /// <summary>
     /// Renders the main menu bar seen at the very top of the window.
     /// </summary>

--- a/Autumn/GUI/Windows/WindowContext.cs
+++ b/Autumn/GUI/Windows/WindowContext.cs
@@ -28,7 +28,7 @@ internal abstract class WindowContext
     public IKeyboard? Keyboard { get; protected set; }
     public IMouse? Mouse { get; protected set; }
 
-    public bool IsFocused { get; private set; }
+    public bool IsFocused { get; private set; } = true;
 
     public ContextHandler ContextHandler { get; }
     public WindowManager WindowManager { get; }

--- a/Autumn/Rendering/CtrH3D/H3DRenderingMaterial.cs
+++ b/Autumn/Rendering/CtrH3D/H3DRenderingMaterial.cs
@@ -620,12 +620,12 @@ internal class H3DRenderingMaterial
         );
     }
 
-    public void SetViewRotation(Quaternion Camera)
+    public void SetViewRotation(Vector3 camera)
     {        
         _materialBuffer.SetData(
             _materialBuffer.Data with
             {
-                CameraView = MathUtils.Round(Vector3.Transform(Vector3.UnitZ, Camera))
+                CameraView = camera
             }
         );
     }

--- a/Autumn/Rendering/ModelRenderer.cs
+++ b/Autumn/Rendering/ModelRenderer.cs
@@ -81,11 +81,11 @@ internal static class ModelRenderer
         }
     }
 
-    public static void UpdateScene(in Matrix4x4 view, in Matrix4x4 projection, Quaternion camera)
+    public static void UpdateSceneParams(in Matrix4x4 view, in Matrix4x4 projection, Quaternion camera)
     {
         if (s_commonSceneParams is null)
             throw new InvalidOperationException(
-                $@"{nameof(ModelRenderer)} must be initialized before any calls to {nameof(UpdateScene)}"
+                $@"{nameof(ModelRenderer)} must be initialized before any calls to {nameof(UpdateSceneParams)}"
             );
 
         s_viewMatrix = view;

--- a/Autumn/Rendering/ModelRenderer.cs
+++ b/Autumn/Rendering/ModelRenderer.cs
@@ -26,7 +26,7 @@ internal static class ModelRenderer
 
     private static Matrix4x4 s_viewMatrix = Matrix4x4.Identity;
     private static Matrix4x4 s_projectionMatrix = Matrix4x4.Identity;
-
+    private static Vector3 s_cameraRotation;
     private static H3DRenderingMaterial.Light _defaultLight = new()
     {
         Ambient = new(0.1f, 0.1f, 0.1f, 1),
@@ -50,7 +50,6 @@ internal static class ModelRenderer
     {
         DefaultCubeRenderer.Initialize(gl);
         AreaRenderer.Initialize(gl);
-
         s_commonSceneParams = new();
         s_defaultCubeMaterialParams = new(new(1, 0.5f, 0, 1), s_highlightColor);
 
@@ -82,15 +81,16 @@ internal static class ModelRenderer
         }
     }
 
-    public static void UpdateMatrices(in Matrix4x4 view, in Matrix4x4 projection)
+    public static void UpdateScene(in Matrix4x4 view, in Matrix4x4 projection, Quaternion camera)
     {
         if (s_commonSceneParams is null)
             throw new InvalidOperationException(
-                $@"{nameof(ModelRenderer)} must be initialized before any calls to {nameof(UpdateMatrices)}"
+                $@"{nameof(ModelRenderer)} must be initialized before any calls to {nameof(UpdateScene)}"
             );
 
         s_viewMatrix = view;
         s_projectionMatrix = projection;
+        s_cameraRotation = Vector3.Transform(Vector3.UnitZ, camera);
 
         s_commonSceneParams.ViewProjection = view * projection;
     }
@@ -160,6 +160,7 @@ internal static class ModelRenderer
                 material.SetSelectionColor(new(s_highlightColor, actorSceneObj.Selected ? 0.4f : 0));
                 material.SetMatrices(s_projectionMatrix, actorSceneObj.Transform, s_viewMatrix);
                 material.SetLight0(previewLight?.GetAsLight() ?? _defaultLight);
+                material.SetViewRotation(s_cameraRotation);
 
                 if (!material.TryUse(gl, out ProgramUniformScope scope))
                     continue;

--- a/Autumn/Rendering/Scene.cs
+++ b/Autumn/Rendering/Scene.cs
@@ -54,7 +54,7 @@ internal class Scene
 
     public void Render(GL gl, in Matrix4x4 view, in Matrix4x4 projection, Quaternion camera)
     {
-        ModelRenderer.UpdateScene(view, projection, camera);
+        ModelRenderer.UpdateSceneParams(view, projection, camera);
 
         foreach (ISceneObj obj in _sceneObjects)
             ModelRenderer.Draw(gl, obj, PreviewLight);

--- a/Autumn/Rendering/Scene.cs
+++ b/Autumn/Rendering/Scene.cs
@@ -52,9 +52,9 @@ internal class Scene
         GenerateFog();
     }
 
-    public void Render(GL gl, in Matrix4x4 view, in Matrix4x4 projection)
+    public void Render(GL gl, in Matrix4x4 view, in Matrix4x4 projection, Quaternion camera)
     {
-        ModelRenderer.UpdateMatrices(view, projection);
+        ModelRenderer.UpdateScene(view, projection, camera);
 
         foreach (ISceneObj obj in _sceneObjects)
             ModelRenderer.Draw(gl, obj, PreviewLight);

--- a/Autumn/Storage/StageLight.cs
+++ b/Autumn/Storage/StageLight.cs
@@ -161,7 +161,7 @@ internal class StageLight
     {
         return new()
         {
-            Position = -Direction,
+            Position = Direction,
             Direction = new(),
             Ambient = Ambient,
             Diffuse = Diffuse,


### PR DESCRIPTION
- Windows should start focused on Windows now which makes it so shortcuts work by default
- Fixed Hide not working (shortcut and gui)
- Cleaned up code related to children and parents
- Small fix in children editor where objects would have the last object's children
- Scale key is now set to S by default, only using F on wasd mode
- Fixed LightParams Constant Color 5 not showing an option to remove it after being added
- Possibly fixed issue with buttons turning transparent (From Properties window not beginning and the button color not being set back to normal)
- Fixed stages with the same name unable to be opened (was using just the name for the selectable, uses name+scenario now )
- Fixed issue with specularity and camera rotation not being set

(Let me know if I need to change anything)