### PR TITLE
CreatorClassNameTable editor, ClassDatabase entry editor and Yaz0 Compressor rewrite

### DIFF
--- a/Autumn/ActionSystem/ActionHandler.cs
+++ b/Autumn/ActionSystem/ActionHandler.cs
@@ -28,6 +28,7 @@ internal class ActionHandler
                 CommandID.NewProject => NewProject(),
                 CommandID.OpenProject => OpenProject(),
                 CommandID.OpenSettings => OpenSettings(),
+                CommandID.CloseScene => CloseScene(),
                 CommandID.Exit => Exit(),
                 CommandID.AddStage => AddStage(),
                 CommandID.SaveStage => SaveStage(),
@@ -266,6 +267,18 @@ internal class ActionHandler
                 mainWindow.OpenSettingsDialog();
             },
             enabled: window => window is MainWindowContext && window.ContextHandler.IsProjectLoaded
+        );
+    private static Command CloseScene() =>
+        new(
+            displayName: "Close Current Scene",
+            action: window =>
+            {
+                if (window is not MainWindowContext mainWindow)
+                    return;
+
+                mainWindow.CloseCurrentScene();
+            },
+            enabled: window => window is MainWindowContext mainContext && mainContext.CurrentScene is not null
         );
 
     private static Command SaveStage() =>

--- a/Autumn/ActionSystem/ActionHandler.cs
+++ b/Autumn/ActionSystem/ActionHandler.cs
@@ -33,14 +33,16 @@ internal class ActionHandler
                 CommandID.AddStage => AddStage(),
                 CommandID.SaveStage => SaveStage(),
                 CommandID.AddObject => AddObj(),
-                CommandID.AddALL => AddAllStages(),
-                CommandID.SaveALL => SaveAllStages(),
                 CommandID.RemoveObj => RemoveObj(),
                 CommandID.DuplicateObj => DuplicateObj(),
                 CommandID.HideObj => HideObj(),
                 CommandID.Undo => Undo(),
                 CommandID.Redo => Redo(),
                 CommandID.GotoParent => GotoParent(),
+                #if DEBUG
+                CommandID.AddALL => AddAllStages(),
+                CommandID.SaveALL => SaveAllStages(),
+                #endif
                 _ => null
             };
 
@@ -202,7 +204,7 @@ internal class ActionHandler
         );
     public static Command AddAllStages() =>
         new(
-            displayName: "Add ALL Stages",
+            displayName: "Open All Project Stages",
             action: window =>
             {
                 if (window is not MainWindowContext mainWindow)
@@ -232,7 +234,7 @@ internal class ActionHandler
         );
     public static Command SaveAllStages() =>
         new(
-            displayName: "Save ALL Stages",
+            displayName: "Save Open Stages",
             action: window =>
             {
                 if (window is not MainWindowContext mainWindow)

--- a/Autumn/Context/ContextHandler.cs
+++ b/Autumn/Context/ContextHandler.cs
@@ -39,6 +39,7 @@ internal class ContextHandler
         Settings = new(_globalSettings);
         SystemSettings = YAMLWrapper.Deserialize<SystemSettings>(sysSettingsFile) ?? new();
 
+        Yaz0Wrapper.Level = SystemSettings.Yaz0Compression;
         FSHandler = new(Settings.RomFSPath);
 
         var actions = YAMLWrapper.Deserialize<Dictionary<string, object>>(actionsFile);

--- a/Autumn/Context/SystemSettings.cs
+++ b/Autumn/Context/SystemSettings.cs
@@ -1,3 +1,6 @@
+using System.IO.Compression;
+using Autumn.Wrappers;
+
 namespace Autumn.Context;
 
 /// <summary>
@@ -18,6 +21,7 @@ internal class SystemSettings
     public bool UseWASD = false;
     public bool UseMiddleMouse = false;
     public bool EnableDBEditor = false;
+    public Yaz0Wrapper.CompressionLevel Yaz0Compression = Yaz0Wrapper.CompressionLevel.Medium;
 
     public void AddRecentlyOpenedPath(string path)
     {

--- a/Autumn/Context/SystemSettings.cs
+++ b/Autumn/Context/SystemSettings.cs
@@ -17,6 +17,7 @@ internal class SystemSettings
     public int MouseSpeed = 20;
     public bool UseWASD = false;
     public bool UseMiddleMouse = false;
+    public bool EnableDBEditor = false;
 
     public void AddRecentlyOpenedPath(string path)
     {

--- a/Autumn/Enums/CommandID.cs
+++ b/Autumn/Enums/CommandID.cs
@@ -5,6 +5,7 @@ internal enum CommandID
     NewProject,
     OpenProject,
     OpenSettings,
+    CloseScene,
     Exit,
     AddStage,
     AddALL,

--- a/Autumn/Enums/CommandID.cs
+++ b/Autumn/Enums/CommandID.cs
@@ -7,6 +7,8 @@ internal enum CommandID
     OpenSettings,
     Exit,
     AddStage,
+    AddALL,
+    SaveALL,
     SaveStage,
     Undo,
     Redo,

--- a/Autumn/Enums/CommandID.cs
+++ b/Autumn/Enums/CommandID.cs
@@ -8,8 +8,6 @@ internal enum CommandID
     CloseScene,
     Exit,
     AddStage,
-    AddALL,
-    SaveALL,
     SaveStage,
     Undo,
     Redo,
@@ -18,4 +16,6 @@ internal enum CommandID
     RemoveObj,
     HideObj,
     GotoParent,
+    AddALL,
+    SaveALL,
 }

--- a/Autumn/FileSystems/LayeredFSHandler.cs
+++ b/Autumn/FileSystems/LayeredFSHandler.cs
@@ -175,6 +175,13 @@ internal class LayeredFSHandler
 
         return new(new Dictionary<string, string>());
     }
+    public bool WriteCreatorClassNameTable(Dictionary<string, string> ccnt)
+    {
+        if (ModFS is not null)
+            return ModFS.WriteCCNT(ccnt);
+
+        return true;
+    }
 
     public BgmTable? ReadBgmTable()
     {
@@ -218,5 +225,10 @@ internal class LayeredFSHandler
             yield return ModFS.Root;
         if (OriginalFS is not null)
             yield return OriginalFS.Root;
+    }
+
+    public ReadOnlyDictionary<string,string> TryReadCCNT(string path)
+    {
+        return RomFSHandler.ReadAnyCreatorClassNameTable(path);
     }
 }

--- a/Autumn/FileSystems/LayeredFSHandler.cs
+++ b/Autumn/FileSystems/LayeredFSHandler.cs
@@ -227,8 +227,14 @@ internal class LayeredFSHandler
             yield return OriginalFS.Root;
     }
 
-    public ReadOnlyDictionary<string,string> TryReadCCNT(string path)
+    public ReadOnlyDictionary<string, string> TryReadCCNT(string path)
     {
         return RomFSHandler.ReadAnyCreatorClassNameTable(path);
+    }
+    public Stage? TryReadStage(string path)
+    {
+        if (ModFS == null || !File.Exists(path))
+            return null;
+        return ModFS.TryReadStage(path);
     }
 }

--- a/Autumn/FileSystems/RomFSHandler.cs
+++ b/Autumn/FileSystems/RomFSHandler.cs
@@ -126,6 +126,8 @@ internal partial class RomFSHandler
         string stg = Path.GetFileName(pth);
         string dir = Path.GetDirectoryName(pth)!;
         var match = _stagesRegex.Match(stg);
+        if (!match.Success)
+            return null;
         string name = match.Groups[1].Value;
         byte scenario = byte.Parse(match.Groups[3].Value);
     
@@ -1223,7 +1225,7 @@ internal partial class RomFSHandler
     {
         Console.WriteLine(Path.Join(_stagesPath, $"{stage.Name}Design{stage.Scenario}"));
         int currentId = 0;
-        bool saveBackup = true;
+        //bool saveBackup = true;
         // check objects in each stage type (map design sound), then on each type we check each Infos list
         Dictionary<StageFileType, string> paths =
             new()
@@ -1397,20 +1399,20 @@ internal partial class RomFSHandler
             }
             if (!st.IsEmpty())
                 narcFS.AddFileRoot("StageData.byml", binFile);
-            if (saveBackup)
-            {
-                if (File.Exists(paths[StageType]))
-                    File.Copy(paths[StageType], Path.Join(paths[StageType] + ".BACKUP"), true);
-                if (File.Exists(Path.Join(_stagesPath, $"{stage.Name}{StageType}{stage.Scenario}.narc")))
-                    File.Copy(Path.Join(_stagesPath, $"{stage.Name}{StageType}{stage.Scenario}.narc"), Path.Join(paths[StageType] + ".narc.BACKUP"), true);
-                if (File.Exists(paths[StageType] + "_StageData.byml"))
-                    File.Copy(paths[StageType] + "_StageData.byml", Path.Join(paths[StageType] + "_StageData.byml" + ".BACKUP"), true);
-            }
-            byte[] uncompressed = NARCParser.Write(narcFS.ToNARC());
+            //if (saveBackup)
+            //{
+            //    if (File.Exists(paths[StageType]))
+            //        File.Copy(paths[StageType], Path.Join(paths[StageType] + ".BACKUP"), true);
+            //    if (File.Exists(Path.Join(_stagesPath, $"{stage.Name}{StageType}{stage.Scenario}.narc")))
+            //        File.Copy(Path.Join(_stagesPath, $"{stage.Name}{StageType}{stage.Scenario}.narc"), Path.Join(paths[StageType] + ".narc.BACKUP"), true);
+            //    if (File.Exists(paths[StageType] + "_StageData.byml"))
+            //        File.Copy(paths[StageType] + "_StageData.byml", Path.Join(paths[StageType] + "_StageData.byml" + ".BACKUP"), true);
+            //}
+            //byte[] uncompressed = NARCParser.Write(narcFS.ToNARC());
             byte[] compressedFile = Yaz0Wrapper.Compress(NARCParser.Write(narcFS.ToNARC()));
-            File.WriteAllBytes(Path.Join(paths[StageType] + "_StageData.byml"), binFile);
+            //File.WriteAllBytes(Path.Join(paths[StageType] + "_StageData.byml"), binFile);
             File.WriteAllBytes(paths[StageType], compressedFile);
-            File.WriteAllBytes(Path.Join(_stagesPath, $"{stage.Name}{StageType}{stage.Scenario}.narc"), uncompressed);
+            //File.WriteAllBytes(Path.Join(_stagesPath, $"{stage.Name}{StageType}{stage.Scenario}.narc"), uncompressed);
         }
         return true;
     }

--- a/Autumn/FileSystems/RomFSHandler.cs
+++ b/Autumn/FileSystems/RomFSHandler.cs
@@ -1162,6 +1162,7 @@ internal partial class RomFSHandler
     public bool WriteStage(Stage stage, bool _useClassNames)
     {
         int currentId = 0;
+        bool saveBackup = true;
         // check objects in each stage type (map design sound), then on each type we check each Infos list
         Dictionary<StageFileType, string> paths =
             new()
@@ -1187,6 +1188,7 @@ internal partial class RomFSHandler
             }   
             else
             {
+                try {
                 dict.Add("AllInfos", new(BYAMLNodeType.Dictionary));
                 dict.Add("AllRailInfos", new(BYAMLNodeType.Dictionary));
                 dict.Add("LayerInfos", new(BYAMLNodeType.Array));
@@ -1300,7 +1302,11 @@ internal partial class RomFSHandler
                 dict["LayerInfos"].Value = layInfos;
                 rootdict = dict;
                 root.Value = rootdict;
-                file.RootNode = root;
+                file.RootNode = root;}
+                catch 
+                {
+                    Console.WriteLine("SOMETHING WENT WRONG DURING STAGE SAVING PLEASE CHECK THE LOGGED FILES");
+                }
             }
 
             NARCFileSystem narcFS = new(new());
@@ -1328,14 +1334,13 @@ internal partial class RomFSHandler
             }
             if (!st.IsEmpty())
                 narcFS.AddFileRoot("StageData.byml", binFile);
+            if (saveBackup)
+            {
+                File.Copy(paths[StageType], Path.Join(paths[StageType] + ".BACKUP"), true);
+            }
             byte[] compressedFile = Yaz0Wrapper.Compress(NARCParser.Write(narcFS.ToNARC()));
-
-            //          #if DEBUG
-            //          if (st.StageFileType == StageFileType.Map)
-            //          {
-            //              File.WriteAllBytes(Path.Join(paths[StageType] + "_StageData.byml"), binFile);
-            //          }
-            //          #endif
+            if (saveBackup)
+                File.WriteAllBytes(Path.Join(paths[StageType] + "_StageData.byml"), binFile);
             File.WriteAllBytes(paths[StageType], compressedFile);
         }
         return true;

--- a/Autumn/FileSystems/RomFSHandler.cs
+++ b/Autumn/FileSystems/RomFSHandler.cs
@@ -1336,6 +1336,7 @@ internal partial class RomFSHandler
                 narcFS.AddFileRoot("StageData.byml", binFile);
             if (saveBackup)
             {
+                if (File.Exists(paths[StageType]))
                 File.Copy(paths[StageType], Path.Join(paths[StageType] + ".BACKUP"), true);
             }
             byte[] compressedFile = Yaz0Wrapper.Compress(NARCParser.Write(narcFS.ToNARC()));

--- a/Autumn/GUI/Dialogs/AddStageDialog.cs
+++ b/Autumn/GUI/Dialogs/AddStageDialog.cs
@@ -118,7 +118,7 @@ internal class AddStageDialog
         {
             if (currentItem == 0)
             {
-                _foundStages = _window.ContextHandler.FSHandler.OriginalFS.EnumerateStages().Where(t => t.Name.Contains(_name, StringComparison.CurrentCultureIgnoreCase)).ToList();
+                _foundStages = _window.ContextHandler.FSHandler.OriginalFS.EnumerateStages().Where(t => t.Name.Contains(_name, StringComparison.InvariantCultureIgnoreCase)).ToList();
 
                 // Remove already opened stages:
                 foreach (var stage in _window.ContextHandler.ProjectStages)

--- a/Autumn/GUI/Dialogs/DatabaseEditorDialog.cs
+++ b/Autumn/GUI/Dialogs/DatabaseEditorDialog.cs
@@ -12,7 +12,6 @@ internal class DatabaseEditor(MainWindowContext _window)
 {
     private bool _isOpened = false;
     private SortedDictionary<string, ClassDatabaseWrapper.DatabaseEntry> _dbEntries;
-    private int[] _args = [-1, -1, -1, -1, -1, -1, -1, -1, -1, -1];
     private int _argsel = -1;
     readonly string[] switches = ["A", "B", "Appear", "Kill", "DeadOn"];
     readonly string[] switchTypes = ["None", "Read", "Write"];
@@ -345,10 +344,6 @@ internal class DatabaseEditor(MainWindowContext _window)
                                     argType = argData.Type;
                                 if (argData.Description is not null)
                                     argDescription = argData.Description;
-                                if (argData.Default is double)
-                                    _args[i] = Convert.ToInt32(argData.Default);
-                                else
-                                    _args[i] = (int)argData.Default;
                             }
                             else continue;
 
@@ -649,7 +644,12 @@ internal class DatabaseEditor(MainWindowContext _window)
             _editArgType = arg.Type == null || arg.Type == "int" ? 1 : arg.Type == "bool" ? 0 : 2;
             _editArgDesc = arg.Description ?? "";
             _editArgName = arg.Name ?? "";
-            _editArgDefault = (int)arg.Default;
+            if (arg.Default is double)
+                _editArgDefault = Convert.ToInt32(arg.Default);
+            else if (arg.Default is int)
+                _editArgDefault = (int)arg.Default;
+            else
+                _editArgDefault = -1;
             _editArgMin = arg.Min;
             _editArgMax = arg.Max;
             _editEnumValues = new();

--- a/Autumn/GUI/Dialogs/DatabaseEditorDialog.cs
+++ b/Autumn/GUI/Dialogs/DatabaseEditorDialog.cs
@@ -184,7 +184,7 @@ internal class DatabaseEditor(MainWindowContext _window)
                         {
                             editArgDefault = editEnumValues.Keys.ElementAt(dfsel);
                         }
-                        int removeAt = -1;
+                        int? removeAt = null;
                         if (ImGui.BeginTable("##enumvalues", 3, ImGuiTableFlags.RowBg
                                                     | ImGuiTableFlags.BordersOuter
                                                     | ImGuiTableFlags.BordersV
@@ -221,9 +221,9 @@ internal class DatabaseEditor(MainWindowContext _window)
                             }
                             ImGui.EndTable();
                         }
-                        if (removeAt > -1)
+                        if (removeAt != null)
                         {
-                            editEnumValues.Remove(removeAt);
+                            editEnumValues.Remove((int)removeAt);
                         }
                         if (editEnumValues.ContainsKey(curEnumVal))
                             ImGui.BeginDisabled();

--- a/Autumn/GUI/Dialogs/DatabaseEditorDialog.cs
+++ b/Autumn/GUI/Dialogs/DatabaseEditorDialog.cs
@@ -265,6 +265,7 @@ internal class DatabaseEditor(MainWindowContext _window)
                 if (ImGui.Button("OK", new(ImGui.GetContentRegionAvail().X, 30)))
                 {
                     SaveNewArg();
+                    UpdateEntry();
                     newPopup = false;
                 }
                 if (!canSave)
@@ -766,10 +767,6 @@ internal class DatabaseEditor(MainWindowContext _window)
                 tp = "enum";
                 break;
         }
-        if (entry.Args == null)
-        {
-            entry.Args = new();
-        }
 
         var arg = new ClassDatabaseWrapper.Arg()
         {
@@ -781,8 +778,14 @@ internal class DatabaseEditor(MainWindowContext _window)
             Min = editArgMin,
             Max = editArgMax
         };
+        var oldargs = entry.Args;
+        entry.Args = new();
+        if (oldargs != null)
+        foreach (string a in oldargs.Keys)
+        {
+            entry.Args[a] = oldargs[a];
+        }
         entry.Args[$"Arg{editArgId}"] = arg;
-        UpdateEntry();
     }
 
     private void SetArgs(bool clean = true)

--- a/Autumn/GUI/Dialogs/DatabaseEditorDialog.cs
+++ b/Autumn/GUI/Dialogs/DatabaseEditorDialog.cs
@@ -1,0 +1,799 @@
+using System.Numerics;
+using Autumn.ActionSystem;
+using Autumn.Enums;
+using Autumn.GUI.Windows;
+using Autumn.Utils;
+using Autumn.Wrappers;
+using ImGuiNET;
+
+namespace Autumn.GUI.Dialogs;
+
+internal class DatabaseEditor(MainWindowContext _window)
+{
+    private bool _isOpened = false;
+    private int[] _args = [-1, -1, -1, -1, -1, -1, -1, -1, -1, -1];
+    private int _argsel = -1;
+    string[] switches = ["A", "B", "Appear", "Kill", "DeadOn"];
+    string[] switchStates = ["None", "Read", "Write"];
+    private string _swsel = "";
+    private SortedDictionary<string, ClassDatabaseWrapper.DatabaseEntry> _dbEntries;
+    private List<string> _modifiedEntries = new();
+    private string _search = "";
+    private ClassDatabaseWrapper.DatabaseEntry oldEntry;
+    private ClassDatabaseWrapper.DatabaseEntry entry;
+    private string newClassName = "";
+    Vector2 dimensions = new(742, 520);
+    bool newPopup = false;
+    string[] ActorTypes = ["Obj", "AreaObj", "CameraAreaObj", "GoalObj", "StartEventObj", "Demo"];
+    string[] filter = ["All"];
+    int filterIdx = 0;
+    bool editClassName = false;
+    bool _isEditor = true;
+
+
+    bool debugflag = false;
+
+
+    bool editArgCanOverwrite = false;
+    int editArgId = 0; // 0 through 9
+    int editArgType = 1; // Bool, Int, Enum
+    string[] editArgTypes = ["bool", "int", "enum"];
+    string editArgDesc = "";
+    string editArgName = "";
+    int editArgDefault = -1;
+    int? editArgMin;
+    int? editArgMax;
+    Dictionary<int, string> editEnumValues = new();
+    string curEnumName = "";
+    int curEnumVal = -1;
+
+    public void Open()
+    {
+        Reset();
+        _isOpened = true;
+        _dbEntries = new(ClassDatabaseWrapper.DatabaseEntries);
+        filter = filter.Concat(ActorTypes).ToArray();
+        _isEditor = _window.ContextHandler.SystemSettings.EnableDBEditor;
+    }
+    public void Reset()
+    {
+        dimensions = new Vector2(742, 520) * _window.ScalingFactor;
+        oldEntry = new();
+        entry = new();
+        _modifiedEntries.Clear();
+        _search = "";
+    }
+    public void Render()
+    {
+        if (!_isOpened)
+            return;
+
+        if (ImGui.IsKeyPressed(ImGuiKey.Escape))
+        {
+            if (newPopup)
+                newPopup = false;
+            else
+            {
+                if (!ImGui.GetIO().WantTextInput) // prevent exiting when input is focused
+                {
+                    Reset();
+                    _isOpened = false;
+                    ImGui.CloseCurrentPopup();
+                }
+            }
+        }
+
+        ImGui.OpenPopup("Class Database Editor");
+
+        ImGui.SetNextWindowSize(dimensions, ImGuiCond.Always);
+        ImGui.SetNextWindowPos(ImGui.GetMainViewport().GetCenter(), ImGuiCond.Appearing, new(0.5f, 0.5f));
+
+        if (
+            !ImGui.BeginPopupModal(
+                "Class Database Editor",
+                ref _isOpened,
+                ImGuiWindowFlags.NoSavedSettings | ImGuiWindowFlags.NoScrollWithMouse | ImGuiWindowFlags.NoScrollbar
+            )
+        )
+            return;
+        dimensions = ImGui.GetWindowSize();
+        var style = ImGui.GetStyle();
+
+        if (newPopup)
+        {
+            ImGui.OpenPopup("Edit Arg");
+            ImGui.SetNextWindowSize(dimensions / 2.8f, ImGuiCond.Appearing);
+            ImGui.SetNextWindowPos(ImGui.GetMainViewport().GetCenter(), ImGuiCond.Appearing, new(0.5f, 0.5f));
+            if (ImGui.BeginPopupModal("Edit Arg", ref newPopup, ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.Popup | ImGuiWindowFlags.AlwaysAutoResize))
+            {
+                if (editArgCanOverwrite)
+                    ImGui.BeginDisabled();
+                ImGui.Text("Arg ID:");
+                ImGui.SameLine();
+                ImGui.SetNextItemWidth(ImGuiWidgets.SetPropertyWidthGen("Arg ID"));
+                ImGui.InputInt("##argid", ref editArgId, 1);
+                editArgId = int.Clamp(editArgId, 0, 9);
+                if (editArgCanOverwrite)
+                    ImGui.EndDisabled();
+                ImGui.Text("Arg name:");
+                ImGui.SameLine();
+                ImGui.SetNextItemWidth(ImGuiWidgets.SetPropertyWidthGen("Arg name"));
+                ImGui.InputTextWithHint("##argname", "Name", ref editArgName, 128);
+                ImGui.Text("Description:");
+                ImGui.SameLine();
+                ImGui.SetNextItemWidth(ImGuiWidgets.SetPropertyWidthGen("Description"));
+                ImGui.InputTextWithHint("##argdesc", "Description", ref editArgDesc, 128);
+                ImGui.Text("Type:");
+                ImGui.SameLine();
+                ImGui.SetNextItemWidth(ImGuiWidgets.SetPropertyWidthGen("Type"));
+                ImGui.Combo("##argtype", ref editArgType, editArgTypes, 3);
+                ImGui.Text("Default:");
+                ImGui.SameLine();
+                ImGui.SetNextItemWidth(ImGuiWidgets.SetPropertyWidthGen("Default"));
+
+                switch (editArgType)
+                {
+                    case 0:
+
+                        int df = editArgDefault == -1 ? 0 : 1;
+                        ImGui.Combo("##defboolval", ref df, ["False", "True"], 2);
+                        editArgDefault = df == 0 ? -1 : 0;
+                        break;
+
+                    case 1:
+                        ImGui.InputInt("##defval", ref editArgDefault, 1);
+                        int min = editArgMin ?? -1;
+                        int max = editArgMax ?? -1;
+                        ImGui.Text("Min:");
+                        ImGui.SameLine();
+                        ImGui.SetNextItemWidth(ImGuiWidgets.SetPropertyWidthGen("Min"));
+                        ImGui.InputInt("##minval", ref min, 1);
+                        if (min != editArgMin) editArgMin = min;
+                        ImGui.Text("Min:");
+                        ImGui.SameLine();
+                        ImGui.SetNextItemWidth(ImGuiWidgets.SetPropertyWidthGen("Max"));
+                        ImGui.InputInt("##maxval", ref max, 1);
+                        if (max != editArgMax) editArgMax = max;
+                        break;
+                    case 2:
+                        var dfsel = editEnumValues.Keys.ToList().IndexOf(editArgDefault);
+                        ImGui.Combo("##defval", ref dfsel, editEnumValues.Values.ToArray(), editEnumValues.Keys.Count);
+                        if (dfsel != editEnumValues.Keys.ToList().IndexOf(editArgDefault))
+                        {
+                            editArgDefault = editEnumValues.Keys.ElementAt(dfsel);
+                        }
+                        int removeAt = -1;
+                        if (ImGui.BeginTable("##enumvalues", 3, ImGuiTableFlags.RowBg
+                                                    | ImGuiTableFlags.BordersOuter
+                                                    | ImGuiTableFlags.BordersV
+                                                    | ImGuiTableFlags.ScrollY
+                                                    | ImGuiTableFlags.Resizable,
+                                                    new(ImGui.GetContentRegionAvail().X, 150)
+                                                    ))
+                        {
+                            ImGui.TableSetupScrollFreeze(0, 1); // Makes top row always visible.
+                            ImGui.TableSetupColumn("Name", ImGuiTableColumnFlags.WidthStretch, 0.9f);
+                            ImGui.TableSetupColumn("Value", ImGuiTableColumnFlags.None);
+                            ImGui.TableSetupColumn("##delete", ImGuiTableColumnFlags.None, 0.1f);
+                            ImGui.TableHeadersRow();
+                            foreach (int i in editEnumValues.Keys)
+                            {
+                                ImGui.TableNextRow();
+                                ImGui.TableSetColumnIndex(0);
+                                if (ImGui.Selectable(editEnumValues[i] + $"##{i}sl", false))
+                                {
+                                    curEnumName = editEnumValues[i];
+                                    curEnumVal = i;
+                                }
+                                ImGui.TableSetColumnIndex(1);
+                                if (ImGui.Selectable(i + $"##{i}slid", false))
+                                {
+                                    curEnumName = editEnumValues[i];
+                                    curEnumVal = i;
+                                }
+                                ImGui.TableSetColumnIndex(2);
+                                if (ImGui.Selectable(IconUtils.MINUS + $"##{i}dl"))
+                                {
+                                    removeAt = i;
+                                }
+                            }
+                            ImGui.EndTable();
+                        }
+                        if (removeAt > -1)
+                        {
+                            editEnumValues.Remove(removeAt);
+                        }
+                        if (editEnumValues.ContainsKey(curEnumVal))
+                            ImGui.BeginDisabled();
+                        if (ImGui.Button("Add", new(ImGui.GetContentRegionAvail().X, 25)))
+                        {
+                            editEnumValues[curEnumVal] = curEnumName;
+                        }
+                        if (editEnumValues.ContainsKey(curEnumVal))
+                            ImGui.EndDisabled();
+
+                        ImGui.Text("Name:");
+                        ImGui.SameLine();
+                        ImGui.SetNextItemWidth(ImGuiWidgets.SetPropertyWidthGen("Arg Name"));
+                        if (ImGui.InputText("##opName", ref curEnumName, 128) && editEnumValues.ContainsKey(curEnumVal))
+                        {
+                            editEnumValues[curEnumVal] = curEnumName;
+                        }
+                        if (!string.IsNullOrWhiteSpace(curEnumName))
+                            ImGui.SetItemTooltip(curEnumName);
+                        ImGui.Text("Value:");
+                        ImGui.SameLine();
+                        ImGui.SetNextItemWidth(ImGuiWidgets.SetPropertyWidthGen("Arg Value"));
+                        ImGui.InputInt("##opVal", ref curEnumVal, 1);
+                        break;
+                }
+
+
+                ImGui.Separator();
+                bool canSave = entry.Args == null || !entry.Args.ContainsKey($"Arg{editArgId}") || editArgCanOverwrite;
+
+                if (ImGui.Button("Cancel", new(ImGui.GetContentRegionAvail().X / 2, 30)))
+                {
+                    newPopup = false;
+                }
+                ImGui.SameLine(default, style.ItemSpacing.X / 2);
+
+                if (!canSave)
+                    ImGui.BeginDisabled();
+                if (ImGui.Button("OK", new(ImGui.GetContentRegionAvail().X, 30)))
+                {
+                    SaveNewArg();
+                    newPopup = false;
+                }
+                if (!canSave)
+                    ImGui.EndDisabled();
+
+            }
+            ImGui.End();
+        }
+        if (newPopup)
+            ImGui.BeginDisabled();
+        if (ImGui.BeginChild("LEFTSIDE", new(ImGui.GetContentRegionAvail().X * 18 / 30, ImGui.GetContentRegionAvail().Y - 30)))
+        {
+            ImGui.SetNextItemWidth(ImGui.GetWindowWidth() / 2 - style.ItemSpacing.X / 2);
+            ImGui.InputTextWithHint("##SEARCHBOX", "Class or Documented name", ref _search, 100);
+            ImGui.SameLine();
+            ImGui.SetNextItemWidth(ImGui.GetWindowWidth() / 2 - style.ItemSpacing.X / 2);
+            ImGui.Combo("##Filter", ref filterIdx, filter, filter.Length);
+            if (ImGui.BeginTable("ClassTable", 2,
+                                                    ImGuiTableFlags.RowBg
+                                                    | ImGuiTableFlags.BordersOuter
+                                                    | ImGuiTableFlags.BordersV
+                                                    | ImGuiTableFlags.ScrollY, new(ImGui.GetWindowWidth() - 1, ImGui.GetContentRegionAvail().Y - 30)))
+            {
+                int i = 0;
+                ImGui.TableSetupScrollFreeze(0, 1); // Makes top row always visible.
+                ImGui.TableSetupColumn("Documented Name", ImGuiTableColumnFlags.None, 0.5f);
+                ImGui.TableSetupColumn("Class Name", ImGuiTableColumnFlags.None, 0.5f);
+                ImGui.TableHeadersRow();
+                foreach (string s in _dbEntries.Keys)
+                {
+                    if (!string.IsNullOrEmpty(_search)
+                    && !s.Contains(_search, StringComparison.InvariantCultureIgnoreCase)
+                    && (_dbEntries[s].Name == null
+                    || !_dbEntries[s].Name!.Contains(_search, StringComparison.InvariantCultureIgnoreCase)))
+                        continue;
+                    switch (filterIdx)
+                    {
+                        case 1:
+                            if (_dbEntries[s].Type != null) continue;
+                            break;
+                        case 2:
+                            if (_dbEntries[s].Type != "AreaObj") continue;
+                            break;
+                        case 3:
+                            if (_dbEntries[s].Type != "CameraAreaObj") continue;
+                            break;
+                        case 4:
+                            if (_dbEntries[s].Type != "GoalObj") continue;
+                            break;
+                        case 5:
+                            if (_dbEntries[s].Type != "StartEventObj") continue;
+                            break;
+                        case 6:
+                            if (_dbEntries[s].Type != "Demo") continue;
+                            break;
+                    }
+                    ImGui.TableNextRow();
+                    ImGui.TableSetColumnIndex(0);
+                    ImGui.Text(_dbEntries[s].Name != null ? _dbEntries[s].Name : "");
+                    ImGui.TableSetColumnIndex(1);
+                    if (ImGui.Selectable(s + $"##{i}", s == oldEntry.ClassName, ImGuiSelectableFlags.SpanAllColumns))
+                    {
+                        oldEntry = _dbEntries[s];
+                        entry = _dbEntries[s];
+                        editClassName = false;
+                        _argsel = -1;
+                    }
+                    i++;
+                }
+                ImGui.EndTable();
+            }
+            if (oldEntry.ClassName == null)
+                ImGui.BeginDisabled();
+            if (ImGui.Button(IconUtils.MINUS, new(ImGui.GetContentRegionAvail().X / 2, default))) // -
+            {
+                _dbEntries.Remove(oldEntry.ClassName);
+                oldEntry = new();
+                entry = new();
+            }
+            if (oldEntry.ClassName == null)
+                ImGui.EndDisabled();
+            ImGui.SameLine(default, ImGui.GetStyle().ItemSpacing.X / 2);
+            if (ImGui.Button(IconUtils.PLUS, new(ImGui.GetContentRegionAvail().X, default))) // +
+            {
+                //newPopup = true;
+
+                for (int i = 0; i < 999; i++)
+                {
+                    if (_dbEntries.ContainsKey($"NewObj{i}")) continue;
+                    oldEntry = new() { ClassName = $"NewObj{i}" };
+                    entry = oldEntry;
+                    _dbEntries.Add(oldEntry.ClassName, oldEntry);
+                    break;
+                }
+            }
+        }
+        ImGui.EndChild();
+        ImGui.SameLine();
+
+        bool update = false;
+        if (ImGui.BeginChild("RIGHTSIDE", new(ImGui.GetContentRegionAvail().X, ImGui.GetContentRegionAvail().Y - 30)))
+        {
+            ImGui.SetWindowFontScale(1.3f);
+            if (string.IsNullOrEmpty(entry.ClassName))
+                ImGui.TextDisabled("No entry selected");
+            else
+                ImGui.Text("Class: " + entry.ClassName);
+            ImGui.SetWindowFontScale(1f);
+            ImGui.Separator();
+            ImGui.Spacing();
+            if (string.IsNullOrEmpty(entry.ClassName))
+                ImGui.BeginDisabled();
+            if (!editClassName)
+                ImGui.BeginDisabled();
+            ImGui.Text("Class Name:");
+            ImGui.SameLine();
+            ImGui.SetNextItemWidth(ImGuiWidgets.SetPropertyWidthGen("Class Name", 20, 30) + style.ItemSpacing.X - 24);
+            string className = entry.ClassName ?? "";
+
+            if (ImGui.InputText("##clsname", ref className, 128, ImGuiInputTextFlags.EnterReturnsTrue) && !_dbEntries.ContainsKey(className) && className != entry.ClassName)
+            {
+                UpdateClassEntry(className != "" ? className : null);
+            }
+            if (!editClassName)
+                ImGui.EndDisabled();
+            ImGui.SameLine(default, 0);
+            if (ImGui.Button(IconUtils.PENCIL))
+            {
+                editClassName = !editClassName;
+            }
+
+            ImGui.Text("Entry Name:");
+            ImGui.SameLine();
+            ImGui.SetNextItemWidth(ImGuiWidgets.SetPropertyWidthGen("Entry Name", 20, 30) + style.ItemSpacing.X);
+            string entryName = entry.Name ?? "";
+            ImGui.InputText("##name", ref entryName, 128);
+            if (entryName != (entry.Name ?? ""))
+            {
+                entry.Name = entryName != "" ? entryName : null;
+                update = true;
+            }
+
+            ImGui.Text("Description:");
+            ImGui.SameLine();
+            string entryDesc = entry.Description ?? "";
+            ImGui.SetNextItemWidth(ImGuiWidgets.SetPropertyWidthGen("Description", 20, 30) + style.ItemSpacing.X);
+            ImGui.InputText("##Descriptionname", ref entryDesc, 1024);
+            if (entryDesc != (entry.Description ?? ""))
+            {
+                entry.Description = entryDesc != "" ? entryDesc : null;
+                update = true;
+            }
+
+            string entryType = entry.Type ?? "Obj";
+            if (entryType == "Obj")
+            {
+                ImGui.Text("Archive:");
+                ImGui.SameLine();
+                string entryArchive = entry.ArchiveName ?? "";
+                ImGui.SetNextItemWidth(ImGuiWidgets.SetPropertyWidthGen("Archive", 20, 30) + style.ItemSpacing.X);
+                ImGui.InputText("##archive", ref entryArchive, 1024);
+                if (entryArchive != (entry.ArchiveName ?? ""))
+                {
+                    entry.ArchiveName = entryArchive != "" ? entryArchive : null;
+                    update = true;
+                }
+                ImGui.SetItemTooltip("Default model to use for this object if it cannot be found from class or object name");
+            }
+            else if (entry.ArchiveName != null) // Disable archivename for non objs
+            {
+                entry.ArchiveName = null;
+            }
+
+            ImGui.Text("Needs Rail:");
+            ImGui.SameLine();
+            bool RailRequired = entry.RailRequired;
+            ImGui.SetNextItemWidth(ImGuiWidgets.SetPropertyWidthGen("Needs Rail", 20, 30) + style.ItemSpacing.X);
+            ImGui.Checkbox("##railr", ref RailRequired);
+            if (RailRequired != entry.RailRequired)
+            {
+                entry.RailRequired = RailRequired;
+                update = true;
+            }
+
+            ImGui.Text("Type:");
+            ImGui.SameLine();
+            int itype = Array.IndexOf(ActorTypes, entryType);
+            ImGui.SetNextItemWidth(ImGuiWidgets.SetPropertyWidthGen("Type", 20, 30) + style.ItemSpacing.X);
+            ImGui.Combo("##etype", ref itype, ActorTypes, ActorTypes.Length);
+            if (itype != Array.IndexOf(ActorTypes, entryType))
+            {
+                entry.Type = ActorTypes[itype] != "Obj" ? ActorTypes[itype] : null; // Since most classes are obj we don't add the property
+                update = true;
+            }
+
+            // ImGui.SetWindowFontScale(1.3f);
+            // if (entry.Name == null)
+            //     ImGui.TextDisabled("Undocumented class");
+            // else
+            //     ImGui.Text(entry.Name);
+            // ImGui.SetWindowFontScale(1f);
+
+            Vector2 descriptionSize = new(ImGui.GetContentRegionAvail().X - 2, -3);
+            if (ImGui.BeginTabBar("##tabs", ImGuiTabBarFlags.NoCloseWithMiddleMouseButton))
+            {
+                if (ImGui.BeginTabItem("Args"))
+                {
+                    if (
+                        ImGui.BeginTable(
+                            "ArgTable",
+                            3,
+                            ImGuiTableFlags.ScrollY
+                            | ImGuiTableFlags.RowBg
+                            | ImGuiTableFlags.BordersOuter
+                            | ImGuiTableFlags.BordersV
+                            | ImGuiTableFlags.Resizable,
+                            new(descriptionSize.X, descriptionSize.Y - 23 - style.ItemSpacing.Y))
+                    )
+                    {
+                        bool isObj = entry.Type == null;
+                        ImGui.TableSetupScrollFreeze(0, 1);
+                        ImGui.TableSetupColumn("Arg", ImGuiTableColumnFlags.None, 0.3f);
+                        ImGui.TableSetupColumn("Type", ImGuiTableColumnFlags.None, 0.35f);
+                        ImGui.TableSetupColumn("Name");
+                        ImGui.TableHeadersRow();
+                        var m = isObj ? 10 : 8;
+                        for (int i = 0; i < m; i++)
+                        {
+                            string arg = $"Arg{i}";
+                            string argName = "";
+                            string argDescription = "";
+                            string argType = "int";
+                            if (
+                                entry.Args is not null
+                                && entry.Args.TryGetValue(arg, out var argData)
+                            )
+                            {
+                                if (argData.Name is not null)
+                                    argName = argData.Name;
+                                if (argData.Type is not null)
+                                    argType = argData.Type;
+                                if (argData.Description is not null)
+                                    argDescription = argData.Description;
+                                if (argData.Default is double)
+                                    _args[i] = Convert.ToInt32(argData.Default);
+                                else
+                                    _args[i] = (int)argData.Default;
+                            }
+                            else continue;
+
+                            ImGui.TableNextRow();
+
+                            ImGui.TableSetColumnIndex(0);
+                            if (ImGui.Selectable(arg, _argsel == i, ImGuiSelectableFlags.SpanAllColumns | ImGuiSelectableFlags.AllowDoubleClick, new(default, 30)))
+                            {
+                                _argsel = i;
+                                if (ImGui.IsMouseDoubleClicked(ImGuiMouseButton.Left))
+                                {
+                                    SetArgs(false);
+                                    newPopup = true;
+                                }
+                            }
+                            if (!string.IsNullOrWhiteSpace(argDescription))
+                                ImGui.SetItemTooltip(argDescription);
+                            ImGui.TableSetColumnIndex(1);
+                            ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
+                            ImGui.Text(argType);
+                            ImGui.TableSetColumnIndex(2);
+                            ImGui.Text(argName);
+                        }
+
+                        ImGui.EndTable();
+
+                        if (_argsel < 0 || entry.Args == null)
+                            ImGui.BeginDisabled();
+                        if (ImGui.Button("Remove ARG", new(ImGui.GetContentRegionAvail().X / 2, default)))
+                        {
+                            entry.Args.Remove($"Arg{_argsel}");
+                            _argsel = -1;
+                            update = true;
+                        }
+                        if (_argsel < 0 || entry.Args == null)
+                            ImGui.EndDisabled();
+                        ImGui.SameLine(default, style.ItemSpacing.X / 2);
+                        if (ImGui.Button("Add ARG", new(ImGui.GetContentRegionAvail().X, default)))
+                        {
+                            SetArgs();
+                            newPopup = true;
+                            update = true;
+                        }
+                    }
+                    ImGui.EndTabItem();
+                }
+                if (ImGui.BeginTabItem("Switches"))
+                {
+                    if (
+                        ImGui.BeginTable(
+                            "SwitchTable",
+                            3,
+                            ImGuiTableFlags.ScrollY
+                            | ImGuiTableFlags.RowBg
+                            | ImGuiTableFlags.BordersOuter
+                            | ImGuiTableFlags.BordersV
+                            | ImGuiTableFlags.Resizable,
+                            new(descriptionSize.X, descriptionSize.Y - 23 - style.ItemSpacing.Y))
+                    )
+                    {
+                        ImGui.TableSetupScrollFreeze(0, 1);
+                        ImGui.TableSetupColumn("Switch", ImGuiTableColumnFlags.None, 0.3f);
+                        ImGui.TableSetupColumn("Type", ImGuiTableColumnFlags.None, 0.4f);
+                        ImGui.TableSetupColumn("##remove");
+                        ImGui.TableHeadersRow();
+                        foreach (string swn in switches)
+                        {
+                            string swName = $"Switch{swn}";
+                            string swDescription = "";
+                            string swType = "";
+
+                            if (entry.Switches != null && entry.Switches.ContainsKey(swName) && entry.Switches[swName] != null)
+                            {
+                                swDescription = entry.Switches[swName]!.Value.Description;
+                                swType = entry.Switches[swName]!.Value.Type;
+                            }
+                            ImGui.TableNextRow();
+
+                            ImGui.TableSetColumnIndex(0);
+                            ImGui.Text(swn);
+                            ImGui.TableSetColumnIndex(1);
+                            ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
+                            int swi = Array.IndexOf(switchStates, swType == "" ? "None" : swType);
+                            ImGui.Combo($"##swcombo{swn}", ref swi, switchStates, 3);
+                            if (swi != Array.IndexOf(switchStates, swType == "" ? "None" : swType))
+                            {
+                                swType = swi == 0 ? "" : switchStates[swi];
+                                update = true;
+                            }
+                            ImGui.TableSetColumnIndex(2);
+                            if (swi == 0)
+                                ImGui.BeginDisabled();
+                            ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
+                            if (ImGui.InputText($"##swDesc{swn}", ref swDescription, 128))
+                            {
+                                update = true;
+                            }
+                            if (!string.IsNullOrWhiteSpace(swDescription))
+                                ImGui.SetItemTooltip(swDescription);
+
+                            if (swi == 0)
+                                ImGui.EndDisabled();
+
+                            if (update)
+                            {
+                                if (entry.Switches == null) entry.Switches = new();
+                                if (swType == "")
+                                    entry.Switches[swName] = null;
+                                else
+                                    entry.Switches[swName] = new()
+                                    {
+                                        Description = swDescription,
+                                        Type = swType
+                                    };
+                                update = false;
+                            }
+                        }
+                        ImGui.EndTable();
+                    }
+                    ImGui.EndTabItem();
+                }
+                if (ImGui.BeginTabItem("Description"))
+                {
+                    ImGui.BeginChild(
+                        "##Descriptionbox",
+                        descriptionSize,
+                        ImGuiChildFlags.Border
+                    );
+                    ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
+                    if (entry.Description == null)
+                        ImGui.TextDisabled("No Description");
+                    else
+                        ImGui.TextWrapped(entryDesc);
+                    ImGui.EndChild();
+
+                    ImGui.EndTabItem();
+                }
+                ImGui.EndTabBar();
+            }
+            var beginLast = ImGui.GetCursorPos();
+            //ImGui.SetCursorPos(beginClass);
+
+            if (string.IsNullOrEmpty(entry.ClassName))
+                ImGui.EndDisabled();
+
+            //ImGui.SetCursorPos(beginLast);
+        }
+        if (update && entry.ClassName != null) UpdateEntry();
+        ImGui.EndChild();
+        if (ImGui.Button("Cancel"))
+        {
+            Reset();
+            _isOpened = false;
+            if (newPopup)
+                ImGui.EndDisabled();
+            ImGui.CloseCurrentPopup(); ;
+            ImGui.EndPopup();
+            return;
+        }
+
+        ImGui.SameLine(ImGui.GetWindowWidth() - ImGui.CalcTextSize("Save").X - style.ItemSpacing.X * 2);
+        if (ImGui.Button("Save"))
+        {
+            _modifiedEntries = _dbEntries.Keys.ToList();
+            foreach (string s in _modifiedEntries)
+            {
+                if (!_dbEntries.ContainsKey(s)) // Erase the files that will no longer be there
+                {
+                    // File.Delete(Path.Join("Resources", "RedPepper-ClassDataBase", "Data", s + ".yml"));
+                }
+                else
+                {
+                    if (_dbEntries[s].Switches != null)
+                    {
+                        if (_dbEntries[s].Switches.Count > 0)
+                        {
+                            foreach (string sw in switches)
+                            {
+                                if (!_dbEntries[s].Switches.ContainsKey($"Switch{sw}")) continue;
+                                if (_dbEntries[s].Switches[$"Switch{sw}"] == null)
+                                    _dbEntries[s].Switches.Remove($"Switch{sw}");
+                            }
+                        }
+                        if (_dbEntries[s].Switches.Count == 0)
+                        {
+                            var e = _dbEntries[s];
+                            e.Switches = null;
+                            _dbEntries[s] = e;
+                        }
+                    }
+                    YAMLWrapper.Serialize(Path.Join("Resources", "RedPepper-ClassDataBase", "Data", s + ".yml"), _dbEntries[s]);
+                }
+            }
+            ClassDatabaseWrapper.ReloadEntries = true;
+            Reset();
+
+            _isOpened = false;
+            if (newPopup)
+                ImGui.EndDisabled();
+            ImGui.CloseCurrentPopup();
+            ImGui.EndPopup();
+            return;
+        }
+        if (newPopup)
+            ImGui.EndDisabled();
+        ImGui.EndPopup();
+    }
+
+    private void UpdateEntry()
+    {
+        if (!_modifiedEntries.Contains(entry.ClassName))
+            _modifiedEntries.Add(entry.ClassName);
+        oldEntry = entry;
+        _dbEntries[entry.ClassName] = entry;
+    }
+
+    /// <summary>
+    /// change the name of the class while removing the previous one
+    /// </summary>
+    /// <param name="newName"></param>
+    private void UpdateClassEntry(string newName)
+    {
+        if (string.IsNullOrWhiteSpace(newName))
+            return;
+        if (!_modifiedEntries.Contains(entry.ClassName))
+            _modifiedEntries.Add(entry.ClassName);
+        if (!_modifiedEntries.Contains(newName))
+            _modifiedEntries.Add(newName);
+        oldEntry = entry;
+        _dbEntries.Remove(entry.ClassName);
+        entry.ClassName = newName;
+        _dbEntries[entry.ClassName] = entry;
+    }
+
+    private void SaveNewArg()
+    {
+        string tp = "";
+        switch (editArgType)
+        {
+            case 0:
+                editArgMin = null;
+                editArgMax = null;
+                editEnumValues.Clear();
+                tp = "bool";
+                break;
+            case 1:
+                editEnumValues.Clear();
+                tp = "int";
+                break;
+            case 2:
+                editArgMin = null;
+                editArgMax = null;
+                tp = "enum";
+                break;
+        }
+        if (entry.Args == null)
+        {
+            entry.Args = new();
+        }
+
+        var arg = new ClassDatabaseWrapper.Arg()
+        {
+            Default = editArgDefault,
+            Type = tp,
+            Description = editArgDesc,
+            Name = editArgName,
+            Values = editEnumValues.Count > 0 ? editEnumValues : null,
+            Min = editArgMin,
+            Max = editArgMax
+        };
+        entry.Args[$"Arg{editArgId}"] = arg;
+        UpdateEntry();
+    }
+
+    private void SetArgs(bool clean = true)
+    {
+        if (clean)
+        {
+            editArgId = 0;
+            editArgType = 1;
+            editArgDesc = "";
+            editArgName = "";
+            editArgDefault = -1;
+            editArgMin = null;
+            editArgMax = null;
+            editEnumValues.Clear();
+            editArgCanOverwrite = false;
+        }
+        else
+        {
+            editArgId = _argsel;
+            var arg = entry.Args[$"Arg{_argsel}"];
+            editArgType = arg.Type == null || arg.Type == "int" ? 1 : arg.Type == "bool" ? 0 : 2;
+            editArgDesc = arg.Description ?? "";
+            editArgName = arg.Name ?? "";
+            editArgDefault = (int)arg.Default;
+            editArgMin = arg.Min;
+            editArgMax = arg.Max;
+            editEnumValues = new();
+            if (arg.Values != null)
+                editEnumValues = new(arg.Values);
+            editArgCanOverwrite = true;
+        }
+        curEnumName = "";
+        curEnumVal = -1;
+    }
+}

--- a/Autumn/GUI/Dialogs/DatabaseEditorDialog.cs
+++ b/Autumn/GUI/Dialogs/DatabaseEditorDialog.cs
@@ -144,16 +144,38 @@ internal class DatabaseEditor(MainWindowContext _window)
                         ImGui.InputInt("##defval", ref editArgDefault, 1);
                         int min = editArgMin ?? -1;
                         int max = editArgMax ?? -1;
+                        if (editArgMin is null)
+                            ImGui.BeginDisabled();
                         ImGui.Text("Min:");
                         ImGui.SameLine();
-                        ImGui.SetNextItemWidth(ImGuiWidgets.SetPropertyWidthGen("Min"));
+                        ImGui.SetNextItemWidth(ImGuiWidgets.SetPropertyWidthGen("Min") - 28);
                         ImGui.InputInt("##minval", ref min, 1);
-                        if (min != editArgMin) editArgMin = min;
-                        ImGui.Text("Min:");
+                        if (min != editArgMin && editArgMin != null) editArgMin = min;
+                        if (editArgMin is null)
+                            ImGui.EndDisabled();
+
+                        ImGui.SameLine(default, style.ItemSpacing.X/2);
+                        if (ImGui.Button((editArgMin is null ? IconUtils.PLUS : IconUtils.MINUS) + "##remMin"))
+                        {
+                            editArgMin = editArgMin is null ? -1 : null;
+                        }
+
+                        if (editArgMax is null)
+                            ImGui.BeginDisabled();
+                        ImGui.Text("Max:");
                         ImGui.SameLine();
-                        ImGui.SetNextItemWidth(ImGuiWidgets.SetPropertyWidthGen("Max"));
+                        ImGui.SetNextItemWidth(ImGuiWidgets.SetPropertyWidthGen("Max")- 28);
                         ImGui.InputInt("##maxval", ref max, 1);
-                        if (max != editArgMax) editArgMax = max;
+                        if (max != editArgMax && editArgMax != null) editArgMax = max;
+                        if (editArgMax is null)
+                            ImGui.EndDisabled();
+
+                        ImGui.SameLine(default, style.ItemSpacing.X/2);
+                        if (ImGui.Button((editArgMax is null ? IconUtils.PLUS : IconUtils.MINUS) + "##remMax"))
+                        {
+                            editArgMax = editArgMax is null ? -1 : null;  
+                        }
+
                         break;
                     case 2:
                         var dfsel = editEnumValues.Keys.ToList().IndexOf(editArgDefault);

--- a/Autumn/GUI/Dialogs/DatabaseEditorDialog.cs
+++ b/Autumn/GUI/Dialogs/DatabaseEditorDialog.cs
@@ -634,7 +634,7 @@ internal class DatabaseEditor(MainWindowContext _window)
             _editArgDefault = -1;
             _editArgMin = null;
             _editArgMax = null;
-            _editEnumValues.Clear();
+            _editEnumValues = new();
             _editArgCanOverwrite = false;
         }
         else
@@ -743,11 +743,12 @@ internal class DatabaseEditor(MainWindowContext _window)
 
                     break;
                 case 2:
-                    var dfsel = _editEnumValues.Keys.ToList().IndexOf(_editArgDefault);
-                    ImGui.Combo("##defval", ref dfsel, _editEnumValues.Values.ToArray(), _editEnumValues.Keys.Count);
-                    if (dfsel != _editEnumValues.Keys.ToList().IndexOf(_editArgDefault))
+                    var argEnumList = _editEnumValues.Keys.ToList();
+                    var dfsel = argEnumList.IndexOf(_editArgDefault);
+                    ImGui.Combo("##defval", ref dfsel, _editEnumValues.Values.ToArray(), argEnumList.Count);
+                    if (dfsel != argEnumList.IndexOf(_editArgDefault))
                     {
-                        _editArgDefault = _editEnumValues.Keys.ElementAt(dfsel);
+                        _editArgDefault = argEnumList.ElementAt(dfsel);
                     }
                     int? removeAt = null;
                     if (ImGui.BeginTable("##enumvalues", 3, _tableFlags,
@@ -758,7 +759,7 @@ internal class DatabaseEditor(MainWindowContext _window)
                         ImGui.TableSetupColumn("Value", ImGuiTableColumnFlags.None);
                         ImGui.TableSetupColumn("##delete", ImGuiTableColumnFlags.None, 0.1f);
                         ImGui.TableHeadersRow();
-                        foreach (int i in _editEnumValues.Keys)
+                        foreach (int i in argEnumList)
                         {
                             ImGui.TableNextRow();
                             ImGui.TableSetColumnIndex(0);

--- a/Autumn/GUI/Dialogs/DatabaseEditorDialog.cs
+++ b/Autumn/GUI/Dialogs/DatabaseEditorDialog.cs
@@ -653,7 +653,6 @@ internal class DatabaseEditor(MainWindowContext _window)
         ImGui.SameLine(ImGui.GetWindowWidth() - ImGui.CalcTextSize("Save").X - style.ItemSpacing.X * 2);
         if (ImGui.Button("Save"))
         {
-            _modifiedEntries = _dbEntries.Keys.ToList();
             foreach (string s in _modifiedEntries)
             {
                 if (!_dbEntries.ContainsKey(s)) // Erase the files that will no longer be there

--- a/Autumn/GUI/Dialogs/EditCCNTDialog.cs
+++ b/Autumn/GUI/Dialogs/EditCCNTDialog.cs
@@ -8,6 +8,7 @@ using Autumn.Rendering.CtrH3D;
 using Autumn.Storage;
 using ImGuiNET;
 using Autumn.Wrappers;
+using Autumn.Utils;
 
 namespace Autumn.GUI.Dialogs;
 
@@ -115,7 +116,7 @@ internal class EditCreatorClassNameTable(MainWindowContext _window)
                 }
                 ImGui.EndTable();
             }
-            if (ImGui.Button("\uf068", new(ImGui.GetWindowWidth() / 2, default))) // -
+            if (ImGui.Button(IconUtils.MINUS, new(ImGui.GetWindowWidth() / 2, default))) // -
             {
                 _tmpCCNT.Remove(_oname);
                 _oname = "";
@@ -124,7 +125,7 @@ internal class EditCreatorClassNameTable(MainWindowContext _window)
                 _class = "";
             }
             ImGui.SameLine(default, ImGui.GetStyle().ItemSpacing.X / 2);
-            if (ImGui.Button("\uf067", new(ImGui.GetWindowWidth() / 2, default))) // +
+            if (ImGui.Button(IconUtils.PLUS, new(ImGui.GetWindowWidth() / 2, default))) // +
             {
                 for (int i = 0; i < 999; i++)
                 {

--- a/Autumn/GUI/Dialogs/EditCCNTDialog.cs
+++ b/Autumn/GUI/Dialogs/EditCCNTDialog.cs
@@ -1,0 +1,253 @@
+using System.Numerics;
+using Autumn.Enums;
+using Autumn.GUI.Windows;
+using Autumn.Rendering.Storage;
+using Autumn.FileSystems;
+using Autumn.Rendering;
+using Autumn.Rendering.CtrH3D;
+using Autumn.Storage;
+using ImGuiNET;
+using Autumn.Wrappers;
+
+namespace Autumn.GUI.Dialogs;
+
+/// <summary>
+/// A dialog that allows the user to change the classes of objects.
+/// </summary>
+internal class EditCreatorClassNameTable(MainWindowContext _window)
+{
+
+    private bool _isOpened = false;
+    private Dictionary<string, string> _tmpCCNT = new();
+    private string _search = "";
+    private string _oname = "";
+    private string _name = "";
+    private string _oclass = "";
+    private string _class = "";
+
+    Vector2 dimensions = new(742, 520);
+    ImGuiWidgets.InputComboBox classCombo = new();
+
+    public void Open()
+    {
+        Reset();
+        _tmpCCNT = new(_window.ContextHandler.FSHandler.ReadCreatorClassNameTable());
+        _isOpened = true;
+    }
+
+
+    /// <summary>
+    /// Resets all values from this dialog to their defaults.
+    /// </summary>
+    public void Reset()
+    {
+        dimensions = new Vector2(742, 520) * _window.ScalingFactor;
+        _tmpCCNT = new();
+        _isOpened = false;
+        _search = "";
+        _oname = "";
+        _name = "";
+        _oclass = "";
+        _class = "";
+    }
+
+    public void Render()
+    {
+        if (!_isOpened)
+            return;
+
+        if (ImGui.IsKeyPressed(ImGuiKey.Escape))
+        {
+            Reset();
+            _isOpened = false;
+            ImGui.CloseCurrentPopup();
+        }
+
+        ImGui.OpenPopup("CreatorClassNameTable Editor");
+
+        ImGui.SetNextWindowSize(dimensions, ImGuiCond.Always);
+        ImGui.SetNextWindowPos(ImGui.GetMainViewport().GetCenter(), ImGuiCond.Always, new(0.5f, 0.5f));
+
+        if (
+            !ImGui.BeginPopupModal(
+                "CreatorClassNameTable Editor",
+                ref _isOpened,
+                ImGuiWindowFlags.NoSavedSettings | ImGuiWindowFlags.NoScrollWithMouse | ImGuiWindowFlags.NoScrollbar
+            )
+        )
+            return;
+
+        dimensions = ImGui.GetWindowSize();
+        var style = ImGui.GetStyle();
+        if (ImGui.BeginChild("LEFTSIDE", new(dimensions.X * 18 / 30, dimensions.Y)))
+        {
+            ImGui.SetNextItemWidth(ImGui.GetWindowWidth());
+            ImGui.InputTextWithHint("##SEARCHBOX", "Class or Object name", ref _search, 100);
+            if (ImGui.BeginTable("ClassObjectTable", 2,
+                                                    ImGuiTableFlags.RowBg
+                                                    | ImGuiTableFlags.BordersOuter
+                                                    | ImGuiTableFlags.BordersV
+                                                    | ImGuiTableFlags.ScrollY, new(ImGui.GetWindowWidth() - 1, ImGui.GetWindowHeight() - 95)))
+            {
+                int i = 0;
+                ImGui.TableSetupScrollFreeze(0, 1); // Makes top row always visible.
+                ImGui.TableSetupColumn("Name", ImGuiTableColumnFlags.None, 0.5f);
+                ImGui.TableSetupColumn("Class", ImGuiTableColumnFlags.None, 0.5f);
+                ImGui.TableHeadersRow();
+                foreach (string s in _tmpCCNT.Keys)
+                {
+                    if (!string.IsNullOrEmpty(_search)
+                    && !s.Contains(_search, StringComparison.InvariantCultureIgnoreCase)
+                    && !_tmpCCNT[s].Contains(_search, StringComparison.InvariantCultureIgnoreCase))
+                        continue;
+                    ImGui.TableNextRow();
+                    ImGui.TableSetColumnIndex(0);
+                    if (ImGui.Selectable(s + $"##{i}", s == _oname, ImGuiSelectableFlags.SpanAllColumns))
+                    {
+                        _oname = s;
+                        _name = s;
+                        _oclass = _tmpCCNT[s];
+                        _class = _tmpCCNT[s];
+                    }
+                    ImGui.TableSetColumnIndex(1);
+                    ImGui.Text(_tmpCCNT[s]);
+                    i++;
+                }
+                ImGui.EndTable();
+            }
+            if (ImGui.Button("\uf068", new(ImGui.GetWindowWidth() / 2, default))) // -
+            {
+                _tmpCCNT.Remove(_oname);
+                _oname = "";
+                _oclass = "";
+                _name = "";
+                _class = "";
+            }
+            ImGui.SameLine(default, ImGui.GetStyle().ItemSpacing.X / 2);
+            if (ImGui.Button("\uf067", new(ImGui.GetWindowWidth() / 2, default))) // +
+            {
+                for (int i = 0; i < 999; i++)
+                {
+                    if (_tmpCCNT.ContainsKey($"NewObj{i}")) continue;
+                    _oname = $"NewObj{i}";
+                    _oclass = "FixMapParts"; // Probably what most people will want to add by default
+                    _tmpCCNT.Add(_oname, _oclass);
+                    _name = _oname;
+                    _class = _oclass;
+                    break;
+                }
+            }
+        }
+        ImGui.EndChild();
+        ImGui.SameLine();
+
+        ClassDatabaseWrapper.DatabaseEntry? dbEntry = ClassDatabaseWrapper.DatabaseEntries.ContainsKey(_oclass) ? ClassDatabaseWrapper.DatabaseEntries[_oclass] : null;
+
+        if (ImGui.BeginChild("RIGHTSIDE", new(dimensions.X * 12 / 30, dimensions.Y)))
+        {
+            ImGui.SetWindowFontScale(1.3f);
+            if (string.IsNullOrEmpty(_name))
+                ImGui.TextDisabled("No object selected");
+            else
+                ImGui.Text(_name);
+            ImGui.SetWindowFontScale(1f);
+            ImGui.Separator();
+            ImGui.Spacing();
+            if (_oname == "")
+                ImGui.BeginDisabled();
+            ImGui.Text("Object Name:");
+            ImGui.SameLine();
+            ImGui.SetNextItemWidth(ImGuiWidgets.SetPropertyWidthGen("Object Name", 20, 30) - 20);
+            ImGui.InputText("##name", ref _name, 128);
+            if (_oname != _name && _name != "" && !_tmpCCNT.ContainsKey(_name))
+            {
+                _tmpCCNT.Remove(_oname);
+                _tmpCCNT.Add(_name, _class);
+                _oname = _name;
+            }
+
+            ImGui.Text("Class:");
+            var beginChild = ImGui.GetCursorPos();
+            ImGui.SameLine();
+            var beginClass = ImGui.GetCursorPos();
+
+            ImGui.SetCursorPos(beginChild);
+            ImGui.SetWindowFontScale(1.3f);
+            if (dbEntry == null || dbEntry.Value.Name == null)
+                ImGui.TextDisabled("Undocumented class");
+            else
+                ImGui.Text(dbEntry.Value.Name);
+            ImGui.SetWindowFontScale(1f);
+
+            ImGui.BeginChild(
+                "##Description",
+                new Vector2(ImGui.GetWindowWidth() - style.ItemSpacing.X * 3, -95),
+                ImGuiChildFlags.Border
+            );
+            ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
+            if (dbEntry == null || dbEntry.Value.Description == null)
+                ImGui.TextDisabled("No Description");
+            else
+                ImGui.TextWrapped(dbEntry.Value.Description);
+            ImGui.EndChild();
+            var beginLast = ImGui.GetCursorPos();
+            ImGui.SetCursorPos(beginClass);
+
+            List<string> comboStrings = _tmpCCNT.Values.Distinct().Where(x=> x != _class).ToList();
+            comboStrings = ClassDatabaseWrapper.DatabaseEntries.Keys.ToList();
+            classCombo.Use("ClassComboString", ref _class, comboStrings, ImGuiWidgets.SetPropertyWidthGen("Class", 20, 30) - 20);
+            
+            if (_oname == "")
+                ImGui.EndDisabled();
+            ImGui.SetCursorPos(beginLast);
+            if (_oclass != _class && !string.IsNullOrWhiteSpace(_class))
+            {
+                _tmpCCNT[_name] = _class;
+                _oclass = _class;
+            }
+
+
+
+            if (ImGui.Button("Merge Objects from another database", new(ImGui.GetWindowWidth() - style.ItemSpacing.X * 2 - 8, default)))
+            {
+
+                SingleFileChooserContext fileChooserContext = new(_window.ContextHandler, _window.WindowManager);
+                _window.WindowManager.Add(fileChooserContext);
+
+                fileChooserContext.SuccessCallback += result =>
+                {
+                    var r = _window.ContextHandler.FSHandler.TryReadCCNT(result[0]);
+                    if (r != null)
+                    {
+                        if (r.Keys.ToList() != _tmpCCNT.Keys.ToList())
+                        {
+                            foreach (string s in r.Keys)
+                            {
+                                if (_tmpCCNT.ContainsKey(s)) continue;
+                                else _tmpCCNT.Add(s, r[s]);
+                            }
+                        }
+                    }
+                };
+            }
+            if (ImGui.Button("Cancel", new(ImGui.GetWindowWidth() / 2 - style.ItemSpacing.X * 2, default)))
+            {
+                Reset();
+                _isOpened = false;
+                ImGui.CloseCurrentPopup();
+            }
+            ImGui.SameLine(default, ImGui.GetStyle().ItemSpacing.X / 2);
+            if (ImGui.Button("Save", new(ImGui.GetWindowWidth() / 2 - style.ItemSpacing.X * 2 + 4, default)))
+            {
+                _window.ContextHandler.FSHandler.WriteCreatorClassNameTable(_tmpCCNT);
+                Reset();
+
+                _isOpened = false;
+                ImGui.CloseCurrentPopup();
+            }
+        }
+        ImGui.EndChild();
+
+        ImGui.EndPopup();
+    }
+}

--- a/Autumn/GUI/Dialogs/EditCCNTDialog.cs
+++ b/Autumn/GUI/Dialogs/EditCCNTDialog.cs
@@ -57,7 +57,7 @@ internal class EditCreatorClassNameTable(MainWindowContext _window)
         if (!_isOpened)
             return;
 
-        if (ImGui.IsKeyPressed(ImGuiKey.Escape))
+        if (ImGui.IsKeyPressed(ImGuiKey.Escape) && !ImGui.GetIO().WantTextInput) // prevent exiting when input is focused
         {
             Reset();
             _isOpened = false;

--- a/Autumn/GUI/Dialogs/EditChildrenDialog.cs
+++ b/Autumn/GUI/Dialogs/EditChildrenDialog.cs
@@ -11,7 +11,7 @@ using ImGuiNET;
 namespace Autumn.GUI.Dialogs;
 
 /// <summary>
-/// A dialog that allows the user to set and unset objects as children of another.
+/// A dialog that allows the user to set, remove and move objects as children of another.
 /// </summary>
 internal class EditChildrenDialog(MainWindowContext _window)
 {
@@ -121,7 +121,7 @@ internal class EditChildrenDialog(MainWindowContext _window)
                 {
                     StageObj stageObj = obj.StageObj;
 
-                    if (_search != "" && !stageObj.Name.Contains(_search, StringComparison.CurrentCultureIgnoreCase))
+                    if (_search != "" && !stageObj.Name.Contains(_search, StringComparison.InvariantCultureIgnoreCase))
                         continue;
 
                     if (!(!_newChildren.Contains(stageObj) && _oldChildren.Contains(stageObj)))

--- a/Autumn/GUI/Dialogs/NewStageObjDialog.cs
+++ b/Autumn/GUI/Dialogs/NewStageObjDialog.cs
@@ -66,7 +66,7 @@ internal class NewStageObjDialog(MainWindowContext window)
             !ImGui.BeginPopupModal(
                 "Add New Object",
                 ref _isOpened,
-                 ImGuiWindowFlags.NoSavedSettings | ImGuiWindowFlags.NoScrollWithMouse
+                ImGuiWindowFlags.NoSavedSettings | ImGuiWindowFlags.NoScrollWithMouse
             )
         )
             return;

--- a/Autumn/GUI/Dialogs/NewStageObjDialog.cs
+++ b/Autumn/GUI/Dialogs/NewStageObjDialog.cs
@@ -45,7 +45,7 @@ internal class NewStageObjDialog(MainWindowContext window)
         if (!_isOpened)
             return;
 
-        if (ImGui.IsKeyPressed(ImGuiKey.Escape))
+        if (ImGui.IsKeyPressed(ImGuiKey.Escape) && !ImGui.GetIO().WantTextInput) // prevent exiting when input is focused
         {
             _isOpened = false;
             ImGui.CloseCurrentPopup();

--- a/Autumn/GUI/Dialogs/SettingsDialog.cs
+++ b/Autumn/GUI/Dialogs/SettingsDialog.cs
@@ -13,6 +13,7 @@ internal class SettingsDialog
 
     private bool _isOpened = false;
     private bool _useClassNames = false;
+    private bool _dbEditor = false;
     private bool _wasd = false;
     private bool _middleMovesCamera = false;
     private bool _enableVSync = false;
@@ -40,6 +41,7 @@ internal class SettingsDialog
         _useClassNames = _window.ContextHandler.Settings.UseClassNames;
         _selectedStyle = _window.ContextHandler.SystemSettings.Theme;
         _wasd = _window.ContextHandler.SystemSettings.UseWASD;
+        _dbEditor = _window.ContextHandler.SystemSettings.EnableDBEditor;
         _middleMovesCamera = _window.ContextHandler.SystemSettings.UseMiddleMouse;
         _mouseSpeed = _window.ContextHandler.SystemSettings.MouseSpeed;
         _oldStyle = _window.ContextHandler.SystemSettings.Theme;
@@ -88,6 +90,7 @@ internal class SettingsDialog
 
         #region Styling
 
+        ImGui.SeparatorText("UI settings");
         string[] comb = ["Default", "Dark", "Light"];
         ImGui.Combo("Application style", ref _selectedStyle, comb, comb.Count());
 
@@ -104,24 +107,28 @@ internal class SettingsDialog
 
         #endregion
 
-        ImGui.Checkbox("Use ClassNames", ref _useClassNames);
-
         ImGui.Checkbox("Enable VSync", ref _enableVSync);
+        ImGui.SameLine();
+        ImGuiWidgets.HelpTooltip("This option requires restarting the editor");
 
-        ImGui.Separator();
+        ImGui.SeparatorText("Viewport");
 
         ImGui.Checkbox("Use WASD to move the viewport camera", ref _wasd);
-        ImGui.SetItemTooltip("Please be aware that this WILL interfere with other editor commands.");
+        ImGui.SameLine();
+        ImGuiWidgets.HelpTooltip("Please be aware that this WILL interfere with other editor commands.");
+
         ImGui.Checkbox("Use middle click instead of right click to move the camera", ref _middleMovesCamera);
-
-        ImGui.Separator();
-
         ImGui.InputInt("Camera Speed", ref _mouseSpeed, 1, default);
-        ImGui.SetItemTooltip("Recommended values: 20, 35");
+        ImGui.SameLine();
+        ImGuiWidgets.HelpTooltip("Recommended values: 20, 35");
         _mouseSpeed = int.Clamp(_mouseSpeed, 10, 120);
 
-        ImGui.Separator();
-        ImGui.Text("Reset:");
+        ImGui.SeparatorText("Editor Functionality");
+
+        ImGui.Checkbox("Use ClassNames", ref _useClassNames);
+        ImGui.Checkbox("Enable Database Editor", ref _dbEditor);
+
+        ImGui.SeparatorText("Reset");
 
         float resetWidth = ImGui.GetWindowWidth() / 2 - ImGui.GetStyle().ItemSpacing.X*1.65f;
         if (ImGui.Button("Values", new(resetWidth,0)))
@@ -129,9 +136,10 @@ internal class SettingsDialog
             _window.ContextHandler.SetProjectSetting("UseClassNames", false);
             _window.ContextHandler.SystemSettings.UseWASD = false;
             _window.ContextHandler.SystemSettings.UseMiddleMouse = false;
-            _window.ContextHandler.SystemSettings.EnableVSync = false;
+            _window.ContextHandler.SystemSettings.EnableVSync = true;
             _window.ContextHandler.SystemSettings.Theme = 0;
             _window.ContextHandler.SystemSettings.MouseSpeed = 20;
+            _window.ContextHandler.SystemSettings.EnableDBEditor = false;
             
             ImGui.StyleColorsDark();
             ImGui.CloseCurrentPopup();
@@ -180,10 +188,6 @@ internal class SettingsDialog
         }
 
         ImGui.SameLine();
-
-        ImGui.SetItemTooltip("This will set all values to their default.");
-
-        ImGui.SameLine();
         ImGui.SetCursorPosX(dimensions.X - 10 - 80);
 
         if (ImGui.Button("Ok", new(80, 0)))
@@ -194,6 +198,7 @@ internal class SettingsDialog
             _window.ContextHandler.SystemSettings.EnableVSync = _enableVSync;
             _window.ContextHandler.SystemSettings.Theme = _selectedStyle;
             _window.ContextHandler.SystemSettings.MouseSpeed = _mouseSpeed;
+            _window.ContextHandler.SystemSettings.EnableDBEditor = _dbEditor;
             ImGui.CloseCurrentPopup();
             ImGui.EndPopup();
             _window.ContextHandler.SaveSettings();

--- a/Autumn/GUI/Dialogs/SettingsDialog.cs
+++ b/Autumn/GUI/Dialogs/SettingsDialog.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Autumn.GUI.Windows;
+using Autumn.Wrappers;
 using ImGuiNET;
 
 namespace Autumn.GUI.Dialogs;
@@ -17,7 +18,9 @@ internal class SettingsDialog
     private bool _wasd = false;
     private bool _middleMovesCamera = false;
     private bool _enableVSync = false;
+    private int _compLevel = 1;
 
+    private string[] compressionLevels = Enum.GetNames(typeof(Yaz0Wrapper.CompressionLevel));
     private int _oldStyle = 0;
     private int _selectedStyle = 0;
     private int _mouseSpeed = 20;
@@ -46,6 +49,8 @@ internal class SettingsDialog
         _mouseSpeed = _window.ContextHandler.SystemSettings.MouseSpeed;
         _oldStyle = _window.ContextHandler.SystemSettings.Theme;
         _enableVSync = _window.ContextHandler.SystemSettings.EnableVSync;
+        _compLevel = Array.IndexOf(Enum.GetValues<Yaz0Wrapper.CompressionLevel>(), _window.ContextHandler.SystemSettings.Yaz0Compression);
+
     }
 
     /// <summary>
@@ -127,6 +132,7 @@ internal class SettingsDialog
 
         ImGui.Checkbox("Use ClassNames", ref _useClassNames);
         ImGui.Checkbox("Enable Database Editor", ref _dbEditor);
+        ImGui.Combo("Yaz0 Compression Level", ref _compLevel, compressionLevels, 5);
 
         ImGui.SeparatorText("Reset");
 
@@ -140,6 +146,8 @@ internal class SettingsDialog
             _window.ContextHandler.SystemSettings.Theme = 0;
             _window.ContextHandler.SystemSettings.MouseSpeed = 20;
             _window.ContextHandler.SystemSettings.EnableDBEditor = false;
+            _window.ContextHandler.SystemSettings.Yaz0Compression = Yaz0Wrapper.CompressionLevel.Medium;
+            Yaz0Wrapper.Level = _window.ContextHandler.SystemSettings.Yaz0Compression;
             
             ImGui.StyleColorsDark();
             ImGui.CloseCurrentPopup();
@@ -199,6 +207,8 @@ internal class SettingsDialog
             _window.ContextHandler.SystemSettings.Theme = _selectedStyle;
             _window.ContextHandler.SystemSettings.MouseSpeed = _mouseSpeed;
             _window.ContextHandler.SystemSettings.EnableDBEditor = _dbEditor;
+            _window.ContextHandler.SystemSettings.Yaz0Compression = Enum.GetValues<Yaz0Wrapper.CompressionLevel>()[_compLevel];
+            Yaz0Wrapper.Level = _window.ContextHandler.SystemSettings.Yaz0Compression;
             ImGui.CloseCurrentPopup();
             ImGui.EndPopup();
             _window.ContextHandler.SaveSettings();

--- a/Autumn/GUI/Dialogs/ShortcutsDialog.cs
+++ b/Autumn/GUI/Dialogs/ShortcutsDialog.cs
@@ -1,0 +1,76 @@
+using System.Numerics;
+using Autumn.ActionSystem;
+using Autumn.Enums;
+using Autumn.GUI.Windows;
+using ImGuiNET;
+
+namespace Autumn.GUI.Dialogs;
+
+internal class ShortcutsDialog(MainWindowContext window)
+{
+    private bool _isOpened = false;
+
+    public void Open() => _isOpened = true;
+
+    public void Render()
+    {
+        if (!_isOpened)
+            return;
+
+        ImGui.OpenPopup("Autumn Shortcuts");
+
+        Vector2 dimensions = new(450 * window.ScalingFactor, 0);
+        ImGui.SetNextWindowSize(dimensions, ImGuiCond.Always);
+
+        ImGui.SetNextWindowPos(
+            ImGui.GetMainViewport().GetCenter(),
+            ImGuiCond.Always,
+            new(0.5f, 0.5f)
+        );
+
+        if (
+            !ImGui.BeginPopupModal(
+                "Autumn Shortcuts",
+                ref _isOpened,
+                ImGuiWindowFlags.NoResize
+                    | ImGuiWindowFlags.NoMove
+                    | ImGuiWindowFlags.NoSavedSettings
+            )
+        )
+            return;
+        ImGui.SeparatorText("General Shortcuts");
+        ShortcutText(CommandID.NewProject);
+        ShortcutText(CommandID.OpenProject);
+        ShortcutText(CommandID.AddStage);
+        ShortcutText(CommandID.OpenSettings);
+        ShortcutText(CommandID.AddObject);
+        ShortcutText(CommandID.Undo);
+        ShortcutText(CommandID.Redo);
+        ImGui.SeparatorText("Selection Shortcuts");
+        ShortcutText(CommandID.HideObj);
+        ShortcutText(CommandID.DuplicateObj);
+        ShortcutText(CommandID.RemoveObj);
+        ImGui.SeparatorText("Viewport Shortcuts");
+        ImGui.Spacing();
+
+
+        ImGui.EndPopup();
+    }
+    
+    void ShortcutText(CommandID command)
+    {
+        var act = window.ContextHandler.ActionHandler.GetAction(command);
+        if (act.Command != null)
+        {
+            ImGui.BulletText(act.Command.DisplayName);
+            ImGui.SameLine();
+        }
+        if (act.Shortcut != null)
+        {
+            ImGui.Text("- " + act.Shortcut.DisplayString);
+        }
+        else
+            ImGui.Text("- No shortcut assigned.");
+
+    }
+}

--- a/Autumn/GUI/Dialogs/ShortcutsDialog.cs
+++ b/Autumn/GUI/Dialogs/ShortcutsDialog.cs
@@ -42,6 +42,7 @@ internal class ShortcutsDialog(MainWindowContext window)
         ShortcutText(CommandID.NewProject);
         ShortcutText(CommandID.OpenProject);
         ShortcutText(CommandID.AddStage);
+        ShortcutText(CommandID.CloseScene);
         ShortcutText(CommandID.OpenSettings);
         ShortcutText(CommandID.AddObject);
         ShortcutText(CommandID.Undo);

--- a/Autumn/GUI/Editors/ObjectWindow.cs
+++ b/Autumn/GUI/Editors/ObjectWindow.cs
@@ -99,7 +99,7 @@ internal class ObjectWindow(MainWindowContext window)
                 else
                     ImGui.PushStyleColor(ImGuiCol.Text, 0xffffffff & ImGui.GetColorU32(ImGuiCol.Text));
 
-                if (ImGui.Button(obj.IsVisible ? "\uF06E" : "\uF070", new(ImGui.GetColumnWidth(), default))) // Hide / Show
+                if (ImGui.Button(obj.IsVisible ? IconUtils.EYE_OPEN : IconUtils.EYE_CLOSED, new(ImGui.GetColumnWidth(), default))) // Hide / Show
                 {
                     ChangeHandler.ChangePropertyValue(
                         window.CurrentScene.History,

--- a/Autumn/GUI/Editors/PropertiesWindow.cs
+++ b/Autumn/GUI/Editors/PropertiesWindow.cs
@@ -284,7 +284,7 @@ internal class PropertiesWindow(MainWindowContext window)
                                                 ImGui.SameLine();
                                                 ImGuiWidgets.SetPropertyWidth(aName);
                                                 ImGui.InputInt("##" + argEntry.Name + "i", ref rf, 1, default);
-                                                int.Clamp(rf, argEntry.Min ?? -99999, argEntry.Max ?? 99999);
+                                                rf = int.Clamp(rf, argEntry.Min ?? -99999, argEntry.Max ?? 99999);
                                                 if (intBuf != rf)
                                                 {
                                                     stageObj.Properties[name] = rf;

--- a/Autumn/GUI/Editors/PropertiesWindow.cs
+++ b/Autumn/GUI/Editors/PropertiesWindow.cs
@@ -26,20 +26,20 @@ internal class PropertiesWindow(MainWindowContext window)
     DragFloat3 RotDrag = new(window);
     LinkedDragFloat3 ScaleDrag = new(window);
     ImGuiWindowClass windowClass = new() { DockNodeFlagsOverrideSet = ImGuiDockNodeFlags.AutoHideTabBar }; //ImGuiWidgets.NO_TAB_BAR };
-    
+
     public void Render()
     {
         ImGui.PushStyleColor(ImGuiCol.Button, 0x00000000);
         ImGui.PushStyleColor(ImGuiCol.ButtonHovered, 0x00000000);
         ImGui.PushStyleColor(ImGuiCol.ButtonActive, 0x00000000);
-        unsafe 
+        unsafe
         {
             fixed (ImGuiWindowClass* tmp = &windowClass)
-            ImGui.SetNextWindowClass(new ImGuiWindowClassPtr(tmp));
+                ImGui.SetNextWindowClass(new ImGuiWindowClassPtr(tmp));
         }
         bool begun = ImGui.Begin("Properties");
         ImGui.PopStyleColor(3);
-        
+
         if (!begun)
             return;
         if (window.CurrentScene is null)
@@ -79,7 +79,7 @@ internal class PropertiesWindow(MainWindowContext window)
 
             // Fake dock
             bool usedbName = ClassDatabaseWrapper.DatabaseEntries.ContainsKey(GetClassFromCCNT(oldName)) && ClassDatabaseWrapper.DatabaseEntries[GetClassFromCCNT(oldName)].Name != null;
-            ImGui.SetCursorPosY(ImGui.GetCursorPosY()-4);
+            ImGui.SetCursorPosY(ImGui.GetCursorPosY() - 4);
             ImGui.Text(stageObj.Type.ToString() + ": " + (usedbName ? ClassDatabaseWrapper.DatabaseEntries[GetClassFromCCNT(oldName)].Name : oldName));
             ImGui.SetWindowFontScale(1.0f);
 
@@ -237,12 +237,13 @@ internal class PropertiesWindow(MainWindowContext window)
                                         if (ClassDatabaseWrapper.DatabaseEntries[cls].Args != null && ClassDatabaseWrapper.DatabaseEntries[cls].Args.ContainsKey(name))
                                         {
                                             var argEntry = ClassDatabaseWrapper.DatabaseEntries[cls].Args[name];
-                                            ImGui.Text(argEntry.Name + ":");
+                                            string aName = string.IsNullOrEmpty(argEntry.Name) ? "Unknown" : argEntry.Name;
+                                            ImGui.Text(aName + ":");
                                             if (argEntry.Type == "enum")
                                             {
                                                 var rf = argEntry.Values.Keys.ToList().IndexOf(intBuf);
                                                 ImGui.SameLine();
-                                                ImGuiWidgets.SetPropertyWidth(argEntry.Name);
+                                                ImGuiWidgets.SetPropertyWidth(aName);
                                                 if (rf < 0)
                                                 {
                                                     rf = intBuf;
@@ -270,7 +271,7 @@ internal class PropertiesWindow(MainWindowContext window)
                                             {
                                                 var rf = intBuf != -1;
                                                 ImGui.SameLine();
-                                                ImGuiWidgets.SetPropertyWidth(argEntry.Name);
+                                                ImGuiWidgets.SetPropertyWidth(aName);
                                                 ImGui.Checkbox("##" + argEntry.Name + "cb", ref rf);
                                                 if ((intBuf != -1) != rf)
                                                 {
@@ -281,7 +282,7 @@ internal class PropertiesWindow(MainWindowContext window)
                                             {
                                                 var rf = intBuf;
                                                 ImGui.SameLine();
-                                                ImGuiWidgets.SetPropertyWidth(argEntry.Name);
+                                                ImGuiWidgets.SetPropertyWidth(aName);
                                                 ImGui.InputInt("##" + argEntry.Name + "i", ref rf, 1, default);
                                                 int.Clamp(rf, argEntry.Min ?? -99999, argEntry.Max ?? 99999);
                                                 if (intBuf != rf)
@@ -351,7 +352,7 @@ internal class PropertiesWindow(MainWindowContext window)
                                 string pName = stageObj.Parent is not null ? stageObj.Parent.Name : "No parent";
                                 if (stageObj.Parent == null)
                                     ImGui.BeginDisabled();
-                                if (ImGui.Button(pName, new(ImGuiWidgets.SetPropertyWidth("Parent") - ImGui.CalcTextSize("\uf127").X * 1.65f * window.ScalingFactor , default)))
+                                if (ImGui.Button(pName, new(ImGuiWidgets.SetPropertyWidth("Parent") - ImGui.CalcTextSize(IconUtils.UNLINK).X * 1.65f * window.ScalingFactor, default)))
                                 {
                                     var p = window.CurrentScene.GetSceneObjFromStageObj(stageObj.Parent!);
                                     ChangeHandler.ToggleObjectSelection(
@@ -368,7 +369,7 @@ internal class PropertiesWindow(MainWindowContext window)
                                 }
 
                                 ImGui.SameLine(default, style.ItemSpacing.X / 2);
-                                if (ImGui.Button("\uf127##" + pName))
+                                if (ImGui.Button(IconUtils.UNLINK + "##" + pName))
                                 {
                                     window.CurrentScene.Stage.GetStageFile(StageFileType.Map).UnlinkChild(stageObj);
                                 }
@@ -677,11 +678,11 @@ internal class PropertiesWindow(MainWindowContext window)
                 if (ImGui.GetWindowWidth() - (ImGui.GetWindowWidth() * 3 / 4 - ImGui.GetStyle().ItemSpacing.X / 2) > (stringWidth + 12))
                 {
                     ImGui.SetCursorPosX(ImGui.GetWindowWidth() / 4);
-                    itemWidth = ImGui.GetWindowWidth() * 3 / 4 - ImGui.GetStyle().ItemSpacing.X / 2 - 24* _window.ScalingFactor;
+                    itemWidth = ImGui.GetWindowWidth() * 3 / 4 - ImGui.GetStyle().ItemSpacing.X / 2 - 24 * _window.ScalingFactor;
                 }
                 else
                 {
-                    itemWidth = ImGui.GetWindowWidth() - stringWidth - ImGui.GetStyle().ItemSpacing.X * 2 - 24* _window.ScalingFactor;
+                    itemWidth = ImGui.GetWindowWidth() - stringWidth - ImGui.GetStyle().ItemSpacing.X * 2 - 24 * _window.ScalingFactor;
                 }
             }
             else
@@ -694,7 +695,7 @@ internal class PropertiesWindow(MainWindowContext window)
             itemWidth = itemWidth / 3 - style.ItemSpacing.X - 7;
 
             ImGui.PushStyleColor(ImGuiCol.ChildBg, 0xFF_04_04_6C); // NEEDS CONSTANT
-            if (ImGui.BeginChild(str + "XTest", new(20* _window.ScalingFactor, 20* _window.ScalingFactor + style.ItemSpacing.Y)))
+            if (ImGui.BeginChild(str + "XTest", new(20 * _window.ScalingFactor, 20 * _window.ScalingFactor + style.ItemSpacing.Y)))
             {
                 ImGui.SetCursorPos(ImGui.GetWindowSize() / 2 - ImGui.CalcTextSize("X") / 2);
                 ImGui.Text("X");
@@ -710,7 +711,7 @@ internal class PropertiesWindow(MainWindowContext window)
             ImGui.SameLine(default, style.ItemSpacing.X / 2);
 
             ImGui.PushStyleColor(ImGuiCol.ChildBg, 0xFF_15_6C_15); // NEEDS CONSTANT
-            if (ImGui.BeginChild(str + "YTest", new(20* _window.ScalingFactor, 20* _window.ScalingFactor + style.ItemSpacing.Y)))
+            if (ImGui.BeginChild(str + "YTest", new(20 * _window.ScalingFactor, 20 * _window.ScalingFactor + style.ItemSpacing.Y)))
             {
                 ImGui.SetCursorPos(ImGui.GetWindowSize() / 2 - ImGui.CalcTextSize("Y") / 2);
                 ImGui.Text("Y");
@@ -726,7 +727,7 @@ internal class PropertiesWindow(MainWindowContext window)
             ImGui.SameLine(default, style.ItemSpacing.X / 2);
 
             ImGui.PushStyleColor(ImGuiCol.ChildBg, 0xFF_6C_27_15); // NEEDS CONSTANT
-            if (ImGui.BeginChild(str + "ZTest", new(20* _window.ScalingFactor, 20* _window.ScalingFactor + style.ItemSpacing.Y)))
+            if (ImGui.BeginChild(str + "ZTest", new(20 * _window.ScalingFactor, 20 * _window.ScalingFactor + style.ItemSpacing.Y)))
             {
                 ImGui.SetCursorPos(ImGui.GetWindowSize() / 2 - ImGui.CalcTextSize("Z") / 2);
                 ImGui.Text("Z");
@@ -830,7 +831,7 @@ internal class PropertiesWindow(MainWindowContext window)
             }
             bool ret = ScaleDrag3.Use(str, ref rf, ref sto, v_speed, itemWidth, isLinked);
             ImGui.SameLine(default, style.ItemSpacing.X / 2);
-            if (ImGui.Button(isLinked ? "\uf0c1" : "\uf127"))
+            if (ImGui.Button(isLinked ? IconUtils.LINK : IconUtils.UNLINK))
             {
                 isLinked = !isLinked;
             }
@@ -913,6 +914,17 @@ internal class PropertiesWindow(MainWindowContext window)
     private bool InputSwitch(string str, ref int rf, int step, ref ISceneObj sco)
     {
         int i = rf;
+
+        string tt = "";
+        if (ClassDatabaseWrapper.DatabaseEntries.ContainsKey(GetClassFromCCNT(sco.StageObj.Name)))
+        {
+            var c = ClassDatabaseWrapper.DatabaseEntries[GetClassFromCCNT(sco.StageObj.Name)];
+            if (c.Switches != null && c.Switches.ContainsKey($"Switch{str}") && c.Switches[$"Switch{str}"] != null)
+            {
+                tt = c.Switches[$"Switch{str}"]?.Type + ": " + c.Switches[$"Switch{str}"]?.Description;
+            }
+        }
+
         bool disable = rf < 0;
         if (disable)
             ImGui.BeginDisabled();
@@ -922,6 +934,10 @@ internal class PropertiesWindow(MainWindowContext window)
         }
         if (disable)
             ImGui.EndDisabled();
+        
+        if (tt != "")
+        ImGui.SetItemTooltip(tt);
+
         ImGui.SameLine();
         ImGui.SetNextItemWidth(ImGui.GetWindowWidth() * 2 / 3 - ImGui.GetStyle().ItemSpacing.X * 2);
         if (ImGui.InputInt("##" + str, ref i, step, default, ImGuiInputTextFlags.EnterReturnsTrue))
@@ -931,6 +947,9 @@ internal class PropertiesWindow(MainWindowContext window)
             rf = i;
             //ChangeHandler.ChangeSwitch(window.CurrentScene.History, sto, str, rf, i);
         }
+        if (tt != "")
+        ImGui.SetItemTooltip(tt);
+
         return false;
     }
     private string GetClassFromCCNT(string objectName)

--- a/Autumn/GUI/Editors/StageParamsWindow.cs
+++ b/Autumn/GUI/Editors/StageParamsWindow.cs
@@ -24,6 +24,8 @@ internal class ParametersWindow(MainWindowContext window)
     int lightIdx;
     int selectedlightarea = -1;
     int selectedlightName = -1;
+    ImGuiWidgets.InputComboBox lightAreaCombo = new();
+
     string[] lightTypes = ["Map Obj Light", "Obj Light", "Player Light", "Stage Map Light"];
     int copyLight = 0;
 
@@ -459,34 +461,36 @@ internal class ParametersWindow(MainWindowContext window)
         ImGui.EndDisabled();
         ImGui.PopItemWidth();
         ImGui.PushItemWidth(prevW - style.ItemSpacing.X * 2);
-        if (ImGui.BeginListBox("##LightList"))
-        {
-            bool iscliked = false;
-            if (ImGui.Selectable("Map Object Light", lightIdx == 0))
-            {
-                lightIdx = 0;
-                iscliked = true;
-            }
-            if (ImGui.Selectable("Object Light", lightIdx == 1))
-            {
-                lightIdx = 1;
-                iscliked = true;
-            }
-            if (ImGui.Selectable("Player Light", lightIdx == 2))
-            {
-                lightIdx = 2;
-                iscliked = true;
-            }
-            if (ImGui.Selectable("Stage Map Light", lightIdx == 3))
-            {
-                lightIdx = 3;
-                iscliked = true;
-            }
 
-            if (iscliked && ImGui.IsKeyDown(ImGuiKey.ModShift))
-                lightIdx = -1;
-            ImGui.EndListBox();
+        ImGui.Separator();
+        ImGui.PushStyleColor(ImGuiCol.WindowBg, ImGui.GetColorU32(ImGuiCol.FrameBg) | 0xFF000000);
+        bool iscliked = false;
+        if (ImGui.Selectable("Map Object Light", lightIdx == 0))
+        {
+            lightIdx = 0;
+            iscliked = true;
         }
+        if (ImGui.Selectable("Object Light", lightIdx == 1))
+        {
+            lightIdx = 1;
+            iscliked = true;
+        }
+        if (ImGui.Selectable("Player Light", lightIdx == 2))
+        {
+            lightIdx = 2;
+            iscliked = true;
+        }
+        if (ImGui.Selectable("Stage Map Light", lightIdx == 3))
+        {
+            lightIdx = 3;
+            iscliked = true;
+        }
+
+        if (iscliked && ImGui.IsKeyDown(ImGuiKey.ModShift))
+            lightIdx = -1;
+
+        ImGui.PopStyleColor();
+        ImGui.Separator();
         selectedlight = lightIdx switch
         {
             0 => scn.Stage.LightParams.MapObjectLight,
@@ -671,13 +675,14 @@ internal class ParametersWindow(MainWindowContext window)
 
             ImGui.PushItemWidth(prevW - PROP_WIDTH - 20);
             var ReadLightAreas = window.ContextHandler.FSHandler.ReadLightAreas();
-            var refStr = scn.Stage.LightAreaNames![scn.Stage.LightAreaNames.Keys.ElementAt(selectedlightarea)];
+            var refStr = scn.Stage.LightAreaNames.Values.ElementAt(selectedlightarea);
+            string prevRefStr = refStr;
 
             int aId = scn.Stage.LightAreaNames.Keys.ElementAt(selectedlightarea);
             ImGui.InputInt("Area Id", ref aId);
             if (aId != scn.Stage.LightAreaNames.Keys.ElementAt(selectedlightarea) && !scn.Stage.LightAreaNames.ContainsKey(aId))
             {
-                string tmpS = scn.Stage.LightAreaNames[scn.Stage.LightAreaNames.Keys.ElementAt(selectedlightarea)];
+                string tmpS = scn.Stage.LightAreaNames.Values.ElementAt(selectedlightarea);
                 scn.Stage.LightAreaNames.Remove(scn.Stage.LightAreaNames.Keys.ElementAt(selectedlightarea));
                 scn.Stage.LightAreaNames.Add(aId, tmpS);
             }
@@ -685,25 +690,33 @@ internal class ParametersWindow(MainWindowContext window)
             if (ReadLightAreas != null)
             {
 
-                selectedlightName = ReadLightAreas.Keys.ToList().IndexOf(refStr);
+                //selectedlightName = ReadLightAreas.Keys.ToList().IndexOf(refStr);
 
+                var p = ImGui.GetCursorPosX();
+                ImGui.Text("Light Name:");
+                ImGui.SameLine();
                 var keyArray = ReadLightAreas.Keys.ToArray();
+                lightAreaCombo.Use("Light Name", ref refStr, ReadLightAreas.Keys.ToList(), ImGui.GetContentRegionAvail().X);
+                ImGui.SetCursorPosX(p);
+                //ImGui.Combo("Light Name", ref selectedlightName, keyArray, ReadLightAreas.Keys.Count - 1);
 
-                ImGui.Combo("Light Name", ref selectedlightName, keyArray, ReadLightAreas.Keys.Count - 1);
+                if (refStr != prevRefStr)
+                    scn.Stage.LightAreaNames[scn.Stage.LightAreaNames.Keys.ElementAt(selectedlightarea)] = refStr;
 
-                if (refStr != keyArray[selectedlightName])
-                    scn.Stage.LightAreaNames[scn.Stage.LightAreaNames.Keys.ElementAt(selectedlightarea)] = keyArray[selectedlightName];
-
-                LightArea area = ReadLightAreas![scn.Stage.LightAreaNames[scn.Stage.LightAreaNames.Keys.ElementAt(selectedlightarea)]];
-
-                ImGui.BeginDisabled();
-                ImGui.DragInt("InterpolateFrame", ref area.InterpolateFrame, 1);
-                ImGui.InputText("Name", ref area.Name, 128);
-                ImGui.PopItemWidth();
-                ImGui.PushItemWidth(prevW - style.ItemSpacing.X);
-                ImGui.EndDisabled();
-                if (ImGui.BeginListBox("##LightList", new(prevW * window.ScalingFactor, 4 * ImGui.GetTextLineHeight() * window.ScalingFactor)))
+                if (keyArray.Contains(refStr))
                 {
+
+                    ImGui.PushItemWidth(prevW - PROP_WIDTH - 20);
+                    LightArea area = ReadLightAreas![scn.Stage.LightAreaNames[scn.Stage.LightAreaNames.Keys.ElementAt(selectedlightarea)]];
+
+                    ImGui.BeginDisabled();
+                    ImGui.DragInt("InterpolateFrame", ref area.InterpolateFrame, 1);
+                    ImGui.InputText("Name", ref area.Name, 128);
+                    ImGui.PopItemWidth();
+                    ImGui.PushItemWidth(prevW - style.ItemSpacing.X);
+                    ImGui.EndDisabled();
+                    ImGui.Separator();
+                    ImGui.PushStyleColor(ImGuiCol.WindowBg, ImGui.GetColorU32(ImGuiCol.FrameBg) | 0xFF000000);
                     if (ImGui.Selectable("Map Object Light", lightIdx == 0))
                     {
                         lightIdx = 0;
@@ -716,68 +729,80 @@ internal class ParametersWindow(MainWindowContext window)
                     {
                         lightIdx = 2;
                     }
-                    ImGui.EndListBox();
-                }
-                selectedlight = lightIdx switch
-                {
-                    0 => area.MapObjectLight,
-                    1 => area.ObjectLight,
-                    2 => area.PlayerLight,
-                    _ => null,
-                };
-                ImGui.PushItemWidth(prevW - PROP_WIDTH);
-                ImGui.BeginDisabled();
-                if (scn.PreviewLight != selectedlight)
-                {
-                    scn.PreviewLight = selectedlight;
-                }
-                if (selectedlight != null)
-                {
-                    int A = 22;
-                    int B = 30;
+                    ImGui.PopStyleColor();
+                    ImGui.Separator();
 
-                    ImGuiWidgets.PrePropertyWidthName("Follow Camera", A, B);
-                    ImGui.Checkbox("##Follow Camera", ref selectedlight.IsCameraFollow);
-
-                    ImGuiWidgets.PrePropertyWidthName("Direction", A, B);
-                    ImGui.DragFloat3("##Direction", ref selectedlight.Direction, 0.01f);
-
-                    ImGuiWidgets.PrePropertyWidthName("Ambient", A, B);
-                    ImGui.ColorEdit4("##Ambient", ref selectedlight.Ambient, _colorEditFlags);
-
-                    ImGuiWidgets.PrePropertyWidthName("Diffuse", A, B);
-                    ImGui.ColorEdit4("##Diffuse", ref selectedlight.Diffuse, _colorEditFlags);
-
-                    ImGuiWidgets.PrePropertyWidthName("Specular 0", A, B);
-                    ImGui.ColorEdit4("##Specular 0", ref selectedlight.Specular0, _colorEditFlags);
-
-                    ImGuiWidgets.PrePropertyWidthName("Specular 1", A, B);
-                    ImGui.ColorEdit4("##Specular 1", ref selectedlight.Specular1, _colorEditFlags);
-                    for (int i = 0; i < 6; i++)
+                    selectedlight = lightIdx switch
                     {
-                        if (selectedlight.ConstantColors[i] != null)
+                        0 => area.MapObjectLight,
+                        1 => area.ObjectLight,
+                        2 => area.PlayerLight,
+                        _ => null,
+                    };
+                    ImGui.PopItemWidth();
+                    ImGui.PushItemWidth(prevW - PROP_WIDTH);
+                    ImGui.BeginDisabled();
+                    if (scn.PreviewLight != selectedlight)
+                    {
+                        scn.PreviewLight = selectedlight;
+                    }
+                    if (selectedlight != null)
+                    {
+                        int A = 22;
+                        int B = 30;
+
+                        ImGuiWidgets.PrePropertyWidthName("Follow Camera", A, B);
+                        ImGui.Checkbox("##Follow Camera", ref selectedlight.IsCameraFollow);
+
+                        ImGuiWidgets.PrePropertyWidthName("Direction", A, B);
+                        ImGui.DragFloat3("##Direction", ref selectedlight.Direction, 0.01f);
+
+                        ImGuiWidgets.PrePropertyWidthName("Ambient", A, B);
+                        ImGui.ColorEdit4("##Ambient", ref selectedlight.Ambient, _colorEditFlags);
+
+                        ImGuiWidgets.PrePropertyWidthName("Diffuse", A, B);
+                        ImGui.ColorEdit4("##Diffuse", ref selectedlight.Diffuse, _colorEditFlags);
+
+                        ImGuiWidgets.PrePropertyWidthName("Specular 0", A, B);
+                        ImGui.ColorEdit4("##Specular 0", ref selectedlight.Specular0, _colorEditFlags);
+
+                        ImGuiWidgets.PrePropertyWidthName("Specular 1", A, B);
+                        ImGui.ColorEdit4("##Specular 1", ref selectedlight.Specular1, _colorEditFlags);
+                        for (int i = 0; i < 6; i++)
                         {
-                            Vector4 ColorEdit = (Vector4)selectedlight.ConstantColors[i]!;
-                            ImGuiWidgets.PrePropertyWidthName($"Constant {i}", A, B);
-                            ImGui.ColorEdit4($"Constant {i}", ref ColorEdit, _colorEditFlags);
-                            if (ColorEdit != selectedlight.ConstantColors[i])
+                            if (selectedlight.ConstantColors[i] != null)
                             {
-                                selectedlight.ConstantColors[i] = ColorEdit;
+                                Vector4 ColorEdit = (Vector4)selectedlight.ConstantColors[i]!;
+                                ImGuiWidgets.PrePropertyWidthName($"Constant {i}", A, B);
+                                ImGui.ColorEdit4($"Constant {i}", ref ColorEdit, _colorEditFlags);
+                                if (ColorEdit != selectedlight.ConstantColors[i])
+                                {
+                                    selectedlight.ConstantColors[i] = ColorEdit;
+                                }
                             }
                         }
-                    }
 
+                    }
+                    ImGui.PopItemWidth();
+                    ImGui.EndDisabled();
                 }
-                ImGui.EndDisabled();
+                else
+                {
+                    ImGui.BeginDisabled();
+                    ImGui.TextWrapped("LightArea with that name couldn't be found in LightDataArea.szs!");
+                    ImGui.Text("Can't display Light info.");
+                    ImGui.EndDisabled();
+                }
                 ImGui.PopItemWidth();
             }
             else
             {
-                var ln = scn.Stage.LightAreaNames[scn.Stage.LightAreaNames.Keys.ElementAt(selectedlightarea)];
+                var ln = scn.Stage.LightAreaNames.Values.ElementAt(selectedlightarea);
                 ImGui.InputText("Light Name", ref ln, 128);
-                if (ln != scn.Stage.LightAreaNames[scn.Stage.LightAreaNames.Keys.ElementAt(selectedlightarea)])
+                if (ln != scn.Stage.LightAreaNames.Values.ElementAt(selectedlightarea))
                     scn.Stage.LightAreaNames[scn.Stage.LightAreaNames.Keys.ElementAt(selectedlightarea)] = ln;
-                ImGui.TextDisabled("LightDataArea.szs not found! \nCan't display Light info.");
+                ImGui.TextDisabled("LightDataArea.szs not found.");
+                ImGui.TextDisabled("Can't display Light info.");
             }
         }
     }

--- a/Autumn/GUI/Editors/StageParamsWindow.cs
+++ b/Autumn/GUI/Editors/StageParamsWindow.cs
@@ -50,7 +50,11 @@ internal class ParametersWindow(MainWindowContext window)
     public void Render()
     {
         if (!IsEnabled)
+        {
+            if (window.CurrentScene != null && window.CurrentScene.PreviewLight != null)
+                window.CurrentScene.PreviewLight = null;
             return;
+        }
         unsafe
         {
             fixed (ImGuiWindowClass* tmp = &windowClass)
@@ -193,6 +197,8 @@ internal class ParametersWindow(MainWindowContext window)
                 }
                 ImGui.EndTabItem();
             }
+            else
+                scn.PreviewLight = null;
             if (ImGui.BeginTabItem("Light Areas", ref LightEnabled))
             {
                 LightAreaTab(scn, prevW, style);

--- a/Autumn/GUI/Editors/StageParamsWindow.cs
+++ b/Autumn/GUI/Editors/StageParamsWindow.cs
@@ -507,16 +507,16 @@ internal class ParametersWindow(MainWindowContext window)
                 switch (copyLight)
                 {
                     case 0:
-                        scn.Stage.LightParams.MapObjectLight = selectedlight!;
+                        scn.Stage.LightParams.MapObjectLight = new(selectedlight);
                         break;
                     case 1:
-                        scn.Stage.LightParams.ObjectLight = selectedlight!;
+                        scn.Stage.LightParams.ObjectLight = new(selectedlight)!;
                         break;
                     case 2:
-                        scn.Stage.LightParams.PlayerLight = selectedlight!;
+                        scn.Stage.LightParams.PlayerLight = new(selectedlight)!;
                         break;
                     case 3:
-                        scn.Stage.LightParams.StageMapLight = selectedlight!;
+                        scn.Stage.LightParams.StageMapLight = new(selectedlight)!;
                         break;
                 }
 

--- a/Autumn/GUI/ImGuiWidgets.cs
+++ b/Autumn/GUI/ImGuiWidgets.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using Autumn.ActionSystem;
 using Autumn.Enums;
+using static Autumn.Utils.IconUtils;
 using Autumn.GUI.Windows;
 using ImGuiNET;
 using TinyFileDialogsSharp;
@@ -80,19 +81,19 @@ internal static class ImGuiWidgets
         switch (dir)
         {
             case ImGuiDir.Up:
-                str = "\uf062##" + str;
+                str = ARROW_UP + "##" + str;
                 break;
             case ImGuiDir.Down:
-                str = "\uf063##" + str;
+                str = ARROW_DOWN + "##" + str;
                 break;
             case ImGuiDir.Left:
-                str = "\uf060##" + str;
+                str = ARROW_LEFT + "##" + str;
                 break;
             case ImGuiDir.Right:
-                str = "\uf061##" + str;
+                str = ARROW_RIGHT + "##" + str;
                 break;
             case ImGuiDir.COUNT:
-                str = "\uf078##" + str;
+                str = DOWN + "##" + str;
                 break;
         }
         return ImGui.Button(str, size ?? default);
@@ -295,5 +296,12 @@ internal static class ImGuiWidgets
         ImGui.SameLine();
         SetPropertyWidthGen(str + ":");
         return ImGui.InputText("##" + str, ref rf, max);
+    }
+
+    public static bool IsMouseHoveringRect(Vector2 v_min, Vector2 v_max)
+    {
+        bool r = v_max.X > ImGui.GetMousePos().X && ImGui.GetMousePos().X > v_min.X;
+        r = r && v_max.Y > ImGui.GetMousePos().Y && ImGui.GetMousePos().Y > v_min.Y;
+        return r;
     }
 }

--- a/Autumn/GUI/Windows/MainWindowContext.cs
+++ b/Autumn/GUI/Windows/MainWindowContext.cs
@@ -31,18 +31,27 @@ internal class MainWindowContext : WindowContext
 
     private bool _isFirstFrame = true;
 
+#region Dialogs
     private readonly AddStageDialog _addStageDialog;
     private readonly ClosingDialog _closingDialog;
     private readonly NewStageObjDialog _newStageObjDialog;
-    private SettingsDialog _settingsDialog;
-    public EditChildrenDialog _editChildrenDialog;
+    private readonly SettingsDialog _settingsDialog;
+    private readonly ShortcutsDialog _shortcutsDialog;
+#endregion
 
+#region Editor Dialogs
+    public readonly EditChildrenDialog _editChildrenDialog;
+    public readonly EditCreatorClassNameTable _editCCNT;
+#endregion
+
+#region Editor Windows 
     private readonly StageWindow _stageWindow;
     private readonly ObjectWindow _objectWindow;
     private readonly PropertiesWindow _propertiesWindow;
     private readonly ParametersWindow _paramsWindow;
     private readonly SceneWindow _sceneWindow;
     private readonly WelcomeDialog _welcomeDialog;
+#endregion
 
 #if DEBUG
     private bool _showDemoWindow = false;
@@ -58,6 +67,8 @@ internal class MainWindowContext : WindowContext
         _welcomeDialog = new(this);
         _editChildrenDialog = new(this);
         _settingsDialog = new(this);
+        _editCCNT = new(this);
+        _shortcutsDialog = new(this);
 
         // Initialize editors:
         _stageWindow = new(this);
@@ -181,6 +192,8 @@ internal class MainWindowContext : WindowContext
             _closingDialog.Render();
             _newStageObjDialog.Render();
             _editChildrenDialog.Render();
+            _editCCNT.Render();
+            _shortcutsDialog.Render();
             _welcomeDialog.Render();
             _settingsDialog.Render();
 
@@ -235,7 +248,7 @@ internal class MainWindowContext : WindowContext
         _paramsWindow.CurrentTab = 0;
     }
     internal void SetupChildrenDialog(StageObj stageObj) => _editChildrenDialog.Open(stageObj);
-    
+
     /// <summary>
     /// Renders the main menu bar seen at the very top of the window.
     /// </summary>
@@ -333,6 +346,29 @@ internal class MainWindowContext : WindowContext
             ImGui.EndMenu();
         }
 
+        if (ImGui.BeginMenu("General"))
+        {
+            if (ImGui.MenuItem("CreatorClassNameTable"))
+               _editCCNT.Open();
+            ImGui.BeginDisabled();
+            if (ImGui.MenuItem("Audio"))
+               _editCCNT.Open();
+            if (ImGui.MenuItem("Light Areas"))
+               _editCCNT.Open();
+            if (ImGui.MenuItem("Stage List"))
+               _editCCNT.Open();
+            if (ImGui.MenuItem("Effects"))
+               _editCCNT.Open();
+            ImGui.EndDisabled();
+            if (ContextHandler.SystemSettings.EnableDBEditor)
+            {
+                ImGui.Separator();
+                if (ImGui.MenuItem("Edit Object Database"))
+                    _editCCNT.Open();
+            }
+            ImGui.EndMenu();
+        }
+
 #if DEBUG
         if (ImGui.BeginMenu("Debug"))
         {
@@ -374,7 +410,6 @@ internal class MainWindowContext : WindowContext
             }
 
             ImGui.Separator();
-
             if (ImGui.MenuItem("Show all params"))
             {
                 _paramsWindow.MiscEnabled = true;
@@ -386,6 +421,17 @@ internal class MainWindowContext : WindowContext
             ImGui.EndMenu();
         }
 #endif
+        ImGui.SetCursorPosX(ImGui.GetWindowWidth() - ImGui.CalcTextSize("Help").X - ImGui.GetStyle().ItemSpacing.X*2);
+        if (ImGui.BeginMenu("Help"))
+        {
+            if (ImGui.MenuItem("Shortcuts"))
+                _shortcutsDialog.Open();
+            if (ImGui.MenuItem("About"))
+            {
+                
+            }
+            ImGui.EndMenu();
+        }
 
         #region SceneTabs
         // Opened stages are displayed in tabs in the main menu bar.
@@ -438,7 +484,7 @@ internal class MainWindowContext : WindowContext
                     if (Scenes.Count == 0)
                     {
                         ImGui.SetWindowFocus("Stages");
-                    }    
+                    }
                 }
             }
 

--- a/Autumn/GUI/Windows/MainWindowContext.cs
+++ b/Autumn/GUI/Windows/MainWindowContext.cs
@@ -281,6 +281,8 @@ internal class MainWindowContext : WindowContext
             ImGui.Separator();
 
             ImGuiWidgets.CommandMenuItem(CommandID.AddStage, ContextHandler.ActionHandler, this);
+            ImGuiWidgets.CommandMenuItem(CommandID.AddALL, ContextHandler.ActionHandler, this);
+            ImGuiWidgets.CommandMenuItem(CommandID.SaveALL, ContextHandler.ActionHandler, this);
             ImGuiWidgets.CommandMenuItem(CommandID.SaveStage, ContextHandler.ActionHandler, this);
 
             ImGui.Separator();

--- a/Autumn/GUI/Windows/MainWindowContext.cs
+++ b/Autumn/GUI/Windows/MainWindowContext.cs
@@ -335,8 +335,6 @@ internal class MainWindowContext : WindowContext
             ImGui.Separator();
 
             ImGuiWidgets.CommandMenuItem(CommandID.AddStage, ContextHandler.ActionHandler, this);
-            ImGuiWidgets.CommandMenuItem(CommandID.AddALL, ContextHandler.ActionHandler, this);
-            ImGuiWidgets.CommandMenuItem(CommandID.SaveALL, ContextHandler.ActionHandler, this);
             ImGuiWidgets.CommandMenuItem(CommandID.SaveStage, ContextHandler.ActionHandler, this);
 
             ImGui.Separator();
@@ -459,6 +457,9 @@ internal class MainWindowContext : WindowContext
                 _paramsWindow.FogEnabled = true;
                 _paramsWindow.LightEnabled = true;
             }
+            ImGui.Separator();
+            ImGuiWidgets.CommandMenuItem(CommandID.AddALL, ContextHandler.ActionHandler, this);
+            ImGuiWidgets.CommandMenuItem(CommandID.SaveALL, ContextHandler.ActionHandler, this);
 
             ImGui.EndMenu();
         }

--- a/Autumn/GUI/Windows/MainWindowContext.cs
+++ b/Autumn/GUI/Windows/MainWindowContext.cs
@@ -31,27 +31,28 @@ internal class MainWindowContext : WindowContext
 
     private bool _isFirstFrame = true;
 
-#region Dialogs
+    #region Dialogs
     private readonly AddStageDialog _addStageDialog;
     private readonly ClosingDialog _closingDialog;
     private readonly NewStageObjDialog _newStageObjDialog;
     private readonly SettingsDialog _settingsDialog;
     private readonly ShortcutsDialog _shortcutsDialog;
-#endregion
+    private readonly DatabaseEditor _DBEditorDialog;
+    #endregion
 
-#region Editor Dialogs
+    #region Editor Dialogs
     public readonly EditChildrenDialog _editChildrenDialog;
     public readonly EditCreatorClassNameTable _editCCNT;
-#endregion
+    #endregion
 
-#region Editor Windows 
+    #region Editor Windows 
     private readonly StageWindow _stageWindow;
     private readonly ObjectWindow _objectWindow;
     private readonly PropertiesWindow _propertiesWindow;
     private readonly ParametersWindow _paramsWindow;
     private readonly SceneWindow _sceneWindow;
     private readonly WelcomeDialog _welcomeDialog;
-#endregion
+    #endregion
 
 #if DEBUG
     private bool _showDemoWindow = false;
@@ -69,6 +70,7 @@ internal class MainWindowContext : WindowContext
         _settingsDialog = new(this);
         _editCCNT = new(this);
         _shortcutsDialog = new(this);
+        _DBEditorDialog = new(this);
 
         // Initialize editors:
         _stageWindow = new(this);
@@ -193,6 +195,7 @@ internal class MainWindowContext : WindowContext
             _newStageObjDialog.Render();
             _editChildrenDialog.Render();
             _editCCNT.Render();
+            _DBEditorDialog.Render();
             _shortcutsDialog.Render();
             _welcomeDialog.Render();
             _settingsDialog.Render();
@@ -248,6 +251,20 @@ internal class MainWindowContext : WindowContext
         _paramsWindow.CurrentTab = 0;
     }
     internal void SetupChildrenDialog(StageObj stageObj) => _editChildrenDialog.Open(stageObj);
+    internal void CloseCurrentScene()
+    {
+        int i = Scenes.IndexOf(CurrentScene!) - 1;
+        Scenes.Remove(CurrentScene!);
+        if (i < 0)
+            CurrentScene = null;
+        else
+            CurrentScene = Scenes[i];
+        if (Scenes.Count == 0)
+        {
+            ImGui.SetWindowFocus("Stages");
+        }
+
+    }
 
     /// <summary>
     /// Renders the main menu bar seen at the very top of the window.
@@ -326,7 +343,7 @@ internal class MainWindowContext : WindowContext
 
             ImGui.EndMenu();
         }
-        // TODO
+
         if (ImGui.BeginMenu("Stage"))
         {
             if (ImGui.MenuItem("Edit General Params"))
@@ -339,6 +356,7 @@ internal class MainWindowContext : WindowContext
                 _paramsWindow.LightEnabled = true;
             ImGui.Separator();
             ImGui.BeginDisabled();
+            // TODO
             if (ImGui.MenuItem("Edit Cameras"))
                 _paramsWindow.CamerasEnabled = true;
 
@@ -349,22 +367,22 @@ internal class MainWindowContext : WindowContext
         if (ImGui.BeginMenu("General"))
         {
             if (ImGui.MenuItem("CreatorClassNameTable"))
-               _editCCNT.Open();
+                _editCCNT.Open();
             ImGui.BeginDisabled();
             if (ImGui.MenuItem("Audio"))
-               _editCCNT.Open();
+                _editCCNT.Open();
             if (ImGui.MenuItem("Light Areas"))
-               _editCCNT.Open();
+                _editCCNT.Open();
             if (ImGui.MenuItem("Stage List"))
-               _editCCNT.Open();
+                _editCCNT.Open();
             if (ImGui.MenuItem("Effects"))
-               _editCCNT.Open();
+                _editCCNT.Open();
             ImGui.EndDisabled();
             if (ContextHandler.SystemSettings.EnableDBEditor)
             {
                 ImGui.Separator();
                 if (ImGui.MenuItem("Edit Object Database"))
-                    _editCCNT.Open();
+                    _DBEditorDialog.Open();
             }
             ImGui.EndMenu();
         }
@@ -421,18 +439,19 @@ internal class MainWindowContext : WindowContext
             ImGui.EndMenu();
         }
 #endif
-        ImGui.SetCursorPosX(ImGui.GetWindowWidth() - ImGui.CalcTextSize("Help").X - ImGui.GetStyle().ItemSpacing.X*2);
+        var c = ImGui.GetCursorPos();
+        ImGui.SetCursorPosX(ImGui.GetWindowWidth() - ImGui.CalcTextSize("Help").X - ImGui.GetStyle().ItemSpacing.X * 2);
         if (ImGui.BeginMenu("Help"))
         {
             if (ImGui.MenuItem("Shortcuts"))
                 _shortcutsDialog.Open();
             if (ImGui.MenuItem("About"))
             {
-                
+
             }
             ImGui.EndMenu();
         }
-
+        ImGui.SetCursorPos(c);
         #region SceneTabs
         // Opened stages are displayed in tabs in the main menu bar.
 

--- a/Autumn/GUI/Windows/MainWindowContext.cs
+++ b/Autumn/GUI/Windows/MainWindowContext.cs
@@ -3,6 +3,7 @@ using Autumn.ActionSystem;
 using Autumn.Background;
 using Autumn.Context;
 using Autumn.Enums;
+using Autumn.FileSystems;
 using Autumn.GUI.Dialogs;
 using Autumn.GUI.Editors;
 using Autumn.Rendering;
@@ -217,6 +218,29 @@ internal class MainWindowContext : WindowContext
 
             if (Directory.Exists(path))
                 ContextHandler.OpenProject(path);
+            else if (ContextHandler.IsProjectLoaded && File.Exists(path) && Path.GetExtension(path) == ".szs")
+            {
+                BackgroundManager.Add(
+                    $"Importing stage from {path}...",
+                    manager =>
+                    {
+                        Stage? stage = ContextHandler.FSHandler.TryReadStage(path);
+                        if (stage == null)
+                            return;
+                        Scene scene =
+                            new(
+                                stage,
+                                ContextHandler.FSHandler,
+                                GLTaskScheduler,
+                                ref manager.StatusMessageSecondary
+                            );
+
+                        Scenes.Add(scene);
+                        ImGui.SetWindowFocus("Objects");
+                    }
+                );
+            }
+
         };
     }
 

--- a/Autumn/Resources/DefaultActions.yml
+++ b/Autumn/Resources/DefaultActions.yml
@@ -43,3 +43,8 @@ AddStage:
   Ctrl: false
   Key: A
   Shift: false
+CloseScene:
+  Alt: false
+  Ctrl: true
+  Key: W
+  Shift: false

--- a/Autumn/Storage/StageLight.cs
+++ b/Autumn/Storage/StageLight.cs
@@ -1,8 +1,6 @@
 using System.Numerics;
-using Autumn.GUI;
 using Autumn.Rendering.CtrH3D;
 using BYAMLSharp;
-using SPICA.Formats.CtrH3D.Model.Material;
 
 namespace Autumn.Storage;
 
@@ -71,6 +69,21 @@ internal class StageLight
 
     public StageLight()
     {
+    }
+
+    public StageLight(StageLight l)
+    {
+        
+        for( int i = 0; i < 6; i++)
+        {
+            ConstantColors[i] = l.ConstantColors[i];
+        }
+        Ambient = l.Ambient;
+        Diffuse = l.Diffuse;
+        Specular0 = l.Specular0;
+        Specular1 = l.Specular1;
+        IsCameraFollow = l.IsCameraFollow;
+        Direction = l.Direction;
     }
 
     public StageLight(Dictionary<string, BYAMLNode> dict)

--- a/Autumn/Utils/IconUtils.cs
+++ b/Autumn/Utils/IconUtils.cs
@@ -1,0 +1,18 @@
+namespace Autumn.Utils;
+
+internal static class IconUtils
+{
+    public const string PENCIL = "\uF303";
+    public const string LINK = "\uf0c1";
+    public const string UNLINK = "\uf127";
+    public const string PLUS = "\uf067";
+    public const string MINUS = "\uf068";
+    public const string EYE_CLOSED = "\uF070";
+    public const string EYE_OPEN = "\uF06E";
+    public const string ARROW_DOWN = "\uf063";
+    public const string ARROW_LEFT = "\uf060";
+    public const string ARROW_RIGHT = "\uf061";
+    public const string ARROW_UP = "\uf062";
+    public const string DOWN = "\uf078";
+
+}

--- a/Autumn/Wrappers/ClassDatabaseWrapper.cs
+++ b/Autumn/Wrappers/ClassDatabaseWrapper.cs
@@ -19,7 +19,7 @@ internal static class ClassDatabaseWrapper
     public struct Arg
     {
         public object Default { get; set; }
-        public string Type { get; set; }
+        public string? Type { get; set; }
         public string Description { get; set; }
         public string Name { get; set; }
         public bool Required { get; set; }
@@ -40,7 +40,7 @@ internal static class ClassDatabaseWrapper
     {
         get
         {
-            if (s_DatabaseEntries is null)
+            if (s_DatabaseEntries is null || ReloadEntries)
             {
                 s_DatabaseEntries = new();
                 string path = Path.Join(Path.Join("Resources", "RedPepper-ClassDataBase"), "Data");
@@ -52,9 +52,12 @@ internal static class ClassDatabaseWrapper
                     if(entry.ClassName is not null)
                         s_DatabaseEntries[entry.ClassName] = entry;
                 }
+                ReloadEntries = false;
             }
 
             return s_DatabaseEntries;
         }
     }
+
+    public static bool ReloadEntries = false;
 }

--- a/Autumn/Wrappers/Yaz0Wrapper.cs
+++ b/Autumn/Wrappers/Yaz0Wrapper.cs
@@ -8,7 +8,6 @@ internal static class Yaz0Wrapper
         MemoryStream resultStream = new();
         MemoryStream dataStream = new(data);
         BinaryWriter bw = new(resultStream);
-        var curtime = System.DateTime.Now;
         bw.Write((byte)'Y');
         bw.Write((byte)'a');
         bw.Write((byte)'z');

--- a/Autumn/Wrappers/Yaz0Wrapper.cs
+++ b/Autumn/Wrappers/Yaz0Wrapper.cs
@@ -1,131 +1,141 @@
-using System.Runtime.InteropServices;
-
 namespace Autumn.Wrappers;
 
-// Code based on EveryFileExplorer (https://github.com/Gericom/EveryFileExplorer/blob/master/CommonCompressors/YAZ0.cs)
 internal static class Yaz0Wrapper
 {
-    /// <summary>
-    /// Defines the level of compression used when compressing.
-    /// </summary>
-    public static byte? Level { get; set; } = 3;
-
     public static unsafe byte[] Compress(byte[] data)
     {
-        int maxBackLevel = Level is null ? 256 : (int)(0x10e0 * (Level / 9.0) - 0x0e0);
+        var watch = System.Diagnostics.Stopwatch.StartNew();
+        MemoryStream resultStream = new();
+        MemoryStream dataStream = new(data);
+        BinaryWriter bw = new(resultStream);
+        var curtime = System.DateTime.Now;
+        bw.Write((byte)'Y');
+        bw.Write((byte)'a');
+        bw.Write((byte)'z');
+        bw.Write((byte)'0');
+        bw.Write((byte)(data.Length >> 24 & 0xFF));
+        bw.Write((byte)(data.Length >> 16 & 0xFF));
+        bw.Write((byte)(data.Length >> 8 & 0xFF));
+        bw.Write((byte)(data.Length >> 0 & 0xFF));
+        bw.BaseStream.Seek(8, SeekOrigin.Current);
 
-        byte* dataptr = (byte*)Marshal.UnsafeAddrOfPinnedArrayElement(data, 0);
+        const int max_2Byte_length = 0x11;  // -2
+        const int max_length = 0x111; // -0x12
+        const int max_back_distance = 0xfff; //
+        bool bad_compression = false; // if enabled, nothing actually gets compressed and the yaz0 file ends up being bigger than the original, but the resulting file is still valid
 
-        byte[] result = new byte[data.Length + data.Length / 8 + 0x10];
-        byte* resultptr = (byte*)Marshal.UnsafeAddrOfPinnedArrayElement(result, 0);
-        *resultptr++ = (byte)'Y';
-        *resultptr++ = (byte)'a';
-        *resultptr++ = (byte)'z';
-        *resultptr++ = (byte)'0';
-        *resultptr++ = (byte)(data.Length >> 24 & 0xFF);
-        *resultptr++ = (byte)(data.Length >> 16 & 0xFF);
-        *resultptr++ = (byte)(data.Length >> 8 & 0xFF);
-        *resultptr++ = (byte)(data.Length >> 0 & 0xFF);
-
-        resultptr += 8;
-
-        int length = data.Length;
-        int dstoffs = 16;
-        int Offs = 0;
-        while (true)
+        while (dataStream.Position < dataStream.Length)
         {
-            int headeroffs = dstoffs++;
-            resultptr++;
-            byte header = 0;
-            for (int i = 0; i < 8; i++)
+            if (bad_compression)
             {
-                int comp = 0;
-                int back = 1;
-                int nr = 2;
-                {
-                    byte* ptr = dataptr - 1;
-                    int maxnum = 0x111;
-                    if (length - Offs < maxnum)
-                        maxnum = length - Offs;
-                    //Use a smaller amount of bytes back to decrease time
-                    int maxback = maxBackLevel; //0x1000;
-                    if (Offs < maxback)
-                        maxback = Offs;
-                    maxback = (int)dataptr - maxback;
-                    int tmpnr;
-                    while (maxback <= (int)ptr)
-                    {
-                        if (*(ushort*)ptr == *(ushort*)dataptr && ptr[2] == dataptr[2])
-                        {
-                            tmpnr = 3;
-                            while (tmpnr < maxnum && ptr[tmpnr] == dataptr[tmpnr])
-                                tmpnr++;
-                            if (tmpnr > nr)
-                            {
-                                if (Offs + tmpnr > length)
-                                {
-                                    nr = length - Offs;
-                                    back = (int)(dataptr - ptr);
-                                    break;
-                                }
-                                nr = tmpnr;
-                                back = (int)(dataptr - ptr);
-                                if (nr == maxnum)
-                                    break;
-                            }
-                        }
-                        --ptr;
-                    }
-                }
-                if (nr > 2)
-                {
-                    Offs += nr;
-                    dataptr += nr;
-                    if (nr >= 0x12)
-                    {
-                        *resultptr++ = (byte)(back - 1 >> 8 & 0xF);
-                        *resultptr++ = (byte)(back - 1 & 0xFF);
-                        *resultptr++ = (byte)(nr - 0x12 & 0xFF);
-                        dstoffs += 3;
-                    }
-                    else
-                    {
-                        *resultptr++ = (byte)(back - 1 >> 8 & 0xF | (nr - 2 & 0xF) << 4);
-                        *resultptr++ = (byte)(back - 1 & 0xFF);
-                        dstoffs += 2;
-                    }
-                    comp = 1;
-                }
-                else
-                {
-                    *resultptr++ = *dataptr++;
-                    dstoffs++;
-                    Offs++;
-                }
-                header = (byte)(header << 1 | (comp == 1 ? 0 : 1));
-                if (Offs >= length)
-                {
-                    header = (byte)(header << 7 - i);
+                bw.Write((byte)0xFF);
+                bw.Write(ReadBytes(8, dataStream));
+                if (dataStream.Position >= dataStream.Length)
                     break;
+                continue;
+            }
+
+            byte header = 0; // 0b11111111 -> all identical, 0b00000000 -> all look ahead
+            var basepos = bw.BaseStream.Position;
+            bw.BaseStream.Seek(1, SeekOrigin.Current); // skip first byte of group before data is ready
+            for (byte chunk = 0; chunk < 8; chunk++)
+            {
+                if (dataStream.Position >= dataStream.Length)
+                    break;
+
+                var chunkpos = dataStream.Position;
+                byte current = (byte)dataStream.ReadByte();
+                dataStream.Position = chunkpos;
+                byte[] checkbytes = ReadBytes(3, dataStream);
+
+                var checkpos = chunkpos - max_back_distance > 0 ? chunkpos - max_back_distance : 0; // if we're not over the lookback limit position we start at 0  
+                bool matched = false;
+                int matchlength = 0;
+                ushort distance = 0;
+                dataStream.Flush();
+                while (checkpos < chunkpos && checkpos < dataStream.Length)
+                {
+                    dataStream.Position = checkpos;
+                    if (checkbytes.SequenceEqual(ReadBytes(3, dataStream)))
+                    {
+                        matched = true;
+                        int oldmatchlength = matchlength;
+                        matchlength = 3;
+                        var tmpnext = dataStream.ReadByte();
+                        dataStream.Position = chunkpos + matchlength;
+                        while (tmpnext == dataStream.ReadByte() && dataStream.Position <= dataStream.Length && matchlength < max_length)
+                        {
+                            matchlength++;
+                            dataStream.Position = checkpos + matchlength;
+                            tmpnext = dataStream.ReadByte();
+                            dataStream.Position = chunkpos + matchlength;
+                        }
+                        if (oldmatchlength < matchlength) // maintain the result until we find a longer match
+                        {
+                            dataStream.Position -= 1;
+                            distance = (ushort)(chunkpos - checkpos - 1);
+                        }
+                        else matchlength = oldmatchlength; 
+                    } 
+                    // Keep checking in case there's a better match
+                    checkpos++;
+                    dataStream.Flush();
+                }
+                dataStream.Position = chunkpos + matchlength;
+
+                if (!matched)// write as is, 1:1
+                {
+                    dataStream.Position = chunkpos + 1;
+                    bw.Write(current);
+                    header |= (byte)(1 << 7 - chunk);  // tell the header this chunk is 1:1
+                }
+                else // look ahead
+                {
+                    if (matchlength - 2 <= max_2Byte_length - 2) // write 2 bytes if it's smaller than or equal to 0xf, else write 3 bytes
+                    {
+                        // lookAheadLength; // value between 1 and 0xf
+
+                        bw.Write((byte)(((distance & 0x0f00) >> 8) + (matchlength - 2) * 0x10));
+                        bw.Write((byte)(distance & 0x00ff));
+                        //bw.Write();
+                    }
+                    else // write 3 bytes
+                    {
+                        bw.Write((byte)((distance & 0x0f00) >> 8));
+                        bw.Write((byte)(distance & 0xff));
+                        bw.Write((byte)(matchlength - 0x12));
+                    }
+
                 }
             }
-            result[headeroffs] = header;
-            if (Offs >= length)
-                break;
+            var nextpos = bw.BaseStream.Position;
+            bw.BaseStream.Position = basepos;
+            bw.Write(header); // write group header byte
+            bw.BaseStream.Position = nextpos;
         }
-        while (dstoffs % 4 != 0)
-            dstoffs++;
-        byte[] realresult = new byte[dstoffs];
-        Array.Copy(result, realresult, dstoffs);
-        return realresult;
+        bw.Close();
+        watch.Stop();
+        Console.WriteLine($"File compressed in {watch.ElapsedMilliseconds}");
+        return resultStream.ToArray();
+    }
+    private static byte[] ReadBytes(int num, MemoryStream s)
+    {
+        byte[] ret = new byte[num];
+        for (int i = 0; i < num; i++)
+        {
+            ret[i] = (byte)s.ReadByte();
+        }
+        return ret;
     }
 
+    // Code based on EveryFileExplorer (https://github.com/Gericom/EveryFileExplorer/blob/master/CommonCompressors/YAZ0.cs)
     public static byte[] Decompress(byte[] Data)
     {
         uint leng = (uint)(Data[4] << 24 | Data[5] << 16 | Data[6] << 8 | Data[7]);
         byte[] Result = new byte[leng];
         int Offs = 16;
         int dstoffs = 0;
+
         while (true)
         {
             byte header = Data[Offs++];

--- a/Autumn/Wrappers/Yaz0Wrapper.cs
+++ b/Autumn/Wrappers/Yaz0Wrapper.cs
@@ -2,6 +2,22 @@ namespace Autumn.Wrappers;
 
 internal static class Yaz0Wrapper
 {
+    /// <summary>
+    /// Defines the level of compression used when compressing.
+    /// </summary>
+    public static CompressionLevel Level { get; set; } = CompressionLevel.Medium;
+
+    /// <summary>
+    /// Recommended compression levels.
+    /// </summary>
+    public enum CompressionLevel
+    {
+        Small = 0x1ff,
+        Medium = 0x4c0,
+        Great = 0xAff,
+        Max = 0xfff,
+        None = 0,
+    }
     public static unsafe byte[] Compress(byte[] data)
     {
         var watch = System.Diagnostics.Stopwatch.StartNew();
@@ -20,8 +36,8 @@ internal static class Yaz0Wrapper
 
         const int max_2Byte_length = 0x11;  // -2
         const int max_length = 0x111; // -0x12
-        const int max_back_distance = 0xfff; //
-        bool bad_compression = false; // if enabled, nothing actually gets compressed and the yaz0 file ends up being bigger than the original, but the resulting file is still valid
+        int max_back_distance = (int)Level;
+        bool bad_compression = Level == CompressionLevel.None; // if enabled, nothing actually gets compressed and the yaz0 file ends up being bigger than the original, but the resulting file is still valid
 
         while (dataStream.Position < dataStream.Length)
         {


### PR DESCRIPTION
CCNT editor:
 - allows adding and removing objects
 - can merge from other CCNT files
 - can select classes documented in the db or write your own
 - can be saved

Db editor: 
 - can edit all properties present in each database entry, including:
 +  name
 + description 
 + type 
 + args
 + switches
 - it can also add and remove entries.

Yaz0 Compressor rewrite:
 - Uses MemoryStream and BinaryWriter as opposed to pointers, preventing the data sometimes being lost mid save  

Other minor changes include:
 - added option select compression level in the settings
 - reworked the settings menu ui
 - made it possible to drag and drop stages that aren't part of the project into the editor to open them
 - fixes to light copying in lightparams tab
 - added a new combobox that can be written into, used in CCNT editor and lightarea selector
 - made it so stages can be closed with Ctrl + W (added it as an action)
 - updated all the UI that used fontawesome icons to use a specialised class instead of writing the unicode value each time (IconUtils)
 - switches now show a tooltip with info if they're documented
 - preview light gets disabled if the light params / area tabs aren't visible // active
 - added menu for general romfs files (that's where you can find the CCNT editor and the DB editor)
 - added help menu with shortcuts automatically grabbed from actionhandler (missing viewport shortcuts for now but those need a rework anyway), and about menu (no window for it yet, needs proper sourcing and crediting when done)