### PR TITLE
Zoom to mouse and rendering improvements

### DIFF
--- a/Autumn/Context/SystemSettings.cs
+++ b/Autumn/Context/SystemSettings.cs
@@ -21,6 +21,7 @@ internal class SystemSettings
     public int MouseSpeed = 20;
     public bool UseWASD = false;
     public bool UseMiddleMouse = true;
+    public bool ZoomToMouse = false;
     public bool RememberLayout = true;
     public bool EnableDBEditor = false;
     public bool[] VisibleDefaults = [false, true, true, true]; // Areas, CameraAreas, Rails, Grid

--- a/Autumn/Context/SystemSettings.cs
+++ b/Autumn/Context/SystemSettings.cs
@@ -17,6 +17,7 @@ internal class SystemSettings
     public bool OpenLastProject = true;
     public string LastOpenedProject = string.Empty;
     public bool EnableVSync = true;
+    public bool AlwaysPreviewStageLights = true;
     public int Theme = 0;
     public int MouseSpeed = 20;
     public bool UseWASD = false;

--- a/Autumn/FileSystems/RomFSHandler.cs
+++ b/Autumn/FileSystems/RomFSHandler.cs
@@ -451,6 +451,19 @@ internal partial class RomFSHandler
         if (!found)
             return actor;
 
+        if (narc.TryGetFile("InitLight.byml", out byte[] light))
+        {
+            BYAML act_lights = BYAMLParser.Read(light, s_byamlEncoding);
+            if (act_lights.RootNode.NodeType == BYAMLNodeType.Dictionary)
+            {
+                var lrt = act_lights.RootNode.GetValueAs<Dictionary<string, BYAMLNode>>();
+                if (lrt!.ContainsKey("LightCalcType"))
+                    actor.InitLight.GetCalcType((string)lrt["LightCalcType"].Value!); 
+                if (lrt!.ContainsKey("LightType"))
+                    actor.InitLight.GetType((string)lrt["LightType"].Value!);
+            }
+        }
+
         H3D h3D;
 
         try

--- a/Autumn/FileSystems/RomFSHandler.cs
+++ b/Autumn/FileSystems/RomFSHandler.cs
@@ -740,9 +740,14 @@ internal partial class RomFSHandler
             }
 
             if (Directory.Exists(Path.Join(_soundPath, "stream")))
-                _bgmTable.BgmFiles = Directory.EnumerateFiles(Path.Join(_soundPath, "stream")).Select(x => Path.GetFileNameWithoutExtension(x)).Order().ToList();
-            else
-                _bgmTable.BgmFiles.Sort();
+            {
+                var fls = Directory.EnumerateFiles(Path.Join(_soundPath, "stream")).Select(x => Path.GetFileNameWithoutExtension(x));
+                foreach (string sng in fls)
+                {
+                    if (!_bgmTable.BgmFiles.Contains(sng)) _bgmTable.BgmFiles.Add(sng);
+                }
+            }
+            _bgmTable.BgmFiles.Sort();
         }
 
         //var query = (from s in _bgmTable.StageDefaultBgmList where s.Scenario == 1 select s).ToList();

--- a/Autumn/GUI/Dialogs/SettingsDialog.cs
+++ b/Autumn/GUI/Dialogs/SettingsDialog.cs
@@ -20,6 +20,7 @@ internal class SettingsDialog
     private bool _rememberLayout = false;
     private bool _wasd = false;
     private bool _middleMovesCamera = false;
+    private bool _zoomToMouse = false;
     private bool _enableVSync = true;
     private bool _restoreNativeFileDialogs = false;
     private int _compLevel = 1;
@@ -55,6 +56,7 @@ internal class SettingsDialog
         _dbEditor = _window.ContextHandler.SystemSettings.EnableDBEditor;
         _middleMovesCamera = _window.ContextHandler.SystemSettings.UseMiddleMouse;
         _mouseSpeed = _window.ContextHandler.SystemSettings.MouseSpeed;
+        _zoomToMouse = _window.ContextHandler.SystemSettings.ZoomToMouse;
         _oldStyle = _window.ContextHandler.SystemSettings.Theme;
         _enableVSync = _window.ContextHandler.SystemSettings.EnableVSync;
         _restoreNativeFileDialogs = _window.ContextHandler.SystemSettings.RestoreNativeFileDialogs;
@@ -149,6 +151,7 @@ internal class SettingsDialog
                 ImGuiWidgets.HelpTooltip("Please be aware that this WILL interfere with other editor commands for now.");
 
                 ImGui.Checkbox("Use middle click instead of right click to move the camera", ref _middleMovesCamera);
+                ImGui.Checkbox("Zoom to mouse", ref _zoomToMouse);
                 ImGui.InputInt("Camera Speed", ref _mouseSpeed, 1, default);
                 ImGui.SameLine();
                 ImGuiWidgets.HelpTooltip("Recommended values: 20, 35");
@@ -217,6 +220,7 @@ internal class SettingsDialog
             _window.ContextHandler.SetProjectSetting("UseClassNames", false);
             _window.ContextHandler.SystemSettings.UseWASD = false;
             _window.ContextHandler.SystemSettings.UseMiddleMouse = false;
+            _window.ContextHandler.SystemSettings.ZoomToMouse = false;
             _window.ContextHandler.SystemSettings.EnableVSync = true;
             _window.ContextHandler.SystemSettings.Theme = 0;
             _window.ContextHandler.SystemSettings.MouseSpeed = 20;
@@ -281,6 +285,7 @@ internal class SettingsDialog
             _window.ContextHandler.SystemSettings.EnableVSync = _enableVSync;
             _window.ContextHandler.SystemSettings.Theme = _selectedStyle;
             _window.ContextHandler.SystemSettings.MouseSpeed = _mouseSpeed;
+            _window.ContextHandler.SystemSettings.ZoomToMouse = _zoomToMouse;
             _window.ContextHandler.SystemSettings.EnableDBEditor = _dbEditor;
             _window.ContextHandler.SystemSettings.RestoreNativeFileDialogs = _restoreNativeFileDialogs;
             _window.ContextHandler.SystemSettings.Yaz0Compression = Enum.GetValues<Yaz0Wrapper.CompressionLevel>()[_compLevel];

--- a/Autumn/GUI/Dialogs/SettingsDialog.cs
+++ b/Autumn/GUI/Dialogs/SettingsDialog.cs
@@ -18,6 +18,7 @@ internal class SettingsDialog
     private bool _useClassNames = false;
     private bool _dbEditor = false;
     private bool _rememberLayout = false;
+    private bool _prevlightonload = false;
     private bool _wasd = false;
     private bool _middleMovesCamera = false;
     private bool _zoomToMouse = false;
@@ -66,6 +67,7 @@ internal class SettingsDialog
         _rememberLayout = _window.ContextHandler.SystemSettings.RememberLayout;
         _romfspath = _window.ContextHandler.Settings.RomFSPath ?? "";
         _romfsIsValidPath = Directory.Exists(_romfspath);
+        _prevlightonload = _window.ContextHandler.SystemSettings.AlwaysPreviewStageLights;
     }
 
     /// <summary>
@@ -156,6 +158,7 @@ internal class SettingsDialog
                 ImGui.SameLine();
                 ImGuiWidgets.HelpTooltip("Recommended values: 20, 35");
                 _mouseSpeed = int.Clamp(_mouseSpeed, 10, 120);
+                ImGui.Checkbox("Preview stage lights without opening the ligths window", ref _prevlightonload); 
                 ImGui.EndTabItem();
             }
             if (ImGui.BeginTabItem("Editor Functionality"))
@@ -293,6 +296,7 @@ internal class SettingsDialog
             _visibleDefaults.CopyTo(_window.ContextHandler.SystemSettings.VisibleDefaults, 0);
             _window.ContextHandler.SystemSettings.OpenLastProject = _loadLast;
             _window.ContextHandler.SystemSettings.RememberLayout = _rememberLayout;
+            _window.ContextHandler.SystemSettings.AlwaysPreviewStageLights = _prevlightonload;
 
             ImGui.CloseCurrentPopup();
             ImGui.EndPopup();

--- a/Autumn/GUI/Editors/ParamsEditors/CameraParamsWindow.cs
+++ b/Autumn/GUI/Editors/ParamsEditors/CameraParamsWindow.cs
@@ -161,7 +161,7 @@ internal class CameraParamsWindow(MainWindowContext window)
 
         if (selectedcam < 0)
             ImGui.BeginDisabled();
-        if (ImGui.Button(IconUtils.MINUS + "## remcam", new Vector2(ImGui.GetWindowWidth() / 3 - 16, default)))
+        if (ImGui.Button(IconUtils.MINUS + "## remcam", new Vector2(ImGui.GetContentRegionAvail().X / 3, default)))
         {
             scn.Stage.CameraParams.Cameras.RemoveAt(selectedcam);
             selectedcam = -1;
@@ -170,7 +170,7 @@ internal class CameraParamsWindow(MainWindowContext window)
 
 
         ImGui.SameLine();
-        if (ImGui.Button(IconUtils.PASTE + "## dupecam", new Vector2(ImGui.GetWindowWidth() / 3 - 16, default)))
+        if (ImGui.Button(IconUtils.PASTE + "## dupecam", new Vector2(ImGui.GetContentRegionAvail().X / 2, default)))
         {
             scn.Stage.CameraParams.AddCamera(new(scn.Stage.CameraParams.Cameras[selectedcam]));
             window.UpdateCameraList();
@@ -180,7 +180,7 @@ internal class CameraParamsWindow(MainWindowContext window)
         if (selectedcam < 0)
             ImGui.EndDisabled();
         ImGui.SameLine();
-        if (ImGui.Button(IconUtils.PLUS + "## addcam", new Vector2(ImGui.GetWindowWidth() / 3 - 16, default)))
+        if (ImGui.Button(IconUtils.PLUS + "## addcam", new Vector2(ImGui.GetContentRegionAvail().X, default)))
         {
             scn.Stage.CameraParams.AddCamera(new());
             window.UpdateCameraList();

--- a/Autumn/GUI/Editors/SceneWindow.cs
+++ b/Autumn/GUI/Editors/SceneWindow.cs
@@ -195,13 +195,11 @@ internal class SceneWindow(MainWindowContext window)
 
         _previousMousePos = mousePos;
 
+        // Camera Movement
+        float camMoveSpeed = (float)(0.4 * deltaSeconds * 60);
+        camMoveSpeed *= window.Keyboard!.IsKeyPressed(Key.ShiftRight) || window.Keyboard.IsKeyPressed(Key.ShiftLeft) ? 6 : 1;
         if (_isSceneHovered || _isSceneWindowFocused)
         {
-            // Camera Movement
-            float camMoveSpeed = (float)(0.4 * deltaSeconds * 60);
-            camMoveSpeed *=
-                window.Keyboard!.IsKeyPressed(Key.ShiftRight) || window.Keyboard.IsKeyPressed(Key.ShiftLeft) ? 6 : 1;
-
             if (window.ContextHandler.SystemSettings.UseWASD)
             {
                 if (!ImGui.IsKeyDown(ImGuiKey.ModCtrl) && !ImGui.IsKeyDown(ImGuiKey.ModSuper))
@@ -221,14 +219,6 @@ internal class SceneWindow(MainWindowContext window)
                     if (window.Keyboard?.IsKeyPressed(Key.E) ?? false)
                         camera.Eye += Vector3.UnitY * camMoveSpeed;
                 }
-            }
-
-            if (window.Mouse!.ScrollWheels[0].Y != 0 && _isSceneHovered)
-            {
-                camera.Eye -= Vector3.Transform(
-                    Vector3.UnitZ * window.Mouse.ScrollWheels[0].Y * 6 * camMoveSpeed,
-                    camera.Rotation
-                );
             }
 
             // if ((window.Keyboard?.IsKeyP ressed(Key.Space) ?? false) && window.CurrentScene.SelectedObjects.Count() > 0){
@@ -384,6 +374,22 @@ internal class SceneWindow(MainWindowContext window)
             //Debug.Assert(canInvert);
             Vector4 worldMousePos = Vector4.Transform(ndcMousePos3D, inverseViewProjection);
             worldMousePos /= worldMousePos.W;
+
+            // Calculate camera zoom in / out
+            if (window.Mouse!.ScrollWheels[0].Y != 0 && _isSceneHovered)
+            {
+                if (window.ContextHandler.SystemSettings.ZoomToMouse == ImGui.IsKeyDown(ImGuiKey.ModAlt))
+                {
+                    camera.Eye -= Vector3.Transform(
+                        Vector3.UnitZ * window.Mouse.ScrollWheels[0].Y * 6 * camMoveSpeed,
+                        camera.Rotation
+                    );
+                }
+                else
+                {
+                    camera.Eye = camera.Eye + -window.Mouse.ScrollWheels[0].Y * 2 * camMoveSpeed * (camera.Eye - Vector3.Lerp(camera.Eye, new Vector3(worldMousePos.X, worldMousePos.Y, worldMousePos.Z), 0.1f));
+                }
+            }
 
             if (
                 ImGui.IsMouseClicked(ImGuiMouseButton.Left)

--- a/Autumn/Rendering/CtrH3D/FragmentShaderGenerator.cs
+++ b/Autumn/Rendering/CtrH3D/FragmentShaderGenerator.cs
@@ -503,17 +503,22 @@ internal class FragmentShaderGenerator
         SB.AppendLine($"\t\tvec3 Rounded = vec3(Roundedx, Roundedy, Roundedz);");
 
         // Same but for Lights[i].Position.
-        SB.AppendLine($"\t\tvec3 RPos = Lights[i].Position;");
-        SB.AppendLine("\t\tif (Lights[i].Directional != 0) {");
+        SB.AppendLine($"\t\tvec3 RPos = -Lights[i].Position;");
 
+        // Ignore Directional bool for now
+        
+        SB.AppendLine("\t\tif (Lights[i].Directional == 0) {");
         SB.AppendLine($"\t\t\tRPos.x = (abs(RPos.x) == 1 || RPos.x == 0) ? RPos.x+0.001 : RPos.x;");
         SB.AppendLine($"\t\t\tRPos.y = (abs(RPos.y) == 1 || RPos.y == 0) ? RPos.y+0.001 : RPos.y;");
         SB.AppendLine($"\t\t\tRPos.z = (abs(RPos.z) == 1 || RPos.z == 0) ? RPos.z+0.001 : RPos.z;");
         SB.AppendLine("\t\t}");
+        // SB.AppendLine(
+        //     "\t\tvec3 Light = (Lights[i].Directional == 0)"
+        //         + " ? normalize(RPos)"
+        //         + $" : normalize(RPos + Rounded);" // * Rounded);"
+        // );
         SB.AppendLine(
-            "\t\tvec3 Light = (Lights[i].Directional != 0)"
-                + " ? normalize(RPos)"
-                + $" : normalize(RPos + Rounded);"
+            "\t\tvec3 Light = normalize(RPos);"
         );
 
         SB.AppendLine($"\t\tvec3 Half = normalize(normalize(Rounded) + Light);");
@@ -617,14 +622,14 @@ internal class FragmentShaderGenerator
             Specular1Color += " * g";
 
         if ((Params.FragmentFlags & H3DFragmentFlags.IsLUTGeoFactorEnabled) != 0)
-            SB.AppendLine("\t\tfloat g = ln / abs(dot(Half, Half));");
+            SB.AppendLine("\t\tfloat g = 1;");// ln / abs(dot(Half, Half));");
 
         SB.AppendLine("\t\tvec4 Diffuse =");
         SB.AppendLine($"\t\t\t{AmbientUniform} * Lights[i].Ambient +");
         SB.AppendLine($"\t\t\t{DiffuseUniform} * Lights[i].Diffuse * clamp(ln, 0, 1);");
         SB.AppendLine(
             $"\t\tvec4 Specular = "
-                + $"{Specular0Color} * Lights[i].Specular0 + "
+                + $"{Specular0Color} * Lights[i].Specular0 * 1.6 + " // Make specular 0 stronger to be closer to original
                 + $"{Specular1Color} * Lights[i].Specular1;"
         );
         SB.AppendLine($"\t\tFragPriColor.rgb += Diffuse.rgb * SpotAtt * DistAtt;");

--- a/Autumn/Rendering/CtrH3D/H3DRenderingMaterial.cs
+++ b/Autumn/Rendering/CtrH3D/H3DRenderingMaterial.cs
@@ -644,23 +644,22 @@ internal class H3DRenderingMaterial
 
     public void SetSelectionColor(Vector4 color) =>
         _materialBuffer.SetData(_materialBuffer.Data with { SelectionColor = color });
-    public void SetLight0(Light light) {
-        if (!IsEqualsLight(_materialBuffer.Data.Light0, light))
-        _materialBuffer.SetData(_materialBuffer.Data with { Light0 = light});}
+    public void SetLight0(StageLight light) {
+            if (!IsEqualStageLight(_materialBuffer.Data.Light0, light))
+                _materialBuffer.SetData(_materialBuffer.Data with { Light0 = light.GetAsLight()});}
     public void SetConst5(Vector4 color) =>
         _materialBuffer.SetData(_materialBuffer.Data with { Constant5Color = color});
-    
-    private bool IsEqualsLight(Light a, Light b)
+    private bool IsEqualStageLight(Light a, StageLight b)
     {
         return a.Ambient == b.Ambient 
         && a.Diffuse == b.Diffuse
         && a.Specular0 == b.Specular0
         && a.Specular1 == b.Specular1
-        && a.ConstantColor5 == b.ConstantColor5
-        && a.Direction == b.Direction
-        && a.Directional == b.Directional
-        && a.Position == b.Position
-        && a.DisableConst5 == b.DisableConst5
+        && a.DisableConst5 == 1 == (b.ConstantColors[5] == null)
+        //&& a.ConstantColor5 == b.ConstantColors[5]
+        //&& a.Direction == b.Direction
+        && a.Directional == 1 == b.IsCameraFollow
+        && a.Position == b.Direction
         && a.Diffuse == b.Diffuse;
     }
 

--- a/Autumn/Rendering/CtrH3D/H3DRenderingMaterial.cs
+++ b/Autumn/Rendering/CtrH3D/H3DRenderingMaterial.cs
@@ -308,7 +308,7 @@ internal class H3DRenderingMaterial
                 HslSCol = new(0.46275f, 0.76078f, 0.87059f, 0.00f),
                 HslSDir = new(0.0f, 0.95703f, 0.28998f, 0.40f),
                 BoolUniforms = (SceneData.Bools)subMesh.BoolUniforms,
-                BillboardMode = 0 // TEMP - NEEDS TO BE ADDED TO SPICA
+                BillboardMode = subMesh.BillboardMode
             };
 
         // Scales:

--- a/Autumn/Rendering/CtrH3D/H3DRenderingMaterial.cs
+++ b/Autumn/Rendering/CtrH3D/H3DRenderingMaterial.cs
@@ -11,6 +11,7 @@ using SceneGL.Materials.Common;
 using Silk.NET.Maths;
 using Silk.NET.OpenGL;
 using SPICA.Formats.CtrGfx.Model.Material;
+using SPICA.Formats.CtrH3D.Model;
 using SPICA.Formats.CtrH3D.Model.Material;
 using SPICA.Formats.CtrH3D.Model.Mesh;
 using SPICA.PICA.Commands;
@@ -19,6 +20,7 @@ namespace Autumn.Rendering.CtrH3D;
 
 internal class H3DRenderingMaterial
 {
+    public string Name = ""; 
     private struct SceneData
     {
         public Matrix3X4<float> WrldMtx;
@@ -40,7 +42,8 @@ internal class H3DRenderingMaterial
         public Vector4D<int> LightCt;
         public Bools BoolUniforms;
         public int DisableVertexColor; // bool
-        public Vector2 _Padding;
+        public H3DBillboardMode BillboardMode; // bool
+        public int _Padding;
 
         [Flags]
         public enum Bools : int
@@ -104,7 +107,7 @@ internal class H3DRenderingMaterial
         public int AngleLUTInput;
         public int SpotAttEnbled; // bool
         public int DistAttEnbled; // bool
-        public int TwoSidedDiffuse; // bool
+        public int TwoSidedDiffuse; // bool, unused in stage lights
         public int Directional; // bool
         public Vector4 ConstantColor5;
     }
@@ -171,6 +174,7 @@ internal class H3DRenderingMaterial
             material.Name,
             material.MaterialParams
         );
+        Name = material.Name;
 
         DepthFunction = (DepthFunction)FromPICATestFunc(matParams.DepthColorMask.DepthFunc);
 
@@ -303,7 +307,8 @@ internal class H3DRenderingMaterial
                 HslGCol = new(0.56471f, 0.34118f, 0.03529f, 0.00f),
                 HslSCol = new(0.46275f, 0.76078f, 0.87059f, 0.00f),
                 HslSDir = new(0.0f, 0.95703f, 0.28998f, 0.40f),
-                BoolUniforms = (SceneData.Bools)subMesh.BoolUniforms
+                BoolUniforms = (SceneData.Bools)subMesh.BoolUniforms,
+                BillboardMode = 0 // TEMP - NEEDS TO BE ADDED TO SPICA
             };
 
         // Scales:
@@ -406,6 +411,7 @@ internal class H3DRenderingMaterial
                 Constant3Color = matParams.Constant3Color.ToVector4(),
                 Constant4Color = matParams.Constant4Color.ToVector4(),
                 Constant5Color = matParams.Constant5Color.ToVector4(),
+                CombBufferColor = matParams.TexEnvBufferColor.ToVector4(),
                 AlphaReference = matParams.AlphaTest.Reference / 225f,
                 Light0 = new()
                 {

--- a/Autumn/Rendering/CtrH3D/H3DShaders.cs
+++ b/Autumn/Rendering/CtrH3D/H3DShaders.cs
@@ -6,727 +6,729 @@ namespace Autumn.Rendering.CtrH3D;
 
 internal class H3DShaders
 {
-    public static ShaderSource VertexShader(bool FakeVtxCol) =>
-        new(
-            "H3D.vert",
-            ShaderType.VertexShader,
-            """
-            //SPICA auto-generated code
-            //This code was translated from a MAESTRO Vertex Shader
-            //This file was also hand modified to improve compatibility
-            //Furthermore, it was modified in order to better fit Autumn's code
-            #version 330 core
+	public static ShaderSource VertexShader(bool FakeVtxCol) =>
+		new(
+			"H3D.vert",
+			ShaderType.VertexShader,
+			"""
+			//SPICA auto-generated code
+			//This code was translated from a MAESTRO Vertex Shader
+			//This file was also hand modified to improve compatibility
+			//Furthermore, it was modified in order to better fit Autumn's code
+			#version 330 core
 
-            layout(std140) uniform ubScene {
-                vec4 WrldMtx[3];
-                vec4 NormMtx[3];
-                vec4 PosOffs;
-                vec4 IrScale[2];
-                vec4 TexcMap;
-                vec4 TexMtx0[3];
-                vec4 TexMtx1[3];
-                vec4 TexMtx2[2];
-                vec4 TexTran;
-                vec4 MatAmbi;
-                vec4 MatDiff;
-                vec4 HslGCol;
-                vec4 HslSCol;
-                vec4 HslSDir;
-                vec4 ProjMtx[4];
-                vec4 ViewMtx[3];
-                ivec4 LightCt;
-                int BoolUniforms;
-                int DisableVertexColor;
-            };
+			layout(std140) uniform ubScene {
+				vec4 WrldMtx[3];
+				vec4 NormMtx[3];
+				vec4 PosOffs;
+				vec4 IrScale[2];
+				vec4 TexcMap;
+				vec4 TexMtx0[3];
+				vec4 TexMtx1[3];
+				vec4 TexMtx2[2];
+				vec4 TexTran;
+				vec4 MatAmbi;
+				vec4 MatDiff;
+				vec4 HslGCol;
+				vec4 HslSCol;
+				vec4 HslSDir;
+				vec4 ProjMtx[4];
+				vec4 ViewMtx[3];
+				ivec4 LightCt;
+				int BoolUniforms;
+				int DisableVertexColor;
+				int BillboardMode;
+			};
 
-            layout(std140) uniform ubUnivReg {
-                vec4 UnivReg[60];
-            };
+			layout(std140) uniform ubUnivReg {
+				vec4 UnivReg[60];
+			};
 
-            layout(std140) uniform ubBoneTable {
-                int BoneTable[20];
-            };
+			layout(std140) uniform ubBoneTable {
+				int BoneTable[20];
+			};
 
-            //Debugging
-            uniform sampler2D weightRamp1;
-            uniform sampler2D weightRamp2;
-            uniform int selectedBoneIndex;
-            uniform int weightRampType;
-            uniform int hasWeights;
+			//Debugging
+			uniform sampler2D weightRamp1;
+			uniform sampler2D weightRamp2;
+			uniform int selectedBoneIndex;
+			uniform int weightRampType;
+			uniform int hasWeights;
 
-            #define IsSmoSk (1 << 1)
-            #define IsRgdSk (1 << 2)
-            #define IsHemiL (1 << 5)
-            #define IsHemiO (1 << 6)
-            #define IsVertA (1 << 7)
-            #define IsBoneW (1 << 8)
-            #define UvMap0 (1 << 9)
-            #define UvMap1 (1 << 10)
-            #define UvMap2 (1 << 11)
-            #define IsVertL (1 << 12)
-            #define IsTex1 (1 << 13)
-            #define IsTex2 (1 << 14)
-            #define IsQuate (1 << 15)
+			#define IsSmoSk (1 << 1)
+			#define IsRgdSk (1 << 2)
+			#define IsHemiL (1 << 5)
+			#define IsHemiO (1 << 6)
+			#define IsVertA (1 << 7)
+			#define IsBoneW (1 << 8)
+			#define UvMap0 (1 << 9)
+			#define UvMap1 (1 << 10)
+			#define UvMap2 (1 << 11)
+			#define IsVertL (1 << 12)
+			#define IsTex1 (1 << 13)
+			#define IsTex2 (1 << 14)
+			#define IsQuate (1 << 15)
 
-            vec4 reg_temp[16];
-            bvec2 reg_cmp;
-            ivec2 reg_a0;
-            int reg_al;
+			vec4 reg_temp[16];
+			bvec2 reg_cmp;
+			ivec2 reg_a0;
+			int reg_al;
 
-            layout(location = 0) in vec4 aPosition;
-            layout(location = 1) in vec4 aNormal;
-            layout(location = 2) in vec4 aTangent;
-            layout(location = 3) in vec4 aColor;
-            layout(location = 4) in vec4 aTexCoord0;
-            layout(location = 5) in vec4 aTexCoord1;
-            layout(location = 6) in vec4 aTexCoord2;
-            layout(location = 7) in vec4 aBoneIndex;
-            layout(location = 8) in vec4 aBoneWeight;
-            layout(location = 9) in vec4 aUserAttribute0;
-            layout(location = 10) in vec4 aUserAttribute1;
-            layout(location = 11) in vec4 aUserAttribute2;
+			layout(location = 0) in vec4 aPosition;
+			layout(location = 1) in vec4 aNormal;
+			layout(location = 2) in vec4 aTangent;
+			layout(location = 3) in vec4 aColor;
+			layout(location = 4) in vec4 aTexCoord0;
+			layout(location = 5) in vec4 aTexCoord1;
+			layout(location = 6) in vec4 aTexCoord2;
+			layout(location = 7) in vec4 aBoneIndex;
+			layout(location = 8) in vec4 aBoneWeight;
+			layout(location = 9) in vec4 aUserAttribute0;
+			layout(location = 10) in vec4 aUserAttribute1;
+			layout(location = 11) in vec4 aUserAttribute2;
+	
+			out vec4 Position;
+			out vec4 QuatNormal;
+			out vec4 View;
+			out vec4 Color;
+			out vec4 TexCoord0;
+			out vec4 TexCoord1;
+			out vec4 TexCoord2;
+			out vec4 WeightPreview;
 
-            out vec4 Position;
-            out vec4 QuatNormal;
-            out vec4 View;
-            out vec4 Color;
-            out vec4 TexCoord0;
-            out vec4 TexCoord1;
-            out vec4 TexCoord2;
-            out vec4 WeightPreview;
+			void proc_full_quaternion_calc_end() {
+				QuatNormal.xyzw = reg_temp[0].xyzw;
+			}
 
-            void proc_full_quaternion_calc_end() {
-            	QuatNormal.xyzw = reg_temp[0].xyzw;
-            }
+			void proc_full_quaternion_calc_fallback() {
+				reg_cmp.x = reg_temp[5].z > reg_temp[5].y;
+				reg_cmp.y = reg_temp[5].y > reg_temp[5].x;
+				if (reg_cmp.x) {
+					if (reg_cmp.y) {
+						reg_temp[8].xyzw = reg_temp[13].yyzw * reg_temp[6].xxxy;
+						reg_temp[8].x = vec4(0, 1, 2, 3).y + -reg_temp[5].y;
+						reg_temp[9].xyzw = reg_temp[5].zzzz + -reg_temp[5].xxxx;
+						reg_temp[8].yzw = reg_temp[8].yzw + reg_temp[14].wxy;
+						reg_temp[8].x = reg_temp[9].x + reg_temp[8].x;
+					} else {
+						reg_cmp.x = reg_temp[5].z > reg_temp[5].x;
+						reg_cmp.y = reg_temp[5].z > reg_temp[5].x;
+						reg_temp[8].xyzw = reg_temp[13].yyzw * reg_temp[6].xxxy;
+						reg_temp[8].x = vec4(0, 1, 2, 3).y + -reg_temp[5].y;
+						if (reg_cmp.x) {
+							reg_temp[9].xyzw = reg_temp[5].zzzz + -reg_temp[5].xxxx;
+							reg_temp[8].yzw = reg_temp[8].yzw + reg_temp[14].wxy;
+							reg_temp[8].x = reg_temp[9].x + reg_temp[8].x;
+						} else {
+							reg_temp[8].xyzw = reg_temp[13].zwwy * reg_temp[6].xxxy;
+							reg_temp[8].z = vec4(0, 1, 2, 3).y + -reg_temp[5].z;
+							reg_temp[9].xyzw = reg_temp[5].xxxx + -reg_temp[5].yyyy;
+							reg_temp[8].xyw = reg_temp[8].xyw + reg_temp[14].xyw;
+							reg_temp[8].z = reg_temp[9].z + reg_temp[8].z;
+						}
+					}
+					reg_temp[8].w = -reg_temp[8].w;
+				} else {
+					if (reg_cmp.y) {
+						reg_temp[8].xyzw = reg_temp[13].yywz * reg_temp[6].xxxy;
+						reg_temp[8].y = vec4(0, 1, 2, 3).y + -reg_temp[5].z;
+						reg_temp[9].xyzw = reg_temp[5].yyyy + -reg_temp[5].xxxx;
+						reg_temp[8].xzw = reg_temp[8].xzw + reg_temp[14].wyx;
+						reg_temp[8].y = reg_temp[9].y + reg_temp[8].y;
+					} else {
+						reg_temp[8].xyzw = reg_temp[13].zwwy * reg_temp[6].xxxy;
+						reg_temp[8].z = vec4(0, 1, 2, 3).y + -reg_temp[5].z;
+						reg_temp[9].xyzw = reg_temp[5].xxxx + -reg_temp[5].yyyy;
+						reg_temp[8].xyw = reg_temp[8].xyw + reg_temp[14].xyw;
+						reg_temp[8].z = reg_temp[9].z + reg_temp[8].z;
+						reg_temp[8].w = -reg_temp[8].w;
+					}
+				}
+				reg_temp[6].xyzw = vec4(dot(reg_temp[8].xyzw, reg_temp[8].xyzw));
+				reg_temp[6].xyzw = inversesqrt(reg_temp[6].xxxx);
+				reg_temp[0].xyzw = reg_temp[8].xyzw * reg_temp[6].xyzw;
+				proc_full_quaternion_calc_end();
+			}
 
-            void proc_full_quaternion_calc_fallback() {
-            	reg_cmp.x = reg_temp[5].z > reg_temp[5].y;
-            	reg_cmp.y = reg_temp[5].y > reg_temp[5].x;
-            	if (reg_cmp.x) {
-            		if (reg_cmp.y) {
-            			reg_temp[8].xyzw = reg_temp[13].yyzw * reg_temp[6].xxxy;
-            			reg_temp[8].x = vec4(0, 1, 2, 3).y + -reg_temp[5].y;
-            			reg_temp[9].xyzw = reg_temp[5].zzzz + -reg_temp[5].xxxx;
-            			reg_temp[8].yzw = reg_temp[8].yzw + reg_temp[14].wxy;
-            			reg_temp[8].x = reg_temp[9].x + reg_temp[8].x;
-            		} else {
-            			reg_cmp.x = reg_temp[5].z > reg_temp[5].x;
-            			reg_cmp.y = reg_temp[5].z > reg_temp[5].x;
-            			reg_temp[8].xyzw = reg_temp[13].yyzw * reg_temp[6].xxxy;
-            			reg_temp[8].x = vec4(0, 1, 2, 3).y + -reg_temp[5].y;
-            			if (reg_cmp.x) {
-            				reg_temp[9].xyzw = reg_temp[5].zzzz + -reg_temp[5].xxxx;
-            				reg_temp[8].yzw = reg_temp[8].yzw + reg_temp[14].wxy;
-            				reg_temp[8].x = reg_temp[9].x + reg_temp[8].x;
-            			} else {
-            				reg_temp[8].xyzw = reg_temp[13].zwwy * reg_temp[6].xxxy;
-            				reg_temp[8].z = vec4(0, 1, 2, 3).y + -reg_temp[5].z;
-            				reg_temp[9].xyzw = reg_temp[5].xxxx + -reg_temp[5].yyyy;
-            				reg_temp[8].xyw = reg_temp[8].xyw + reg_temp[14].xyw;
-            				reg_temp[8].z = reg_temp[9].z + reg_temp[8].z;
-            			}
-            		}
-            		reg_temp[8].w = -reg_temp[8].w;
-            	} else {
-            		if (reg_cmp.y) {
-            			reg_temp[8].xyzw = reg_temp[13].yywz * reg_temp[6].xxxy;
-            			reg_temp[8].y = vec4(0, 1, 2, 3).y + -reg_temp[5].z;
-            			reg_temp[9].xyzw = reg_temp[5].yyyy + -reg_temp[5].xxxx;
-            			reg_temp[8].xzw = reg_temp[8].xzw + reg_temp[14].wyx;
-            			reg_temp[8].y = reg_temp[9].y + reg_temp[8].y;
-            		} else {
-            			reg_temp[8].xyzw = reg_temp[13].zwwy * reg_temp[6].xxxy;
-            			reg_temp[8].z = vec4(0, 1, 2, 3).y + -reg_temp[5].z;
-            			reg_temp[9].xyzw = reg_temp[5].xxxx + -reg_temp[5].yyyy;
-            			reg_temp[8].xyw = reg_temp[8].xyw + reg_temp[14].xyw;
-            			reg_temp[8].z = reg_temp[9].z + reg_temp[8].z;
-            			reg_temp[8].w = -reg_temp[8].w;
-            		}
-            	}
-            	reg_temp[6].xyzw = vec4(dot(reg_temp[8].xyzw, reg_temp[8].xyzw));
-            	reg_temp[6].xyzw = inversesqrt(reg_temp[6].xxxx);
-            	reg_temp[0].xyzw = reg_temp[8].xyzw * reg_temp[6].xyzw;
-            	proc_full_quaternion_calc_end();
-            }
+			void proc_calc_quaternion_from_normal_end() {
+				QuatNormal.xyzw = reg_temp[0].xyzw;
+			}
 
-            void proc_calc_quaternion_from_normal_end() {
-            	QuatNormal.xyzw = reg_temp[0].xyzw;
-            }
+			void proc_gen_texcoord_sphere_reflection() {
+				reg_temp[1].xy = vec4(0.125, 0.00390625, 0.5, 0.25).zz;
+				reg_temp[1].zw = vec4(0, 1, 2, 3).xx;
+				reg_temp[6].xyzw = reg_temp[14].xyzw * reg_temp[1].xyzw + reg_temp[1].xyzw;
+				reg_temp[6].zw = vec4(0, 1, 2, 3).yy;
+			}
 
-            void proc_gen_texcoord_sphere_reflection() {
-            	reg_temp[1].xy = vec4(0.125, 0.00390625, 0.5, 0.25).zz;
-            	reg_temp[1].zw = vec4(0, 1, 2, 3).xx;
-            	reg_temp[6].xyzw = reg_temp[14].xyzw * reg_temp[1].xyzw + reg_temp[1].xyzw;
-            	reg_temp[6].zw = vec4(0, 1, 2, 3).yy;
-            }
+			void proc_gen_texcoord_reflection() {
+				reg_temp[2].xyzw = -reg_temp[15].xyzw;
+				reg_temp[2].w = dot(reg_temp[2].xyz, reg_temp[2].xyz);
+				reg_temp[2].w = inversesqrt(reg_temp[2].w);
+				reg_temp[2].xyzw = reg_temp[2].xyzw * reg_temp[2].wwww;
+				reg_temp[1].xyzw = vec4(dot(reg_temp[2].xyz, reg_temp[14].xyz));
+				reg_temp[1].xyzw = reg_temp[1].xyzw + reg_temp[1].xyzw;
+				reg_temp[6].xyzw = reg_temp[1].xyzw * reg_temp[14].xyzw + -reg_temp[2].xyzw;
+			}
 
-            void proc_gen_texcoord_reflection() {
-            	reg_temp[2].xyzw = -reg_temp[15].xyzw;
-            	reg_temp[2].w = dot(reg_temp[2].xyz, reg_temp[2].xyz);
-            	reg_temp[2].w = inversesqrt(reg_temp[2].w);
-            	reg_temp[2].xyzw = reg_temp[2].xyzw * reg_temp[2].wwww;
-            	reg_temp[1].xyzw = vec4(dot(reg_temp[2].xyz, reg_temp[14].xyz));
-            	reg_temp[1].xyzw = reg_temp[1].xyzw + reg_temp[1].xyzw;
-            	reg_temp[6].xyzw = reg_temp[1].xyzw * reg_temp[14].xyzw + -reg_temp[2].xyzw;
-            }
+			void proc_get_texcoord_source() {
+				reg_cmp.x = vec4(0, 1, 2, 3).y == reg_temp[0].x;
+				reg_cmp.y = vec4(0, 1, 2, 3).z == reg_temp[0].y;
+				if (!reg_cmp.x && !reg_cmp.y) {
+					reg_temp[6].xy = IrScale[1].xx * aTexCoord0.xy;
+				} else {
+					if (reg_cmp.x && !reg_cmp.y) {
+						reg_temp[6].xy = IrScale[1].yy * aTexCoord1.xy;
+					} else {
+						reg_temp[6].xy = IrScale[1].zz * aTexCoord2.xy;
+					}
+				}
+				reg_temp[6].zw = vec4(0, 1, 2, 3).yy;
+			}
 
-            void proc_get_texcoord_source() {
-            	reg_cmp.x = vec4(0, 1, 2, 3).y == reg_temp[0].x;
-            	reg_cmp.y = vec4(0, 1, 2, 3).z == reg_temp[0].y;
-            	if (!reg_cmp.x && !reg_cmp.y) {
-            		reg_temp[6].xy = IrScale[1].xx * aTexCoord0.xy;
-            	} else {
-            		if (reg_cmp.x && !reg_cmp.y) {
-            			reg_temp[6].xy = IrScale[1].yy * aTexCoord1.xy;
-            		} else {
-            			reg_temp[6].xy = IrScale[1].zz * aTexCoord2.xy;
-            		}
-            	}
-            	reg_temp[6].zw = vec4(0, 1, 2, 3).yy;
-            }
+			void proc_calc_hemisphere_lighting() {
+				reg_temp[1].xyzw = vec4(dot(HslSDir.xyz, reg_temp[14].xyz));
+				reg_temp[2].xyzw = HslSDir.wwww;
+				reg_temp[1].xyzw = reg_temp[1].xyzw * reg_temp[2].xyzw + reg_temp[2].xyzw;
+				reg_temp[3].xyzw = HslGCol.xyzw;
+				reg_temp[2].xyzw = HslSCol.xyzw + -reg_temp[3].xyzw;
+				reg_temp[4].xyzw = reg_temp[2].xyzw * reg_temp[1].xyzw + reg_temp[3].xyzw;
+				if ((BoolUniforms & IsHemiO) != 0) {
+					reg_temp[4].xyzw = reg_temp[4].xyzw * reg_temp[9].wwww;
+				}
+				reg_temp[9].xyz = reg_temp[4].xyz * MatDiff.xyz + reg_temp[9].xyz;
+				reg_temp[8].x = vec4(0, 1, 2, 3).y;
+			}
 
-            void proc_calc_hemisphere_lighting() {
-            	reg_temp[1].xyzw = vec4(dot(HslSDir.xyz, reg_temp[14].xyz));
-            	reg_temp[2].xyzw = HslSDir.wwww;
-            	reg_temp[1].xyzw = reg_temp[1].xyzw * reg_temp[2].xyzw + reg_temp[2].xyzw;
-            	reg_temp[3].xyzw = HslGCol.xyzw;
-            	reg_temp[2].xyzw = HslSCol.xyzw + -reg_temp[3].xyzw;
-            	reg_temp[4].xyzw = reg_temp[2].xyzw * reg_temp[1].xyzw + reg_temp[3].xyzw;
-            	if ((BoolUniforms & IsHemiO) != 0) {
-            		reg_temp[4].xyzw = reg_temp[4].xyzw * reg_temp[9].wwww;
-            	}
-            	reg_temp[9].xyz = reg_temp[4].xyz * MatDiff.xyz + reg_temp[9].xyz;
-            	reg_temp[8].x = vec4(0, 1, 2, 3).y;
-            }
+			void proc_calc_vertex_lighting() {
+				reg_temp[1].xyzw = MatAmbi.xyzw;
+				reg_temp[2].xyzw = MatDiff.xyzw;
+				reg_temp[3].xyzw = vec4(0, 1, 2, 3).xxxx;
+				for (reg_al = LightCt.y; reg_al <= LightCt.x; reg_al += LightCt.z) {
+					reg_a0.x = int(reg_temp[3].x);
+					reg_temp[4].x = UnivReg[56 + reg_a0.x].w;
+					reg_temp[4].y = UnivReg[58 + reg_a0.x].w;
+					reg_cmp.x = vec4(0, 1, 2, 3).x == reg_temp[4].x;
+					reg_cmp.y = vec4(0, 1, 2, 3).y == reg_temp[4].y;
+					if (reg_cmp.x) {
+						reg_temp[6].x = dot(UnivReg[56 + reg_a0.x].xyz, reg_temp[14].xyz);
+						reg_temp[6].y = vec4(0, 1, 2, 3).y;
+					} else {
+						reg_temp[4].xyzw = UnivReg[56 + reg_a0.x].xyzw + -reg_temp[15].xyzw;
+						reg_temp[6].y = vec4(0, 1, 2, 3).y;
+						if (reg_cmp.y) {
+							reg_temp[5].x = vec4(0, 1, 2, 3).y;
+							reg_temp[5].z = dot(reg_temp[4].xyz, reg_temp[4].xyz);
+							reg_temp[5].y = reg_temp[5].z * reg_temp[5].z;
+							reg_temp[6].y = dot(UnivReg[58 + reg_a0.x].xyz, reg_temp[5].xyz);
+							reg_temp[6].y = 1 / reg_temp[6].y;
+						}
+						reg_temp[5].xyzw = UnivReg[57 + reg_a0.x].xyzw;
+						reg_cmp.x = vec4(0, 1, 2, 3).y == reg_temp[5].w;
+						reg_cmp.y = vec4(0, 1, 2, 3).y == reg_temp[5].w;
+						reg_temp[4].w = dot(reg_temp[4].xyz, reg_temp[4].xyz);
+						reg_temp[4].w = inversesqrt(reg_temp[4].w);
+						reg_temp[4].xyzw = reg_temp[4].xyzw * reg_temp[4].wwww;
+						if (reg_cmp.x) {
+							reg_temp[5].x = dot(UnivReg[57 + reg_a0.x].xyz, -reg_temp[4].xyz);
+							reg_temp[5].y = reg_temp[5].x < reg_temp[5].y ? 1 : 0;
+							reg_cmp.x = vec4(0, 1, 2, 3).y == reg_temp[5].x;
+							reg_cmp.y = vec4(0, 1, 2, 3).y == reg_temp[5].y;
+							if (reg_cmp.y) {
+								reg_temp[5].x = vec4(0, 1, 2, 3).x;
+							} else {
+								reg_temp[5].y = UnivReg[59 + reg_a0.x].x * reg_temp[5].y;
+							}
+							reg_temp[6].y = reg_temp[6].y * reg_temp[5].x;
+						}
+						reg_temp[6].x = dot(reg_temp[14].xyz, reg_temp[4].xyz);
+					}
+					reg_cmp.x = vec4(0, 1, 2, 3).x == reg_temp[6].x;
+					reg_cmp.y = vec4(0, 1, 2, 3).x < reg_temp[6].y;
+					if (reg_cmp.y) {
+						reg_temp[6].x = max(vec4(0, 1, 2, 3).x, reg_temp[6].x);
+						reg_temp[9].xyz = reg_temp[1].xyz * UnivReg[54 + reg_a0.x].xyz + reg_temp[9].xyz;
+						reg_temp[4].xyzw = UnivReg[55 + reg_a0.x].xyzw * reg_temp[2].xyzw;
+						reg_temp[5].xyz = reg_temp[6].xxx * reg_temp[4].xyz;
+						reg_temp[5].xyz = reg_temp[6].yyy * reg_temp[5].xyz;
+						reg_temp[9].xyz = reg_temp[9].xyz + reg_temp[5].xyz;
+						reg_temp[9].w = reg_temp[9].w + reg_temp[4].w;
+					}
+					reg_temp[3].xyzw = -vec4(3, 4, 5, 6).wwww + reg_temp[3].xyzw;
+					if (LightCt.z == 0) break;
+				}
+				reg_temp[8].x = vec4(0, 1, 2, 3).y;
+			}
 
-            void proc_calc_vertex_lighting() {
-            	reg_temp[1].xyzw = MatAmbi.xyzw;
-            	reg_temp[2].xyzw = MatDiff.xyzw;
-            	reg_temp[3].xyzw = vec4(0, 1, 2, 3).xxxx;
-            	for (reg_al = LightCt.y; reg_al <= LightCt.x; reg_al += LightCt.z) {
-            		reg_a0.x = int(reg_temp[3].x);
-            		reg_temp[4].x = UnivReg[56 + reg_a0.x].w;
-            		reg_temp[4].y = UnivReg[58 + reg_a0.x].w;
-            		reg_cmp.x = vec4(0, 1, 2, 3).x == reg_temp[4].x;
-            		reg_cmp.y = vec4(0, 1, 2, 3).y == reg_temp[4].y;
-            		if (reg_cmp.x) {
-            			reg_temp[6].x = dot(UnivReg[56 + reg_a0.x].xyz, reg_temp[14].xyz);
-            			reg_temp[6].y = vec4(0, 1, 2, 3).y;
-            		} else {
-            			reg_temp[4].xyzw = UnivReg[56 + reg_a0.x].xyzw + -reg_temp[15].xyzw;
-            			reg_temp[6].y = vec4(0, 1, 2, 3).y;
-            			if (reg_cmp.y) {
-            				reg_temp[5].x = vec4(0, 1, 2, 3).y;
-            				reg_temp[5].z = dot(reg_temp[4].xyz, reg_temp[4].xyz);
-            				reg_temp[5].y = reg_temp[5].z * reg_temp[5].z;
-            				reg_temp[6].y = dot(UnivReg[58 + reg_a0.x].xyz, reg_temp[5].xyz);
-            				reg_temp[6].y = 1 / reg_temp[6].y;
-            			}
-            			reg_temp[5].xyzw = UnivReg[57 + reg_a0.x].xyzw;
-            			reg_cmp.x = vec4(0, 1, 2, 3).y == reg_temp[5].w;
-            			reg_cmp.y = vec4(0, 1, 2, 3).y == reg_temp[5].w;
-            			reg_temp[4].w = dot(reg_temp[4].xyz, reg_temp[4].xyz);
-            			reg_temp[4].w = inversesqrt(reg_temp[4].w);
-            			reg_temp[4].xyzw = reg_temp[4].xyzw * reg_temp[4].wwww;
-            			if (reg_cmp.x) {
-            				reg_temp[5].x = dot(UnivReg[57 + reg_a0.x].xyz, -reg_temp[4].xyz);
-            				reg_temp[5].y = reg_temp[5].x < reg_temp[5].y ? 1 : 0;
-            				reg_cmp.x = vec4(0, 1, 2, 3).y == reg_temp[5].x;
-            				reg_cmp.y = vec4(0, 1, 2, 3).y == reg_temp[5].y;
-            				if (reg_cmp.y) {
-            					reg_temp[5].x = vec4(0, 1, 2, 3).x;
-            				} else {
-            					reg_temp[5].y = UnivReg[59 + reg_a0.x].x * reg_temp[5].y;
-            				}
-            				reg_temp[6].y = reg_temp[6].y * reg_temp[5].x;
-            			}
-            			reg_temp[6].x = dot(reg_temp[14].xyz, reg_temp[4].xyz);
-            		}
-            		reg_cmp.x = vec4(0, 1, 2, 3).x == reg_temp[6].x;
-            		reg_cmp.y = vec4(0, 1, 2, 3).x < reg_temp[6].y;
-            		if (reg_cmp.y) {
-            			reg_temp[6].x = max(vec4(0, 1, 2, 3).x, reg_temp[6].x);
-            			reg_temp[9].xyz = reg_temp[1].xyz * UnivReg[54 + reg_a0.x].xyz + reg_temp[9].xyz;
-            			reg_temp[4].xyzw = UnivReg[55 + reg_a0.x].xyzw * reg_temp[2].xyzw;
-            			reg_temp[5].xyz = reg_temp[6].xxx * reg_temp[4].xyz;
-            			reg_temp[5].xyz = reg_temp[6].yyy * reg_temp[5].xyz;
-            			reg_temp[9].xyz = reg_temp[9].xyz + reg_temp[5].xyz;
-            			reg_temp[9].w = reg_temp[9].w + reg_temp[4].w;
-            		}
-            		reg_temp[3].xyzw = -vec4(3, 4, 5, 6).wwww + reg_temp[3].xyzw;
-                    if (LightCt.z == 0) break;
-            	}
-            	reg_temp[8].x = vec4(0, 1, 2, 3).y;
-            }
+			void proc_blend_vertex_p() {
+				reg_a0.x = int(reg_temp[1].x);
+				reg_temp[3].x = dot(UnivReg[0 + reg_a0.x].xyzw, reg_temp[15].xyzw);
+				reg_temp[3].y = dot(UnivReg[1 + reg_a0.x].xyzw, reg_temp[15].xyzw);
+				reg_temp[3].z = dot(UnivReg[2 + reg_a0.x].xyzw, reg_temp[15].xyzw);
+				reg_temp[7].xyzw = reg_temp[1].wwww * reg_temp[3].xyzw + reg_temp[7].xyzw;
+			}
 
-            void proc_blend_vertex_p() {
-            	reg_a0.x = int(reg_temp[1].x);
-            	reg_temp[3].x = dot(UnivReg[0 + reg_a0.x].xyzw, reg_temp[15].xyzw);
-            	reg_temp[3].y = dot(UnivReg[1 + reg_a0.x].xyzw, reg_temp[15].xyzw);
-            	reg_temp[3].z = dot(UnivReg[2 + reg_a0.x].xyzw, reg_temp[15].xyzw);
-            	reg_temp[7].xyzw = reg_temp[1].wwww * reg_temp[3].xyzw + reg_temp[7].xyzw;
-            }
+			void proc_calc_quaternion_from_tangent() {
+				reg_temp[6].x = dot(reg_temp[14].xyz, reg_temp[14].xyz);
+				reg_temp[7].x = dot(reg_temp[12].xyz, reg_temp[12].xyz);
+				reg_temp[6].x = inversesqrt(reg_temp[6].x);
+				reg_temp[7].x = inversesqrt(reg_temp[7].x);
+				reg_temp[14].xyz = reg_temp[14].xyz * reg_temp[6].xxx;
+				reg_temp[12].xyz = reg_temp[12].xyz * reg_temp[7].xxx;
+				reg_temp[13].xyz = reg_temp[13].xyz * reg_temp[6].xxx;
+				reg_temp[11].xyz = reg_temp[11].xyz * reg_temp[7].xxx;
+				reg_temp[0].xyzw = vec4(0, 1, 2, 3).yxxx;
+				reg_temp[13].xyz = reg_temp[13].xyz * reg_temp[6].xxx;
+				reg_temp[11].xyz = reg_temp[11].xyz * reg_temp[7].xxx;
+				reg_temp[5].xyzw = reg_temp[14].yzxx * reg_temp[13].zxyy;
+				reg_temp[5].xyzw = -reg_temp[13].yzxx * reg_temp[14].zxyy + reg_temp[5].xyzw;
+				reg_temp[5].w = dot(reg_temp[5].xyz, reg_temp[5].xyz);
+				reg_temp[5].w = inversesqrt(reg_temp[5].w);
+				reg_temp[5].xyzw = reg_temp[5].xyzw * reg_temp[5].wwww;
+				reg_temp[6].w = reg_temp[14].z + reg_temp[5].y;
+				reg_temp[13].xyzw = reg_temp[5].yzxx * reg_temp[14].zxyy;
+				reg_temp[13].xyzw = -reg_temp[14].yzxx * reg_temp[5].zxyy + reg_temp[13].xyzw;
+				reg_temp[6].w = reg_temp[13].x + reg_temp[6].w;
+				reg_temp[13].w = reg_temp[5].z;
+				reg_temp[5].z = reg_temp[13].x;
+				reg_temp[6].w = vec4(0, 1, 2, 3).y + reg_temp[6].w;
+				reg_temp[14].w = reg_temp[5].x;
+				reg_temp[5].x = reg_temp[14].z;
+				reg_cmp.x = vec4(0.125, 0.00390625, 0.5, 0.25).y < reg_temp[6].w;
+				reg_cmp.y = vec4(0.125, 0.00390625, 0.5, 0.25).y < reg_temp[6].w;
+				reg_temp[6].x = vec4(0, 1, 2, 3).y;
+				reg_temp[6].y = -vec4(0, 1, 2, 3).y;
+				if (!reg_cmp.x) { //Jump
+					proc_full_quaternion_calc_fallback();
+					return;
+				}
+				reg_temp[7].xz = reg_temp[13].wy + -reg_temp[14].yw;
+				reg_temp[7].y = reg_temp[14].x + -reg_temp[13].z;
+				reg_temp[7].w = reg_temp[6].w;
+				reg_temp[6].xyzw = vec4(dot(reg_temp[7].xyzw, reg_temp[7].xyzw));
+				reg_temp[6].xyzw = inversesqrt(reg_temp[6].xxxx);
+				reg_temp[0].xyzw = reg_temp[7].xyzw * reg_temp[6].xyzw;
+				if (true) { //Jump
+					proc_full_quaternion_calc_end();
+					return;
+				}
+				proc_full_quaternion_calc_fallback();
+			}
 
-            void proc_calc_quaternion_from_tangent() {
-            	reg_temp[6].x = dot(reg_temp[14].xyz, reg_temp[14].xyz);
-            	reg_temp[7].x = dot(reg_temp[12].xyz, reg_temp[12].xyz);
-            	reg_temp[6].x = inversesqrt(reg_temp[6].x);
-            	reg_temp[7].x = inversesqrt(reg_temp[7].x);
-            	reg_temp[14].xyz = reg_temp[14].xyz * reg_temp[6].xxx;
-            	reg_temp[12].xyz = reg_temp[12].xyz * reg_temp[7].xxx;
-            	reg_temp[13].xyz = reg_temp[13].xyz * reg_temp[6].xxx;
-            	reg_temp[11].xyz = reg_temp[11].xyz * reg_temp[7].xxx;
-            	reg_temp[0].xyzw = vec4(0, 1, 2, 3).yxxx;
-            	reg_temp[13].xyz = reg_temp[13].xyz * reg_temp[6].xxx;
-            	reg_temp[11].xyz = reg_temp[11].xyz * reg_temp[7].xxx;
-            	reg_temp[5].xyzw = reg_temp[14].yzxx * reg_temp[13].zxyy;
-            	reg_temp[5].xyzw = -reg_temp[13].yzxx * reg_temp[14].zxyy + reg_temp[5].xyzw;
-            	reg_temp[5].w = dot(reg_temp[5].xyz, reg_temp[5].xyz);
-            	reg_temp[5].w = inversesqrt(reg_temp[5].w);
-            	reg_temp[5].xyzw = reg_temp[5].xyzw * reg_temp[5].wwww;
-            	reg_temp[6].w = reg_temp[14].z + reg_temp[5].y;
-            	reg_temp[13].xyzw = reg_temp[5].yzxx * reg_temp[14].zxyy;
-            	reg_temp[13].xyzw = -reg_temp[14].yzxx * reg_temp[5].zxyy + reg_temp[13].xyzw;
-            	reg_temp[6].w = reg_temp[13].x + reg_temp[6].w;
-            	reg_temp[13].w = reg_temp[5].z;
-            	reg_temp[5].z = reg_temp[13].x;
-            	reg_temp[6].w = vec4(0, 1, 2, 3).y + reg_temp[6].w;
-            	reg_temp[14].w = reg_temp[5].x;
-            	reg_temp[5].x = reg_temp[14].z;
-            	reg_cmp.x = vec4(0.125, 0.00390625, 0.5, 0.25).y < reg_temp[6].w;
-            	reg_cmp.y = vec4(0.125, 0.00390625, 0.5, 0.25).y < reg_temp[6].w;
-            	reg_temp[6].x = vec4(0, 1, 2, 3).y;
-            	reg_temp[6].y = -vec4(0, 1, 2, 3).y;
-            	if (!reg_cmp.x) { //Jump
-            		proc_full_quaternion_calc_fallback();
-            		return;
-            	}
-            	reg_temp[7].xz = reg_temp[13].wy + -reg_temp[14].yw;
-            	reg_temp[7].y = reg_temp[14].x + -reg_temp[13].z;
-            	reg_temp[7].w = reg_temp[6].w;
-            	reg_temp[6].xyzw = vec4(dot(reg_temp[7].xyzw, reg_temp[7].xyzw));
-            	reg_temp[6].xyzw = inversesqrt(reg_temp[6].xxxx);
-            	reg_temp[0].xyzw = reg_temp[7].xyzw * reg_temp[6].xyzw;
-            	if (true) { //Jump
-            		proc_full_quaternion_calc_end();
-            		return;
-            	}
-            	proc_full_quaternion_calc_fallback();
-            }
+			void proc_blend_vertex_pnt() {
+				reg_a0.x = int(reg_temp[1].x);
+				reg_temp[3].x = dot(UnivReg[0 + reg_a0.x].xyzw, reg_temp[15].xyzw);
+				reg_temp[3].y = dot(UnivReg[1 + reg_a0.x].xyzw, reg_temp[15].xyzw);
+				reg_temp[3].z = dot(UnivReg[2 + reg_a0.x].xyzw, reg_temp[15].xyzw);
+				reg_temp[4].x = dot(UnivReg[0 + reg_a0.x].xyz, reg_temp[14].xyz);
+				reg_temp[4].y = dot(UnivReg[1 + reg_a0.x].xyz, reg_temp[14].xyz);
+				reg_temp[4].z = dot(UnivReg[2 + reg_a0.x].xyz, reg_temp[14].xyz);
+				reg_temp[5].x = dot(UnivReg[0 + reg_a0.x].xyz, reg_temp[13].xyz);
+				reg_temp[5].y = dot(UnivReg[1 + reg_a0.x].xyz, reg_temp[13].xyz);
+				reg_temp[5].z = dot(UnivReg[2 + reg_a0.x].xyz, reg_temp[13].xyz);
+				reg_temp[7].xyzw = reg_temp[1].wwww * reg_temp[3].xyzw + reg_temp[7].xyzw;
+				reg_temp[12].xyzw = reg_temp[1].wwww * reg_temp[4].xyzw + reg_temp[12].xyzw;
+				reg_temp[11].xyzw = reg_temp[1].wwww * reg_temp[5].xyzw + reg_temp[11].xyzw;
+			}
 
-            void proc_blend_vertex_pnt() {
-            	reg_a0.x = int(reg_temp[1].x);
-            	reg_temp[3].x = dot(UnivReg[0 + reg_a0.x].xyzw, reg_temp[15].xyzw);
-            	reg_temp[3].y = dot(UnivReg[1 + reg_a0.x].xyzw, reg_temp[15].xyzw);
-            	reg_temp[3].z = dot(UnivReg[2 + reg_a0.x].xyzw, reg_temp[15].xyzw);
-            	reg_temp[4].x = dot(UnivReg[0 + reg_a0.x].xyz, reg_temp[14].xyz);
-            	reg_temp[4].y = dot(UnivReg[1 + reg_a0.x].xyz, reg_temp[14].xyz);
-            	reg_temp[4].z = dot(UnivReg[2 + reg_a0.x].xyz, reg_temp[14].xyz);
-            	reg_temp[5].x = dot(UnivReg[0 + reg_a0.x].xyz, reg_temp[13].xyz);
-            	reg_temp[5].y = dot(UnivReg[1 + reg_a0.x].xyz, reg_temp[13].xyz);
-            	reg_temp[5].z = dot(UnivReg[2 + reg_a0.x].xyz, reg_temp[13].xyz);
-            	reg_temp[7].xyzw = reg_temp[1].wwww * reg_temp[3].xyzw + reg_temp[7].xyzw;
-            	reg_temp[12].xyzw = reg_temp[1].wwww * reg_temp[4].xyzw + reg_temp[12].xyzw;
-            	reg_temp[11].xyzw = reg_temp[1].wwww * reg_temp[5].xyzw + reg_temp[11].xyzw;
-            }
+			void proc_calc_quaternion_from_normal() {
+				reg_temp[6].x = dot(reg_temp[14].xyz, reg_temp[14].xyz);
+				reg_temp[7].x = dot(reg_temp[12].xyz, reg_temp[12].xyz);
+				reg_temp[6].x = inversesqrt(reg_temp[6].x);
+				reg_temp[7].x = inversesqrt(reg_temp[7].x);
+				reg_temp[14].xyz = reg_temp[14].xyz * reg_temp[6].xxx;
+				reg_temp[12].xyz = reg_temp[12].xyz * reg_temp[7].xxx;
+				reg_temp[0].xyzw = vec4(0, 1, 2, 3).yxxx;
+				reg_temp[4].xyzw = vec4(0, 1, 2, 3).yyyy + reg_temp[14].zzzz;
+				reg_temp[4].xyzw = vec4(0.125, 0.00390625, 0.5, 0.25).zzzz * reg_temp[4].xyzw;
+				reg_cmp.x = vec4(0, 1, 2, 3).x >= reg_temp[4].x;
+				reg_cmp.y = vec4(0, 1, 2, 3).x >= reg_temp[4].x;
+				reg_temp[4].xyzw = inversesqrt(reg_temp[4].xxxx);
+				reg_temp[5].xyzw = vec4(0.125, 0.00390625, 0.5, 0.25).zzzz * reg_temp[14].xyzw;
+				if (reg_cmp.x) { //Jump
+					proc_calc_quaternion_from_normal_end();
+					return;
+				}
+				reg_temp[0].z = 1 / reg_temp[4].x;
+				reg_temp[0].xy = reg_temp[5].xy * reg_temp[4].xy;
+				proc_calc_quaternion_from_normal_end();
+			}
 
-            void proc_calc_quaternion_from_normal() {
-            	reg_temp[6].x = dot(reg_temp[14].xyz, reg_temp[14].xyz);
-            	reg_temp[7].x = dot(reg_temp[12].xyz, reg_temp[12].xyz);
-            	reg_temp[6].x = inversesqrt(reg_temp[6].x);
-            	reg_temp[7].x = inversesqrt(reg_temp[7].x);
-            	reg_temp[14].xyz = reg_temp[14].xyz * reg_temp[6].xxx;
-            	reg_temp[12].xyz = reg_temp[12].xyz * reg_temp[7].xxx;
-            	reg_temp[0].xyzw = vec4(0, 1, 2, 3).yxxx;
-            	reg_temp[4].xyzw = vec4(0, 1, 2, 3).yyyy + reg_temp[14].zzzz;
-            	reg_temp[4].xyzw = vec4(0.125, 0.00390625, 0.5, 0.25).zzzz * reg_temp[4].xyzw;
-            	reg_cmp.x = vec4(0, 1, 2, 3).x >= reg_temp[4].x;
-            	reg_cmp.y = vec4(0, 1, 2, 3).x >= reg_temp[4].x;
-            	reg_temp[4].xyzw = inversesqrt(reg_temp[4].xxxx);
-            	reg_temp[5].xyzw = vec4(0.125, 0.00390625, 0.5, 0.25).zzzz * reg_temp[14].xyzw;
-            	if (reg_cmp.x) { //Jump
-            		proc_calc_quaternion_from_normal_end();
-            		return;
-            	}
-            	reg_temp[0].z = 1 / reg_temp[4].x;
-            	reg_temp[0].xy = reg_temp[5].xy * reg_temp[4].xy;
-            	proc_calc_quaternion_from_normal_end();
-            }
+			void proc_blend_vertex_pn() {
+				reg_a0.x = int(reg_temp[1].x);
+				reg_temp[3].x = dot(UnivReg[0 + reg_a0.x].xyzw, reg_temp[15].xyzw);
+				reg_temp[3].y = dot(UnivReg[1 + reg_a0.x].xyzw, reg_temp[15].xyzw);
+				reg_temp[3].z = dot(UnivReg[2 + reg_a0.x].xyzw, reg_temp[15].xyzw);
+				reg_temp[4].x = dot(UnivReg[0 + reg_a0.x].xyz, reg_temp[14].xyz);
+				reg_temp[4].y = dot(UnivReg[1 + reg_a0.x].xyz, reg_temp[14].xyz);
+				reg_temp[4].z = dot(UnivReg[2 + reg_a0.x].xyz, reg_temp[14].xyz);
+				reg_temp[7].xyzw = reg_temp[1].wwww * reg_temp[3].xyzw + reg_temp[7].xyzw;
+				reg_temp[12].xyzw = reg_temp[1].wwww * reg_temp[4].xyzw + reg_temp[12].xyzw;
+			}
 
-            void proc_blend_vertex_pn() {
-            	reg_a0.x = int(reg_temp[1].x);
-            	reg_temp[3].x = dot(UnivReg[0 + reg_a0.x].xyzw, reg_temp[15].xyzw);
-            	reg_temp[3].y = dot(UnivReg[1 + reg_a0.x].xyzw, reg_temp[15].xyzw);
-            	reg_temp[3].z = dot(UnivReg[2 + reg_a0.x].xyzw, reg_temp[15].xyzw);
-            	reg_temp[4].x = dot(UnivReg[0 + reg_a0.x].xyz, reg_temp[14].xyz);
-            	reg_temp[4].y = dot(UnivReg[1 + reg_a0.x].xyz, reg_temp[14].xyz);
-            	reg_temp[4].z = dot(UnivReg[2 + reg_a0.x].xyz, reg_temp[14].xyz);
-            	reg_temp[7].xyzw = reg_temp[1].wwww * reg_temp[3].xyzw + reg_temp[7].xyzw;
-            	reg_temp[12].xyzw = reg_temp[1].wwww * reg_temp[4].xyzw + reg_temp[12].xyzw;
-            }
+			void proc_calc_texcoord2() {
+				reg_temp[0].xy = TexcMap.zz;
+				if ((BoolUniforms & UvMap2) != 0) {
+					proc_get_texcoord_source();
+					reg_temp[5].x = dot(TexMtx2[0].xywz, reg_temp[6].xyzw);
+					reg_temp[5].y = dot(TexMtx2[1].xywz, reg_temp[6].xyzw);
+					TexCoord2.xyzw = reg_temp[5].xyzw;
+				} else {
+					reg_temp[6].zw = vec4(0, 1, 2, 3).yy;
+					reg_temp[5].zw = reg_temp[6].ww;
+					proc_gen_texcoord_sphere_reflection();
+					reg_temp[5].x = dot(TexMtx2[0].xyzw, reg_temp[6].xyzw);
+					reg_temp[5].y = dot(TexMtx2[1].xyzw, reg_temp[6].xyzw);
+					TexCoord2.xyzw = reg_temp[5].xyzw;
+				}
+			}
 
-            void proc_calc_texcoord2() {
-            	reg_temp[0].xy = TexcMap.zz;
-            	if ((BoolUniforms & UvMap2) != 0) {
-            		proc_get_texcoord_source();
-            		reg_temp[5].x = dot(TexMtx2[0].xywz, reg_temp[6].xyzw);
-            		reg_temp[5].y = dot(TexMtx2[1].xywz, reg_temp[6].xyzw);
-            		TexCoord2.xyzw = reg_temp[5].xyzw;
-            	} else {
-            		reg_temp[6].zw = vec4(0, 1, 2, 3).yy;
-            		reg_temp[5].zw = reg_temp[6].ww;
-            		proc_gen_texcoord_sphere_reflection();
-            		reg_temp[5].x = dot(TexMtx2[0].xyzw, reg_temp[6].xyzw);
-            		reg_temp[5].y = dot(TexMtx2[1].xyzw, reg_temp[6].xyzw);
-            		TexCoord2.xyzw = reg_temp[5].xyzw;
-            	}
-            }
+			void proc_calc_texcoord1() {
+				reg_temp[0].xy = TexcMap.yy;
+				if ((BoolUniforms & UvMap1) != 0) {
+					proc_get_texcoord_source();
+					reg_temp[4].x = dot(TexMtx1[0].xywz, reg_temp[6].xyzw);
+					reg_temp[4].y = dot(TexMtx1[1].xywz, reg_temp[6].xyzw);
+					TexCoord1.xyzw = reg_temp[4].xyzw;
+				} else {
+					reg_cmp.x = vec4(3, 4, 5, 6).x == reg_temp[0].x;
+					reg_cmp.y = vec4(3, 4, 5, 6).y == reg_temp[0].y;
+					reg_temp[6].zw = vec4(0, 1, 2, 3).yy;
+					if (!reg_cmp.x && !reg_cmp.y) {
+						reg_temp[6].xyzw = reg_temp[10].xyzw;
+						reg_temp[4].x = dot(TexMtx1[0].xyzw, reg_temp[6].xyzw);
+						reg_temp[4].y = dot(TexMtx1[1].xyzw, reg_temp[6].xyzw);
+						reg_temp[4].z = dot(TexMtx1[2].xyzw, reg_temp[6].xyzw);
+						reg_temp[4].xy = TexTran.xy + reg_temp[4].xy;
+					} else {
+						proc_gen_texcoord_sphere_reflection();
+						reg_temp[4].x = dot(TexMtx1[0].xyzw, reg_temp[6].xyzw);
+						reg_temp[4].y = dot(TexMtx1[1].xyzw, reg_temp[6].xyzw);
+					}
+					TexCoord1.xyzw = reg_temp[4].xyzw;
+				}
+			}
 
-            void proc_calc_texcoord1() {
-            	reg_temp[0].xy = TexcMap.yy;
-            	if ((BoolUniforms & UvMap1) != 0) {
-            		proc_get_texcoord_source();
-            		reg_temp[4].x = dot(TexMtx1[0].xywz, reg_temp[6].xyzw);
-            		reg_temp[4].y = dot(TexMtx1[1].xywz, reg_temp[6].xyzw);
-            		TexCoord1.xyzw = reg_temp[4].xyzw;
-            	} else {
-            		reg_cmp.x = vec4(3, 4, 5, 6).x == reg_temp[0].x;
-            		reg_cmp.y = vec4(3, 4, 5, 6).y == reg_temp[0].y;
-            		reg_temp[6].zw = vec4(0, 1, 2, 3).yy;
-            		if (!reg_cmp.x && !reg_cmp.y) {
-            			reg_temp[6].xyzw = reg_temp[10].xyzw;
-            			reg_temp[4].x = dot(TexMtx1[0].xyzw, reg_temp[6].xyzw);
-            			reg_temp[4].y = dot(TexMtx1[1].xyzw, reg_temp[6].xyzw);
-            			reg_temp[4].z = dot(TexMtx1[2].xyzw, reg_temp[6].xyzw);
-            			reg_temp[4].xy = TexTran.xy + reg_temp[4].xy;
-            		} else {
-            			proc_gen_texcoord_sphere_reflection();
-            			reg_temp[4].x = dot(TexMtx1[0].xyzw, reg_temp[6].xyzw);
-            			reg_temp[4].y = dot(TexMtx1[1].xyzw, reg_temp[6].xyzw);
-            		}
-            		TexCoord1.xyzw = reg_temp[4].xyzw;
-            	}
-            }
+			void proc_calc_texcoord0() {
+				reg_temp[0].xy = TexcMap.xx;
+				if ((BoolUniforms & UvMap0) != 0) {
+					proc_get_texcoord_source();
+					reg_temp[3].x = dot(TexMtx0[0].xywz, reg_temp[6].xyzw);
+					reg_temp[3].y = dot(TexMtx0[1].xywz, reg_temp[6].xyzw);
+					reg_temp[3].zw = vec4(0, 1, 2, 3).xx;
+					TexCoord0.xyzw = reg_temp[3].xyzw;
+				}
+				else
+				{
+					reg_cmp.x = vec4(3, 4, 5, 6).x == reg_temp[0].x;
+					reg_cmp.y = vec4(3, 4, 5, 6).y == reg_temp[0].y;
+					reg_temp[6].zw = vec4(0, 1, 2, 3).yy;
+					if (!reg_cmp.x && !reg_cmp.y)
+					{
+						reg_temp[6].xyzw = reg_temp[10].xyzw;
+						reg_temp[3].x = dot(TexMtx0[0].xyzw, reg_temp[6].xyzw);
+						reg_temp[3].y = dot(TexMtx0[1].xyzw, reg_temp[6].xyzw);
+						reg_temp[3].z = dot(TexMtx0[2].xyzw, reg_temp[6].xyzw);
+						reg_temp[0].xy = TexTran.xy * reg_temp[3].zz;
+						reg_temp[3].xy = reg_temp[3].xy + reg_temp[0].xy;
+					}
+					else 
+					{
+						if (reg_cmp.x && !reg_cmp.y) 
+						{
+							proc_gen_texcoord_reflection();
+							reg_temp[3].x = dot(TexMtx0[0].xyz, reg_temp[6].xyz);
+							reg_temp[3].y = dot(TexMtx0[1].xyz, reg_temp[6].xyz);
+							reg_temp[3].z = dot(TexMtx0[2].xyz, reg_temp[6].xyz);
+						}
+						else 
+						{
+							proc_gen_texcoord_sphere_reflection();
+							reg_temp[3].x = dot(TexMtx0[0].xyzw, reg_temp[6].xyzw);
+							reg_temp[3].y = dot(TexMtx0[1].xyzw, reg_temp[6].xyzw);
+						}
+					}
+					TexCoord0.xyzw = reg_temp[3].xyzw;
+				}
+			}
 
-            void proc_calc_texcoord0() {
-            	reg_temp[0].xy = TexcMap.xx;
-            	if ((BoolUniforms & UvMap0) != 0) {
-            		proc_get_texcoord_source();
-            		reg_temp[3].x = dot(TexMtx0[0].xywz, reg_temp[6].xyzw);
-            		reg_temp[3].y = dot(TexMtx0[1].xywz, reg_temp[6].xyzw);
-            		reg_temp[3].zw = vec4(0, 1, 2, 3).xx;
-            		TexCoord0.xyzw = reg_temp[3].xyzw;
-            	}
-            	else
-            	{
-            		reg_cmp.x = vec4(3, 4, 5, 6).x == reg_temp[0].x;
-            		reg_cmp.y = vec4(3, 4, 5, 6).y == reg_temp[0].y;
-            		reg_temp[6].zw = vec4(0, 1, 2, 3).yy;
-            		if (!reg_cmp.x && !reg_cmp.y)
-            		{
-            			reg_temp[6].xyzw = reg_temp[10].xyzw;
-            			reg_temp[3].x = dot(TexMtx0[0].xyzw, reg_temp[6].xyzw);
-            			reg_temp[3].y = dot(TexMtx0[1].xyzw, reg_temp[6].xyzw);
-            			reg_temp[3].z = dot(TexMtx0[2].xyzw, reg_temp[6].xyzw);
-            			reg_temp[0].xy = TexTran.xy * reg_temp[3].zz;
-            			reg_temp[3].xy = reg_temp[3].xy + reg_temp[0].xy;
-            		}
-            		else 
-            		{
-            			if (reg_cmp.x && !reg_cmp.y) 
-            			{
-            				proc_gen_texcoord_reflection();
-            				reg_temp[3].x = dot(TexMtx0[0].xyz, reg_temp[6].xyz);
-            				reg_temp[3].y = dot(TexMtx0[1].xyz, reg_temp[6].xyz);
-            				reg_temp[3].z = dot(TexMtx0[2].xyz, reg_temp[6].xyz);
-            			}
-            			else 
-            			{
-            				proc_gen_texcoord_sphere_reflection();
-            				reg_temp[3].x = dot(TexMtx0[0].xyzw, reg_temp[6].xyzw);
-            				reg_temp[3].y = dot(TexMtx0[1].xyzw, reg_temp[6].xyzw);
-            			}
-            		}
-            		TexCoord0.xyzw = reg_temp[3].xyzw;
-            	}
-            }
-
-            void proc_calc_color() {
-            	reg_temp[8].xy = vec4(0, 1, 2, 3).xx;
-            	reg_temp[0].y = IrScale[0].w;
-            	reg_cmp.x = vec4(0, 1, 2, 3).x != reg_temp[0].x;
-            	reg_cmp.y = vec4(0, 1, 2, 3).x != reg_temp[0].y;
-            	reg_temp[9].xyz = vec4(0, 1, 2, 3).xxx;
-            	reg_temp[9].w = MatDiff.w;
-            	if (reg_cmp.y) {
-            		reg_temp[0].xyzw = IrScale[0].wwww * aColor.xyzw;
-            		if ((BoolUniforms & IsVertA) != 0) {
-            			reg_temp[9].w = reg_temp[9].w * reg_temp[0].w;
-            		}
-            		reg_temp[9].xyz = MatAmbi.www * reg_temp[0].xyz;
-            		reg_temp[8].x = vec4(0, 1, 2, 3).y;
-            	}
-            	if ((BoolUniforms & IsVertL) != 0) proc_calc_vertex_lighting();
-            	if ((BoolUniforms & IsHemiL) != 0) proc_calc_hemisphere_lighting();
-            	reg_cmp.x = vec4(0, 1, 2, 3).x == reg_temp[8].x;
-            	reg_cmp.y = vec4(0, 1, 2, 3).x == reg_temp[8].y;
-            	if (reg_cmp.x && reg_cmp.y) {
-            		reg_temp[9].xyzw = MatDiff.xyzw;
-            	}
-                vec4 tmp = max(vec4(0), reg_temp[9]);
-                // Undefined for objects that use Vertex Colors in stages but have no Color attribute assigned
-            """
+			void proc_calc_color() {
+				reg_temp[8].xy = vec4(0, 1, 2, 3).xx;
+				reg_temp[0].y = IrScale[0].w;
+				reg_cmp.x = vec4(0, 1, 2, 3).x != reg_temp[0].x;
+				reg_cmp.y = vec4(0, 1, 2, 3).x != reg_temp[0].y;
+				reg_temp[9].xyz = vec4(0, 1, 2, 3).xxx;
+				reg_temp[9].w = MatDiff.w;
+				if (reg_cmp.y) {
+					reg_temp[0].xyzw = IrScale[0].wwww * aColor.xyzw;
+					if ((BoolUniforms & IsVertA) != 0) {
+						reg_temp[9].w = reg_temp[9].w * reg_temp[0].w;
+					}
+					reg_temp[9].xyz = MatAmbi.www * reg_temp[0].xyz;
+					reg_temp[8].x = vec4(0, 1, 2, 3).y;
+				}
+				if ((BoolUniforms & IsVertL) != 0) proc_calc_vertex_lighting();
+				if ((BoolUniforms & IsHemiL) != 0) proc_calc_hemisphere_lighting();
+				reg_cmp.x = vec4(0, 1, 2, 3).x == reg_temp[8].x;
+				reg_cmp.y = vec4(0, 1, 2, 3).x == reg_temp[8].y;
+				if (reg_cmp.x && reg_cmp.y) {
+					reg_temp[9].xyzw = MatDiff.xyzw;
+				}
+				vec4 tmp = max(vec4(0), reg_temp[9]);
+				// Undefined for objects that use Vertex Colors in stages but have no Color attribute assigned
+			"""
 + 
 (	FakeVtxCol ?
-            """
-               
-            	Color.xyzw = vec4(1);
-            """
+			"""
+			   
+				Color.xyzw = vec4(1);
+			"""
 :
-            """
-               
-            	Color.xyzw = tmp;
-            """)
+			"""
+			   
+				Color.xyzw = tmp;
+			""")
 + 
-            """
+			"""
 
-            	if (DisableVertexColor == 1)
-            		Color.xyzw = vec4(1);
-            }
+				if (DisableVertexColor == 1)
+					Color.xyzw = vec4(1);
+			}
 
-            void proc_transform_matrix() {
-            	reg_temp[15].xyz = IrScale[0].xxx * aPosition.xyz;
-            	reg_temp[14].xyz = IrScale[0].yyy * aNormal.xyz;
-            	reg_temp[13].xyz = IrScale[0].zzz * aTangent.xyz;
-            	reg_temp[15].xyz = PosOffs.xyz + reg_temp[15].xyz;
-            	reg_temp[15].w = vec4(0, 1, 2, 3).y;
-            	if ((BoolUniforms & IsSmoSk) != 0) {
-            		reg_temp[0].xyzw = IrScale[0].xyzw;
-            		reg_cmp.x = vec4(0, 1, 2, 3).x != reg_temp[0].y;
-            		reg_cmp.y = vec4(0, 1, 2, 3).x != reg_temp[0].z;
-            		reg_temp[7].xyzw = vec4(0, 1, 2, 3).xxxx;
-            		reg_temp[12].xyzw = vec4(0, 1, 2, 3).xxxx;
-            		reg_temp[11].xyzw = vec4(0, 1, 2, 3).xxxx;
-            		reg_temp[2].xyzw = vec4(0, 1, 2, 3).wwww * min(aBoneIndex.xyzw, vec4(19));
-            		if (reg_cmp.x && !reg_cmp.y) {
-            			reg_cmp.x = vec4(0, 1, 2, 3).x != aBoneWeight.z;
-            			reg_cmp.y = vec4(0, 1, 2, 3).x != aBoneWeight.w;
-            			reg_temp[1].xy = reg_temp[2].xx;
-            			reg_temp[1].w = IrScale[1].w * aBoneWeight.x;
-            			proc_blend_vertex_pn();
-            			reg_temp[1].xy = reg_temp[2].yy;
-            			reg_temp[1].w = IrScale[1].w * aBoneWeight.y;
-            			proc_blend_vertex_pn();
-            			reg_temp[1].xy = reg_temp[2].zz;
-            			reg_temp[1].w = IrScale[1].w * aBoneWeight.z;
-            			if (reg_cmp.x) proc_blend_vertex_pn();
-            			if ((BoolUniforms & IsBoneW) != 0) {
-            				reg_temp[1].xy = reg_temp[2].ww;
-            				reg_temp[1].w = IrScale[1].w * aBoneWeight.w;
-            				if (reg_cmp.y) proc_blend_vertex_pn();
-            			}
-            			reg_temp[7].w = vec4(0, 1, 2, 3).y;
-            			reg_temp[10].x = dot(WrldMtx[0].xyzw, reg_temp[7].xyzw);
-            			reg_temp[10].y = dot(WrldMtx[1].xyzw, reg_temp[7].xyzw);
-            			reg_temp[10].z = dot(WrldMtx[2].xyzw, reg_temp[7].xyzw);
-            			reg_temp[10].w = vec4(0, 1, 2, 3).y;
-            			reg_temp[15].x = dot(ViewMtx[0].xyzw, reg_temp[10].xyzw);
-            			reg_temp[15].y = dot(ViewMtx[1].xyzw, reg_temp[10].xyzw);
-            			reg_temp[15].z = dot(ViewMtx[2].xyzw, reg_temp[10].xyzw);
-            			reg_temp[15].w = vec4(0, 1, 2, 3).y;
-            			reg_temp[14].x = dot(NormMtx[0].xyz, reg_temp[12].xyz);
-            			reg_temp[14].y = dot(NormMtx[1].xyz, reg_temp[12].xyz);
-            			reg_temp[14].z = dot(NormMtx[2].xyz, reg_temp[12].xyz);
-            			proc_calc_quaternion_from_normal();
-            		} else {
-            			if (reg_cmp.x && reg_cmp.y) {
-            				reg_cmp.x = vec4(0, 1, 2, 3).x != aBoneWeight.z;
-            				reg_cmp.y = vec4(0, 1, 2, 3).x != aBoneWeight.w;
-            				reg_temp[1].xy = reg_temp[2].xx;
-            				reg_temp[1].w = IrScale[1].w * aBoneWeight.x;
-            				proc_blend_vertex_pnt();
-            				reg_temp[1].xy = reg_temp[2].yy;
-            				reg_temp[1].w = IrScale[1].w * aBoneWeight.y;
-            				proc_blend_vertex_pnt();
-            				reg_temp[1].xy = reg_temp[2].zz;
-            				reg_temp[1].w = IrScale[1].w * aBoneWeight.z;
-            				if (reg_cmp.x) proc_blend_vertex_pnt();
-            				if ((BoolUniforms & IsBoneW) != 0) {
-            					reg_temp[1].xy = reg_temp[2].ww;
-            					reg_temp[1].w = IrScale[1].w * aBoneWeight.w;
-            					if (reg_cmp.y) proc_blend_vertex_pnt();
-            				}
-            				reg_temp[7].w = vec4(0, 1, 2, 3).y;
-            				reg_temp[10].x = dot(WrldMtx[0].xyzw, reg_temp[7].xyzw);
-            				reg_temp[10].y = dot(WrldMtx[1].xyzw, reg_temp[7].xyzw);
-            				reg_temp[10].z = dot(WrldMtx[2].xyzw, reg_temp[7].xyzw);
-            				reg_temp[10].w = vec4(0, 1, 2, 3).y;
-            				reg_temp[13].x = dot(NormMtx[0].xyz, reg_temp[11].xyz);
-            				reg_temp[13].y = dot(NormMtx[1].xyz, reg_temp[11].xyz);
-            				reg_temp[13].z = dot(NormMtx[2].xyz, reg_temp[11].xyz);
-            				reg_temp[14].x = dot(NormMtx[0].xyz, reg_temp[12].xyz);
-            				reg_temp[14].y = dot(NormMtx[1].xyz, reg_temp[12].xyz);
-            				reg_temp[14].z = dot(NormMtx[2].xyz, reg_temp[12].xyz);
-            				reg_temp[15].x = dot(ViewMtx[0].xyzw, reg_temp[10].xyzw);
-            				reg_temp[15].y = dot(ViewMtx[1].xyzw, reg_temp[10].xyzw);
-            				reg_temp[15].z = dot(ViewMtx[2].xyzw, reg_temp[10].xyzw);
-            				reg_temp[15].w = vec4(0, 1, 2, 3).y;
-            				proc_calc_quaternion_from_tangent();
-            			} else {
-            				reg_cmp.x = vec4(0, 1, 2, 3).x != aBoneWeight.z;
-            				reg_cmp.y = vec4(0, 1, 2, 3).x != aBoneWeight.w;
-            				reg_temp[1].xy = reg_temp[2].xx;
-            				reg_temp[1].w = IrScale[1].w * aBoneWeight.x;
-            				proc_blend_vertex_p();
-            				reg_temp[1].xy = reg_temp[2].yy;
-            				reg_temp[1].w = IrScale[1].w * aBoneWeight.y;
-            				proc_blend_vertex_p();
-            				reg_temp[1].xy = reg_temp[2].zz;
-            				reg_temp[1].w = IrScale[1].w * aBoneWeight.z;
-            				if (reg_cmp.x) proc_blend_vertex_p();
-            				if ((BoolUniforms & IsBoneW) != 0) {
-            					reg_temp[1].xy = reg_temp[2].ww;
-            					reg_temp[1].w = IrScale[1].w * aBoneWeight.w;
-            					if (reg_cmp.y) proc_blend_vertex_p();
-            				}
-            				reg_temp[7].w = vec4(0, 1, 2, 3).y;
-            				reg_temp[10].x = dot(WrldMtx[0].xyzw, reg_temp[7].xyzw);
-            				reg_temp[10].y = dot(WrldMtx[1].xyzw, reg_temp[7].xyzw);
-            				reg_temp[10].z = dot(WrldMtx[2].xyzw, reg_temp[7].xyzw);
-            				reg_temp[10].w = vec4(0, 1, 2, 3).y;
-            				reg_temp[15].x = dot(ViewMtx[0].xyzw, reg_temp[10].xyzw);
-            				reg_temp[15].y = dot(ViewMtx[1].xyzw, reg_temp[10].xyzw);
-            				reg_temp[15].z = dot(ViewMtx[2].xyzw, reg_temp[10].xyzw);
-            				reg_temp[15].w = vec4(0, 1, 2, 3).y;
-            				QuatNormal.xyzw = vec4(0, 1, 2, 3).xxxx;
-            			}
-            		}
-            		View.xyzw = -reg_temp[15].xyzw;
-            		Position.x = dot(ProjMtx[0].xyzw, reg_temp[15].xyzw);
-            		Position.y = dot(ProjMtx[1].xyzw, reg_temp[15].xyzw);
-            		Position.z = dot(ProjMtx[2].xyzw, reg_temp[15].xyzw);
-            		Position.w = dot(ProjMtx[3].xyzw, reg_temp[15].xyzw);
-            	} else {
-            		reg_temp[0].xyzw = IrScale[0].xyzw;
-            		reg_cmp.x = vec4(0, 1, 2, 3).x != reg_temp[0].y;
-            		reg_cmp.y = vec4(0, 1, 2, 3).x != reg_temp[0].z;
-            		if ((BoolUniforms & IsRgdSk) != 0) {
-            			reg_temp[1].x = vec4(0, 1, 2, 3).w * min(aBoneIndex.x, 19);
-            			reg_a0.x = int(reg_temp[1].x);
-            			reg_temp[7].x = dot(UnivReg[0 + reg_a0.x].xyzw, reg_temp[15].xyzw);
-            			reg_temp[7].y = dot(UnivReg[1 + reg_a0.x].xyzw, reg_temp[15].xyzw);
-            			reg_temp[7].z = dot(UnivReg[2 + reg_a0.x].xyzw, reg_temp[15].xyzw);
-            			reg_temp[7].w = vec4(0, 1, 2, 3).y;
-            			reg_temp[10].x = dot(WrldMtx[0].xyzw, reg_temp[7].xyzw);
-            			reg_temp[10].y = dot(WrldMtx[1].xyzw, reg_temp[7].xyzw);
-            			reg_temp[10].z = dot(WrldMtx[2].xyzw, reg_temp[7].xyzw);
-            			reg_temp[10].w = vec4(0, 1, 2, 3).y;
-            		} else {
-            			reg_a0.x = int(vec4(0, 1, 2, 3).x);
-                        vec4 p = vec4(0);
-                        p.x = dot(UnivReg[0].xyzw, reg_temp[15].xyzw);
-                        p.y = dot(UnivReg[1].xyzw, reg_temp[15].xyzw);
-                        p.z = dot(UnivReg[2].xyzw, reg_temp[15].xyzw);
-                        p.w = vec4(0, 1, 2, 3).y;
+			void proc_transform_matrix() {
+				reg_temp[15].xyz = IrScale[0].xxx * aPosition.xyz;
+				reg_temp[14].xyz = IrScale[0].yyy * aNormal.xyz;
+				reg_temp[13].xyz = IrScale[0].zzz * aTangent.xyz;
+				reg_temp[15].xyz = PosOffs.xyz + reg_temp[15].xyz;
+				reg_temp[15].w = vec4(0, 1, 2, 3).y;
+				if ((BoolUniforms & IsSmoSk) != 0) {
+					reg_temp[0].xyzw = IrScale[0].xyzw;
+					reg_cmp.x = vec4(0, 1, 2, 3).x != reg_temp[0].y;
+					reg_cmp.y = vec4(0, 1, 2, 3).x != reg_temp[0].z;
+					reg_temp[7].xyzw = vec4(0, 1, 2, 3).xxxx;
+					reg_temp[12].xyzw = vec4(0, 1, 2, 3).xxxx;
+					reg_temp[11].xyzw = vec4(0, 1, 2, 3).xxxx;
+					reg_temp[2].xyzw = vec4(0, 1, 2, 3).wwww * min(aBoneIndex.xyzw, vec4(19));
+					if (reg_cmp.x && !reg_cmp.y) {
+						reg_cmp.x = vec4(0, 1, 2, 3).x != aBoneWeight.z;
+						reg_cmp.y = vec4(0, 1, 2, 3).x != aBoneWeight.w;
+						reg_temp[1].xy = reg_temp[2].xx;
+						reg_temp[1].w = IrScale[1].w * aBoneWeight.x;
+						proc_blend_vertex_pn();
+						reg_temp[1].xy = reg_temp[2].yy;
+						reg_temp[1].w = IrScale[1].w * aBoneWeight.y;
+						proc_blend_vertex_pn();
+						reg_temp[1].xy = reg_temp[2].zz;
+						reg_temp[1].w = IrScale[1].w * aBoneWeight.z;
+						if (reg_cmp.x) proc_blend_vertex_pn();
+						if ((BoolUniforms & IsBoneW) != 0) {
+							reg_temp[1].xy = reg_temp[2].ww;
+							reg_temp[1].w = IrScale[1].w * aBoneWeight.w;
+							if (reg_cmp.y) proc_blend_vertex_pn();
+						}
+						reg_temp[7].w = vec4(0, 1, 2, 3).y;
+						reg_temp[10].x = dot(WrldMtx[0].xyzw, reg_temp[7].xyzw);
+						reg_temp[10].y = dot(WrldMtx[1].xyzw, reg_temp[7].xyzw);
+						reg_temp[10].z = dot(WrldMtx[2].xyzw, reg_temp[7].xyzw);
+						reg_temp[10].w = vec4(0, 1, 2, 3).y;
+						reg_temp[15].x = dot(ViewMtx[0].xyzw, reg_temp[10].xyzw);
+						reg_temp[15].y = dot(ViewMtx[1].xyzw, reg_temp[10].xyzw);
+						reg_temp[15].z = dot(ViewMtx[2].xyzw, reg_temp[10].xyzw);
+						reg_temp[15].w = vec4(0, 1, 2, 3).y;
+						reg_temp[14].x = dot(NormMtx[0].xyz, reg_temp[12].xyz);
+						reg_temp[14].y = dot(NormMtx[1].xyz, reg_temp[12].xyz);
+						reg_temp[14].z = dot(NormMtx[2].xyz, reg_temp[12].xyz);
+						proc_calc_quaternion_from_normal();
+					} else {
+						if (reg_cmp.x && reg_cmp.y) {
+							reg_cmp.x = vec4(0, 1, 2, 3).x != aBoneWeight.z;
+							reg_cmp.y = vec4(0, 1, 2, 3).x != aBoneWeight.w;
+							reg_temp[1].xy = reg_temp[2].xx;
+							reg_temp[1].w = IrScale[1].w * aBoneWeight.x;
+							proc_blend_vertex_pnt();
+							reg_temp[1].xy = reg_temp[2].yy;
+							reg_temp[1].w = IrScale[1].w * aBoneWeight.y;
+							proc_blend_vertex_pnt();
+							reg_temp[1].xy = reg_temp[2].zz;
+							reg_temp[1].w = IrScale[1].w * aBoneWeight.z;
+							if (reg_cmp.x) proc_blend_vertex_pnt();
+							if ((BoolUniforms & IsBoneW) != 0) {
+								reg_temp[1].xy = reg_temp[2].ww;
+								reg_temp[1].w = IrScale[1].w * aBoneWeight.w;
+								if (reg_cmp.y) proc_blend_vertex_pnt();
+							}
+							reg_temp[7].w = vec4(0, 1, 2, 3).y;
+							reg_temp[10].x = dot(WrldMtx[0].xyzw, reg_temp[7].xyzw);
+							reg_temp[10].y = dot(WrldMtx[1].xyzw, reg_temp[7].xyzw);
+							reg_temp[10].z = dot(WrldMtx[2].xyzw, reg_temp[7].xyzw);
+							reg_temp[10].w = vec4(0, 1, 2, 3).y;
+							reg_temp[13].x = dot(NormMtx[0].xyz, reg_temp[11].xyz);
+							reg_temp[13].y = dot(NormMtx[1].xyz, reg_temp[11].xyz);
+							reg_temp[13].z = dot(NormMtx[2].xyz, reg_temp[11].xyz);
+							reg_temp[14].x = dot(NormMtx[0].xyz, reg_temp[12].xyz);
+							reg_temp[14].y = dot(NormMtx[1].xyz, reg_temp[12].xyz);
+							reg_temp[14].z = dot(NormMtx[2].xyz, reg_temp[12].xyz);
+							reg_temp[15].x = dot(ViewMtx[0].xyzw, reg_temp[10].xyzw);
+							reg_temp[15].y = dot(ViewMtx[1].xyzw, reg_temp[10].xyzw);
+							reg_temp[15].z = dot(ViewMtx[2].xyzw, reg_temp[10].xyzw);
+							reg_temp[15].w = vec4(0, 1, 2, 3).y;
+							proc_calc_quaternion_from_tangent();
+						} else {
+							reg_cmp.x = vec4(0, 1, 2, 3).x != aBoneWeight.z;
+							reg_cmp.y = vec4(0, 1, 2, 3).x != aBoneWeight.w;
+							reg_temp[1].xy = reg_temp[2].xx;
+							reg_temp[1].w = IrScale[1].w * aBoneWeight.x;
+							proc_blend_vertex_p();
+							reg_temp[1].xy = reg_temp[2].yy;
+							reg_temp[1].w = IrScale[1].w * aBoneWeight.y;
+							proc_blend_vertex_p();
+							reg_temp[1].xy = reg_temp[2].zz;
+							reg_temp[1].w = IrScale[1].w * aBoneWeight.z;
+							if (reg_cmp.x) proc_blend_vertex_p();
+							if ((BoolUniforms & IsBoneW) != 0) {
+								reg_temp[1].xy = reg_temp[2].ww;
+								reg_temp[1].w = IrScale[1].w * aBoneWeight.w;
+								if (reg_cmp.y) proc_blend_vertex_p();
+							}
+							reg_temp[7].w = vec4(0, 1, 2, 3).y;
+							reg_temp[10].x = dot(WrldMtx[0].xyzw, reg_temp[7].xyzw);
+							reg_temp[10].y = dot(WrldMtx[1].xyzw, reg_temp[7].xyzw);
+							reg_temp[10].z = dot(WrldMtx[2].xyzw, reg_temp[7].xyzw);
+							reg_temp[10].w = vec4(0, 1, 2, 3).y;
+							reg_temp[15].x = dot(ViewMtx[0].xyzw, reg_temp[10].xyzw);
+							reg_temp[15].y = dot(ViewMtx[1].xyzw, reg_temp[10].xyzw);
+							reg_temp[15].z = dot(ViewMtx[2].xyzw, reg_temp[10].xyzw);
+							reg_temp[15].w = vec4(0, 1, 2, 3).y;
+							QuatNormal.xyzw = vec4(0, 1, 2, 3).xxxx;
+						}
+					}
+					View.xyzw = -reg_temp[15].xyzw;
+					Position.x = dot(ProjMtx[0].xyzw, reg_temp[15].xyzw);
+					Position.y = dot(ProjMtx[1].xyzw, reg_temp[15].xyzw);
+					Position.z = dot(ProjMtx[2].xyzw, reg_temp[15].xyzw);
+					Position.w = dot(ProjMtx[3].xyzw, reg_temp[15].xyzw);
+				} else {
+					reg_temp[0].xyzw = IrScale[0].xyzw;
+					reg_cmp.x = vec4(0, 1, 2, 3).x != reg_temp[0].y;
+					reg_cmp.y = vec4(0, 1, 2, 3).x != reg_temp[0].z;
+					if ((BoolUniforms & IsRgdSk) != 0) {
+						reg_temp[1].x = vec4(0, 1, 2, 3).w * min(aBoneIndex.x, 19);
+						reg_a0.x = int(reg_temp[1].x);
+						reg_temp[7].x = dot(UnivReg[0 + reg_a0.x].xyzw, reg_temp[15].xyzw);
+						reg_temp[7].y = dot(UnivReg[1 + reg_a0.x].xyzw, reg_temp[15].xyzw);
+						reg_temp[7].z = dot(UnivReg[2 + reg_a0.x].xyzw, reg_temp[15].xyzw);
+						reg_temp[7].w = vec4(0, 1, 2, 3).y;
+						reg_temp[10].x = dot(WrldMtx[0].xyzw, reg_temp[7].xyzw);
+						reg_temp[10].y = dot(WrldMtx[1].xyzw, reg_temp[7].xyzw);
+						reg_temp[10].z = dot(WrldMtx[2].xyzw, reg_temp[7].xyzw);
+						reg_temp[10].w = vec4(0, 1, 2, 3).y;
+					} else {
+						reg_a0.x = int(vec4(0, 1, 2, 3).x);
+						vec4 p = vec4(0);
+						p.x = dot(UnivReg[0].xyzw, reg_temp[15].xyzw);
+						p.y = dot(UnivReg[1].xyzw, reg_temp[15].xyzw);
+						p.z = dot(UnivReg[2].xyzw, reg_temp[15].xyzw);
+						p.w = vec4(0, 1, 2, 3).y;
 
-                        reg_temp[10].x = dot(WrldMtx[0].xyzw, p.xyzw);
-                        reg_temp[10].y = dot(WrldMtx[1].xyzw, p.xyzw);
-                        reg_temp[10].z = dot(WrldMtx[2].xyzw, p.xyzw);
-            			reg_temp[10].w = vec4(0, 1, 2, 3).y;
-            		}
-            		if (reg_cmp.x && !reg_cmp.y) {
-            			reg_temp[12].x = dot(UnivReg[0 + reg_a0.x].xyz, reg_temp[14].xyz);
-            			reg_temp[12].y = dot(UnivReg[1 + reg_a0.x].xyz, reg_temp[14].xyz);
-            			reg_temp[12].z = dot(UnivReg[2 + reg_a0.x].xyz, reg_temp[14].xyz);
-            			reg_temp[15].x = dot(ViewMtx[0].xyzw, reg_temp[10].xyzw);
-            			reg_temp[15].y = dot(ViewMtx[1].xyzw, reg_temp[10].xyzw);
-            			reg_temp[15].z = dot(ViewMtx[2].xyzw, reg_temp[10].xyzw);
-            			reg_temp[15].w = vec4(0, 1, 2, 3).y;
-            			reg_temp[14].x = dot(NormMtx[0].xyz, reg_temp[12].xyz);
-            			reg_temp[14].y = dot(NormMtx[1].xyz, reg_temp[12].xyz);
-            			reg_temp[14].z = dot(NormMtx[2].xyz, reg_temp[12].xyz);
-            			proc_calc_quaternion_from_normal();
-            		} else {
-            			if (reg_cmp.x && reg_cmp.y) {
-            				reg_temp[12].x = dot(UnivReg[0 + reg_a0.x].xyz, reg_temp[14].xyz);
-            				reg_temp[12].y = dot(UnivReg[1 + reg_a0.x].xyz, reg_temp[14].xyz);
-            				reg_temp[12].z = dot(UnivReg[2 + reg_a0.x].xyz, reg_temp[14].xyz);
-            				reg_temp[11].x = dot(UnivReg[0 + reg_a0.x].xyz, reg_temp[13].xyz);
-            				reg_temp[11].y = dot(UnivReg[1 + reg_a0.x].xyz, reg_temp[13].xyz);
-            				reg_temp[11].z = dot(UnivReg[2 + reg_a0.x].xyz, reg_temp[13].xyz);
-            				reg_temp[15].x = dot(ViewMtx[0].xyzw, reg_temp[10].xyzw);
-            				reg_temp[15].y = dot(ViewMtx[1].xyzw, reg_temp[10].xyzw);
-            				reg_temp[15].z = dot(ViewMtx[2].xyzw, reg_temp[10].xyzw);
-            				reg_temp[15].w = vec4(0, 1, 2, 3).y;
-            				reg_temp[14].x = dot(NormMtx[0].xyz, reg_temp[12].xyz);
-            				reg_temp[14].y = dot(NormMtx[1].xyz, reg_temp[12].xyz);
-            				reg_temp[14].z = dot(NormMtx[2].xyz, reg_temp[12].xyz);
-            				reg_temp[13].x = dot(NormMtx[0].xyz, reg_temp[11].xyz);
-            				reg_temp[13].y = dot(NormMtx[1].xyz, reg_temp[11].xyz);
-            				reg_temp[13].z = dot(NormMtx[2].xyz, reg_temp[11].xyz);
-            				proc_calc_quaternion_from_tangent();
-            			} else {
-            				reg_temp[15].x = dot(ViewMtx[0].xyzw, reg_temp[10].xyzw);
-            				reg_temp[15].y = dot(ViewMtx[1].xyzw, reg_temp[10].xyzw);
-            				reg_temp[15].z = dot(ViewMtx[2].xyzw, reg_temp[10].xyzw);
-            				reg_temp[15].w = vec4(0, 1, 2, 3).y;
-            				QuatNormal.xyzw = vec4(0, 1, 2, 3).xxxx;
-            			}
-            		}
-            		View.xyzw = -reg_temp[15].xyzw;
-            		Position.x = dot(ProjMtx[0].xyzw, reg_temp[15].xyzw);
-            		Position.y = dot(ProjMtx[1].xyzw, reg_temp[15].xyzw);
-            		Position.z = dot(ProjMtx[2].xyzw, reg_temp[15].xyzw);
-            		Position.w = dot(ProjMtx[3].xyzw, reg_temp[15].xyzw);
-            	}
-            }
+						reg_temp[10].x = dot(WrldMtx[0].xyzw, p.xyzw);
+						reg_temp[10].y = dot(WrldMtx[1].xyzw, p.xyzw);
+						reg_temp[10].z = dot(WrldMtx[2].xyzw, p.xyzw);
+						reg_temp[10].w = vec4(0, 1, 2, 3).y;
+					}
+					if (reg_cmp.x && !reg_cmp.y) {
+						reg_temp[12].x = dot(UnivReg[0 + reg_a0.x].xyz, reg_temp[14].xyz);
+						reg_temp[12].y = dot(UnivReg[1 + reg_a0.x].xyz, reg_temp[14].xyz);
+						reg_temp[12].z = dot(UnivReg[2 + reg_a0.x].xyz, reg_temp[14].xyz);
+						reg_temp[15].x = dot(ViewMtx[0].xyzw, reg_temp[10].xyzw);
+						reg_temp[15].y = dot(ViewMtx[1].xyzw, reg_temp[10].xyzw);
+						reg_temp[15].z = dot(ViewMtx[2].xyzw, reg_temp[10].xyzw);
+						reg_temp[15].w = vec4(0, 1, 2, 3).y;
+						reg_temp[14].x = dot(NormMtx[0].xyz, reg_temp[12].xyz);
+						reg_temp[14].y = dot(NormMtx[1].xyz, reg_temp[12].xyz);
+						reg_temp[14].z = dot(NormMtx[2].xyz, reg_temp[12].xyz);
+						proc_calc_quaternion_from_normal();
+					} else {
+						if (reg_cmp.x && reg_cmp.y) {
+							reg_temp[12].x = dot(UnivReg[0 + reg_a0.x].xyz, reg_temp[14].xyz);
+							reg_temp[12].y = dot(UnivReg[1 + reg_a0.x].xyz, reg_temp[14].xyz);
+							reg_temp[12].z = dot(UnivReg[2 + reg_a0.x].xyz, reg_temp[14].xyz);
+							reg_temp[11].x = dot(UnivReg[0 + reg_a0.x].xyz, reg_temp[13].xyz);
+							reg_temp[11].y = dot(UnivReg[1 + reg_a0.x].xyz, reg_temp[13].xyz);
+							reg_temp[11].z = dot(UnivReg[2 + reg_a0.x].xyz, reg_temp[13].xyz);
+							reg_temp[15].x = dot(ViewMtx[0].xyzw, reg_temp[10].xyzw);
+							reg_temp[15].y = dot(ViewMtx[1].xyzw, reg_temp[10].xyzw);
+							reg_temp[15].z = dot(ViewMtx[2].xyzw, reg_temp[10].xyzw);
+							reg_temp[15].w = vec4(0, 1, 2, 3).y;
+							reg_temp[14].x = dot(NormMtx[0].xyz, reg_temp[12].xyz);
+							reg_temp[14].y = dot(NormMtx[1].xyz, reg_temp[12].xyz);
+							reg_temp[14].z = dot(NormMtx[2].xyz, reg_temp[12].xyz);
+							reg_temp[13].x = dot(NormMtx[0].xyz, reg_temp[11].xyz);
+							reg_temp[13].y = dot(NormMtx[1].xyz, reg_temp[11].xyz);
+							reg_temp[13].z = dot(NormMtx[2].xyz, reg_temp[11].xyz);
+							proc_calc_quaternion_from_tangent();
+						} else {
+							reg_temp[15].x = dot(ViewMtx[0].xyzw, reg_temp[10].xyzw);
+							reg_temp[15].y = dot(ViewMtx[1].xyzw, reg_temp[10].xyzw);
+							reg_temp[15].z = dot(ViewMtx[2].xyzw, reg_temp[10].xyzw);
+							reg_temp[15].w = vec4(0, 1, 2, 3).y;
+							QuatNormal.xyzw = vec4(0, 1, 2, 3).xxxx;
+						}
+					}
+					View.xyzw = -reg_temp[15].xyzw;
+					Position.x = dot(ProjMtx[0].xyzw, reg_temp[15].xyzw);
+					Position.y = dot(ProjMtx[1].xyzw, reg_temp[15].xyzw);
+					Position.z = dot(ProjMtx[2].xyzw, reg_temp[15].xyzw);
+					Position.w = dot(ProjMtx[3].xyzw, reg_temp[15].xyzw);
+				}
+			}
 
-            vec3 BoneWeightColor(float weights)
-            {
-            	float rampInputLuminance = weights;
-            	rampInputLuminance = clamp((rampInputLuminance), 0.001, 0.999);
-                if (weightRampType == 1) // Greyscale
-                    return vec3(weights);
-                else if (weightRampType == 2) // Color 1
-            	   return texture(weightRamp1, vec2(1 - rampInputLuminance, 0.50)).rgb;
-                else // Color 2
-                    return texture(weightRamp2, vec2(1 - rampInputLuminance, 0.50)).rgb;
-            }
+			vec3 BoneWeightColor(float weights)
+			{
+				float rampInputLuminance = weights;
+				rampInputLuminance = clamp((rampInputLuminance), 0.001, 0.999);
+				if (weightRampType == 1) // Greyscale
+					return vec3(weights);
+				else if (weightRampType == 2) // Color 1
+				   return texture(weightRamp1, vec2(1 - rampInputLuminance, 0.50)).rgb;
+				else // Color 2
+					return texture(weightRamp2, vec2(1 - rampInputLuminance, 0.50)).rgb;
+			}
 
-            float BoneWeightDisplay(ivec4 index)
-            {
-                float weight = 0;
-                if (selectedBoneIndex == BoneTable[index.x])
-                    weight += aBoneWeight.x;
-                if (selectedBoneIndex == BoneTable[index.y])
-                    weight += aBoneWeight.y;
-                if (selectedBoneIndex == BoneTable[index.z])
-                    weight += aBoneWeight.z;
-                if (selectedBoneIndex == BoneTable[index.w])
-                    weight += aBoneWeight.w;
+			float BoneWeightDisplay(ivec4 index)
+			{
+				float weight = 0;
+				if (selectedBoneIndex == BoneTable[index.x])
+					weight += aBoneWeight.x;
+				if (selectedBoneIndex == BoneTable[index.y])
+					weight += aBoneWeight.y;
+				if (selectedBoneIndex == BoneTable[index.z])
+					weight += aBoneWeight.z;
+				if (selectedBoneIndex == BoneTable[index.w])
+					weight += aBoneWeight.w;
 
-                if (selectedBoneIndex == BoneTable[index.x] && hasWeights == 0)
-                    weight += 1.0;
+				if (selectedBoneIndex == BoneTable[index.x] && hasWeights == 0)
+					weight += 1.0;
 
-                return weight;
-            }
+				return weight;
+			}
 
-            void main() {
-            	proc_transform_matrix();
-            	proc_calc_color();
-            	proc_calc_texcoord0();
-            	proc_calc_texcoord1();
-            	proc_calc_texcoord2();
-            	gl_Position = Position;
-                float totalWeight = BoneWeightDisplay(ivec4(aBoneIndex));
-                WeightPreview = vec4(BoneWeightColor(totalWeight).rgb, 1);
-            }
-            """
-        );
-    public static ShaderSource GetFragmentShader(string name, H3DMaterialParams materialParams)
-    {
-        FragmentShaderGenerator generator = new(materialParams);
+			void main() {
+				proc_transform_matrix();
+				proc_calc_color();
+				proc_calc_texcoord0();
+				proc_calc_texcoord1();
+				proc_calc_texcoord2();
+				gl_Position = Position;
+				// Color.xyz = vec3((BillboardMode >> 0) & 1, (BillboardMode >> 1) & 1, (BillboardMode >> 2) & 1);
+				float totalWeight = BoneWeightDisplay(ivec4(aBoneIndex));
+				WeightPreview = vec4(BoneWeightColor(totalWeight).rgb, 1);
+			}
+			"""
+		);
+	public static ShaderSource GetFragmentShader(string name, H3DMaterialParams materialParams)
+	{
+		FragmentShaderGenerator generator = new(materialParams);
 
-        return new(name + ".frag", ShaderType.FragmentShader, generator.GetFragShader());
-    }
+		return new(name + ".frag", ShaderType.FragmentShader, generator.GetFragShader());
+	}
 }

--- a/Autumn/Rendering/ModelRenderer.cs
+++ b/Autumn/Rendering/ModelRenderer.cs
@@ -97,7 +97,7 @@ internal static class ModelRenderer
         s_railGeometryParams.Camera = cameraEye;
     }
 
-    public static void Draw(GL gl, ISceneObj sceneObj, StageLight? previewLight = null)
+    public static void Draw(GL gl, ISceneObj sceneObj, Scene scn)
     {
         if (s_commonSceneParams is null || s_defaultCubeMaterialParams is null)
             throw new InvalidOperationException(
@@ -167,7 +167,8 @@ internal static class ModelRenderer
             {
                 material.SetSelectionColor(new(s_highlightColor, actorSceneObj.Selected ? 0.4f : 0));
                 material.SetMatrices(s_projectionMatrix, actorSceneObj.Transform, s_viewMatrix);
-                material.SetLight0(previewLight?.GetAsLight() ?? _defaultLight);
+                if (scn.CanPreviewLights) material.SetLight0((scn.PreviewOneLight ? (scn.PreviewLight?.GetAsLight() ?? scn.GetPreviewLight(actor.InitLight.Type)?.GetAsLight()) : scn.GetPreviewLight(actor.InitLight.Type)?.GetAsLight()) ?? _defaultLight);
+                else material.SetLight0(_defaultLight); 
                 material.SetViewRotation(s_cameraRotation);
 
                 if (!material.TryUse(gl, out ProgramUniformScope scope))

--- a/Autumn/Rendering/ModelRenderer.cs
+++ b/Autumn/Rendering/ModelRenderer.cs
@@ -32,7 +32,7 @@ internal static class ModelRenderer
     private static Matrix4x4 s_viewMatrix = Matrix4x4.Identity;
     private static Matrix4x4 s_projectionMatrix = Matrix4x4.Identity;
     private static Vector3 s_cameraRotation;
-    private static H3DRenderingMaterial.Light _defaultLight = new StageLight().GetAsLight();
+    private static StageLight _defaultLight = new StageLight();
 
     public static Dictionary<string, TextureSampler> GeneralLUTs = new();
 
@@ -167,7 +167,7 @@ internal static class ModelRenderer
             {
                 material.SetSelectionColor(new(s_highlightColor, actorSceneObj.Selected ? 0.4f : 0));
                 material.SetMatrices(s_projectionMatrix, actorSceneObj.Transform, s_viewMatrix);
-                if (scn.CanPreviewLights) material.SetLight0((scn.PreviewOneLight ? (scn.PreviewLight?.GetAsLight() ?? scn.GetPreviewLight(actor.InitLight.Type)?.GetAsLight()) : scn.GetPreviewLight(actor.InitLight.Type)?.GetAsLight()) ?? _defaultLight);
+                if (scn.CanPreviewLights) material.SetLight0((scn.PreviewOneLight ? (scn.PreviewLight ?? scn.GetPreviewLight(actor.InitLight.Type)) : scn.GetPreviewLight(actor.InitLight.Type)) ?? _defaultLight);
                 else material.SetLight0(_defaultLight); 
                 material.SetViewRotation(s_cameraRotation);
 

--- a/Autumn/Rendering/ModelRenderer.cs
+++ b/Autumn/Rendering/ModelRenderer.cs
@@ -32,18 +32,7 @@ internal static class ModelRenderer
     private static Matrix4x4 s_viewMatrix = Matrix4x4.Identity;
     private static Matrix4x4 s_projectionMatrix = Matrix4x4.Identity;
     private static Vector3 s_cameraRotation;
-    private static H3DRenderingMaterial.Light _defaultLight = new()
-    {
-        Ambient = new(0.1f, 0.1f, 0.1f, 1),
-        Diffuse = new(0.4f, 0.4f, 0.4f, 1),
-        Specular0 = new(0.8f, 0.8f, 0.8f, 1),
-        Specular1 = new(0.4f, 0.4f, 0.4f, 1),
-        Position = new(1, 1, 0.7f),
-        Direction = new(0, 0, 0),
-        Directional = 1,
-        TwoSidedDiffuse = 0,
-        DisableConst5 = 1
-    };
+    private static H3DRenderingMaterial.Light _defaultLight = new StageLight().GetAsLight();
 
     public static Dictionary<string, TextureSampler> GeneralLUTs = new();
 
@@ -202,7 +191,7 @@ internal static class ModelRenderer
                             material.BlendingColor.W
                         );
 
-                        gl.BlendEquationSeparate(material.ColorBlendEquation, material.AlphaBlendEquation);
+                        gl.BlendEquationSeparate(material.ColorBlendEquation, BlendEquationModeEXT.Max);//material.AlphaBlendEquation);
 
                         gl.BlendFuncSeparate(
                             material.ColorSrcFact,
@@ -219,7 +208,7 @@ internal static class ModelRenderer
                     gl.StencilOp(material.StencilOps[0], material.StencilOps[1], material.StencilOps[2]);
 
                     gl.DepthFunc(material.DepthFunction);
-                    gl.DepthMask(material.DepthMaskEnabled);
+                    gl.DepthMask(material.DepthMaskEnabled); // /* Hacky fix to self overlapping alphas (within the same mesh),*/ if we wanted it && !material.Name.Contains("Edge"));
 
                     gl.ColorMask(
                         material.ColorMask[0],

--- a/Autumn/Rendering/Rail/RailModel.cs
+++ b/Autumn/Rendering/Rail/RailModel.cs
@@ -8,7 +8,7 @@ namespace Autumn.Rendering.Rail;
 
 internal class RailModel(RailObj rail)
 {
-    private const float _bezierPointStep = 0.2f;
+    private const float _bezierPointStep = 0.08f;
 
     private bool _initialized = false;
 

--- a/Autumn/Rendering/Rail/RailPointMaterial.cs
+++ b/Autumn/Rendering/Rail/RailPointMaterial.cs
@@ -60,14 +60,20 @@ internal static class RailPointMaterial
 
                 float a = max3(
                     min(absolute.x, absolute.y),
-                    min(absolute.x, absolute.z),
-                    min(absolute.y, absolute.z));
+                    min(absolute.y, absolute.z),
+                    min(absolute.x, -absolute.z));
 
                 float wa = fwidth(a);
 
-                float outline = smoothstep(0.5 - wa * 2, 0.5 - wa, a);
-
-                oColor = mix(uColor * 0.18, uColor, outline);
+                float outline = smoothstep(0.01 - wa, 0.17 - wa, a);
+                
+                //vec4 glint = vec4(1,0.88,0.2,1) + 0.06; // YELLOW
+                //vec4 col = vec4(0.93,0.8,0,1); 
+                //vec4 glint = vec4(1,0.4,0.4,1) + 0.06; // RED
+                //vec4 col = vec4(1,0,0.24,1);
+                vec4 glint = vec4(0.38,0.69,1,1) + 0.06; // BLUE
+                vec4 col = vec4(0.09,0.5,0.86,1);
+                oColor = mix(glint, col, outline);
                 oColor.rgb = mix(oColor.rgb, uHighlightColor.rgb, uHighlightColor.a);
                 oColor.a = 1;
             }

--- a/Autumn/Rendering/Scene.cs
+++ b/Autumn/Rendering/Scene.cs
@@ -26,7 +26,11 @@ internal class Scene
 
     public Camera Camera { get; } = new(new Vector3(-10, 7, 10), Vector3.Zero);
     public Camera PreviewCamera { get; } = new(new Vector3(-10, 7, 10), Vector3.Zero);
+    public bool CanPreviewLights {get; set;} = false;
+    public bool PreviewOneLight {get; set;} = false;
+    public bool UseLightArea {get; set;} = false;
     public StageLight? PreviewLight { get; set; } = null;
+    public LightArea? PreviewLightAreas { get; set; } = null;
     public int SelectedCam { get; set; } = -1;
 
     /// <summary>
@@ -60,7 +64,7 @@ internal class Scene
         ModelRenderer.UpdateSceneParams(view, projection, cameraRot, cameraEye);
 
         foreach (ISceneObj obj in _sceneObjects)
-            ModelRenderer.Draw(gl, obj, PreviewLight);
+            ModelRenderer.Draw(gl, obj, this);
     }
 
     #region Object selection
@@ -127,6 +131,31 @@ internal class Scene
 
     #region Params
 
+    public StageLight? GetPreviewLight(ActorLight.LightType t)
+    {
+        if (!UseLightArea)
+        {
+            if (Stage.LightParams == null) return null;
+            return t switch
+            {
+                ActorLight.LightType.Player => Stage.LightParams.PlayerLight,
+                ActorLight.LightType.Character => Stage.LightParams.ObjectLight,
+                ActorLight.LightType.Terrain_Object => Stage.LightParams.MapObjectLight,
+                _ => Stage.LightParams.StageMapLight,
+            };
+        }
+        else
+        {
+            if (PreviewLightAreas == null) return null;
+            return t switch
+            {
+                ActorLight.LightType.Player => PreviewLightAreas.PlayerLight,
+                ActorLight.LightType.Character => PreviewLightAreas.ObjectLight,
+                ActorLight.LightType.Terrain_Object => PreviewLightAreas.MapObjectLight,
+                _ => Stage.LightParams != null ? Stage.LightParams.StageMapLight : null,
+            };
+        }
+    }
 
     public void AddLight()
     {

--- a/Autumn/Storage/Actor.cs
+++ b/Autumn/Storage/Actor.cs
@@ -21,6 +21,7 @@ internal class Actor
     public bool IsEmptyModel { get; private set; }
 
     public AxisAlignedBoundingBox AABB { get; set; } = new();
+    public ActorLight InitLight = new();
 
     /// <summary>
     /// An array of mesh lists. Each entry in the array represents a mesh layer.

--- a/Autumn/Storage/Actor/ActorLight.cs
+++ b/Autumn/Storage/Actor/ActorLight.cs
@@ -1,0 +1,55 @@
+
+namespace Autumn.Storage;
+
+internal class ActorLight
+{
+    public CalcType Calc = CalcType.Initial;
+    public LightType Type = LightType.Terrain; // DEFAULT 
+
+    /// <summary>
+    /// Determines when the light gets calculated for this actor 
+    ///
+    /// </summary>
+    public enum CalcType
+    {
+        /// <summary> Light is only calculated when the actor first shows up - 出現時のみ </summary>
+        Initial,
+
+        /// <summary> Light is calculated every frame - いつも計算 </summary>
+        Continuous
+    }
+    
+    /// <summary>
+    /// Type of light that will affect this actor
+    /// </summary>
+    public enum LightType
+    {
+        Player, //プレイヤー,
+        Character, //キャラ,
+        Terrain, // 地形, // DEFAULT 
+        Terrain_Object, // Stage Object  // 地形オブジェ,
+        /// <summary>地形_コンスト５, can take constant5 in its light calculation</summary>
+        Terrain_Constant5, //
+    }
+    public void GetCalcType(string s)
+    {
+        Calc = s switch
+        {
+            "出現時のみ" => CalcType.Initial,
+            "いつも計算" => CalcType.Continuous
+        };
+    }
+
+    public void GetType(string s)
+    {
+        Type = s switch
+        {
+            "プレイヤー"    => LightType.Player,
+            "キャラ"    => LightType.Character,
+            "地形"  => LightType.Terrain,
+            "地形オブジェ"  => LightType.Terrain_Object,
+            "地形_コンスト５"   => LightType.Terrain_Constant5
+        };
+    }
+
+}

--- a/Autumn/Storage/StageLight.cs
+++ b/Autumn/Storage/StageLight.cs
@@ -64,7 +64,7 @@ internal class StageLight
     public Vector4 Diffuse = new(0.23f, 0.22f, 0.21f, 1);
     public Vector4 Specular0 = new(0.5f, 0.5f, 0.5f, 1);
     public Vector4 Specular1 = new(0.5f, 0.5f, 0.5f, 1);
-    public bool IsCameraFollow = true;
+    public bool IsCameraFollow = false;
     public Vector3 Direction = new(-1,-1,-0.7f);
 
     public StageLight()


### PR DESCRIPTION
- Added a setting to zoom to the mouse, can also be toggled with Alt while scrolling (And if you press alt while the setting is enabled you get the regular "focused" zoom).
- Fixed issues with per material alpha, although the fix was found by trying what would work so I'm not really sure if this is the correct way to do it.
- Fixed Sky and BlockRoulette colors, they used Buffer color in the material and it wasn't being read.
- Fixed light directions being set in the opposite direction in the editor as ingame
- Made the preview light for the renderer use a new StageLight, so if we make changes to that the default StageLight, it will be the same for both.
- IsCameraFollow option didn't seem to do anything ON or OFF ingame, so the setting has been disabled in the shader for now, leading to much closer results to ingame. Also disabled geometry factor in the shader too, since it lead to incorrect results altogether.
- Made it so lights can only affect their designated object types, getting that information from the actor szs. Also made it so stage lights are loaded by default, instead of needing to open the lights menu
- (Unusable for now) Made preparations to pass billboard information from models to the vertex shader, although this functionality is not implemented yet.
- Fix to the list of music files available