### PR TITLE
Several render changes and quality of life changes + fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "Autumn/Resources/RedPepper-ClassDataBase"]
 	path = Autumn/Resources/RedPepper-ClassDataBase
 	url = https://github.com/fruityloops1/RedPepper-ClassDataBase
+[submodule "Autumn/Resources/Autumn-ClassModifiers"]
+	path = Autumn/Resources/Autumn-ClassModifiers
+	url = https://github.com/KirbysDarkNebula/Autumn-ClassModifiers

--- a/Autumn/ActionSystem/ActionHandler.cs
+++ b/Autumn/ActionSystem/ActionHandler.cs
@@ -396,7 +396,7 @@ internal class ActionHandler
             enabled: window =>
                 window is MainWindowContext mainContext
                 && mainContext.CurrentScene is not null
-                && mainContext.CurrentScene.SelectedObjCount > 0
+                && mainContext.CurrentScene.SelectedObjects.Any()
                 && !mainContext.IsTransformActive,
             Command.CommandCategory.Selection
         );
@@ -436,7 +436,7 @@ internal class ActionHandler
             enabled: window =>
                 window is MainWindowContext mainContext
                 && mainContext.CurrentScene is not null
-                && mainContext.CurrentScene.SelectedObjCount > 0
+                && mainContext.CurrentScene.SelectedObjects.Any()
                 && !mainContext.IsTransformActive,
             Command.CommandCategory.Selection
         );
@@ -466,7 +466,7 @@ internal class ActionHandler
                 ChangeHandler.ChangeHideMultiple(mainContext.CurrentScene!.History, mainContext.CurrentScene.SelectedObjects);
             },
             enabled: window =>
-                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjCount > 0 && mainContext.IsSceneFocused,
+                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjects.Any() && mainContext.IsSceneFocused,
             Command.CommandCategory.Selection
         );
     private static Command UnselectAll() =>
@@ -480,7 +480,7 @@ internal class ActionHandler
                 mainContext.CurrentScene!.UnselectAllObjects();
             },
             enabled: window =>
-                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjCount > 0 && mainContext.IsSceneFocused,
+                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjects.Any() && mainContext.IsSceneFocused,
             Command.CommandCategory.Selection
         );
 
@@ -497,7 +497,7 @@ internal class ActionHandler
                 else mainContext.FinishTransform();
             },
             enabled: window =>
-                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjCount > 0 
+                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjects.Any() 
                 && mainContext.IsSceneFocused && (mainContext.SceneTranslating != mainContext.IsSceneHovered)
                 && !ImGui.GetIO().WantTextInput && !mainContext.SceneScaling && !mainContext.SceneRotating,
             Command.CommandCategory.Transform
@@ -512,7 +512,7 @@ internal class ActionHandler
                 mainContext.MoveToPoint();
             },
             enabled: window =>
-                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjCount > 0 && mainContext.IsSceneHovered
+                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjects.Any() && mainContext.IsSceneHovered
                 && !ImGui.GetIO().WantTextInput && !mainContext.SceneScaling && !mainContext.SceneRotating && !mainContext.SceneTranslating,
             Command.CommandCategory.Transform
         );
@@ -528,7 +528,7 @@ internal class ActionHandler
                 else mainContext.FinishTransform();
             },
             enabled: window =>
-                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjCount > 0 
+                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjects.Any() 
                 && mainContext.IsSceneFocused && (mainContext.SceneRotating != mainContext.IsSceneHovered)
                 && !ImGui.GetIO().WantTextInput && !mainContext.SceneScaling && !mainContext.SceneTranslating,
             Command.CommandCategory.Transform
@@ -545,7 +545,7 @@ internal class ActionHandler
                 else mainContext.FinishTransform();
             },
             enabled: window =>
-                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjCount > 0 
+                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjects.Any() 
                 && mainContext.IsSceneFocused && (mainContext.SceneScaling != mainContext.IsSceneHovered)
                 && !ImGui.GetIO().WantTextInput && !mainContext.SceneTranslating && !mainContext.SceneRotating,
             Command.CommandCategory.Transform
@@ -571,7 +571,7 @@ internal class ActionHandler
 
             },
             enabled: window =>
-                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjCount > 0 && mainContext.IsSceneFocused
+                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjects.Any() && mainContext.IsSceneFocused
                 && (mainContext.CurrentScene.SelectedObjects.First() is RailSceneObj || mainContext.CurrentScene.SelectedObjects.First() is RailPointSceneObj),
             Command.CommandCategory.Rail
         );    
@@ -585,7 +585,7 @@ internal class ActionHandler
                 mainContext.CameraToObject();
             },
             enabled: window =>
-                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjCount > 0 && mainContext.IsSceneFocused,
+                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjects.Any() && mainContext.IsSceneFocused,
             Command.CommandCategory.Selection
         );
     private Command ShowHandles() =>

--- a/Autumn/ActionSystem/ActionHandler.cs
+++ b/Autumn/ActionSystem/ActionHandler.cs
@@ -387,7 +387,7 @@ internal class ActionHandler
                     else if (del is RailHandleSceneObj && !mainContext.CurrentScene!.SelectedObjects.Contains((del as RailHandleSceneObj)!.ParentPoint)) 
                     {
                         ChangeHandler.ChangeHandleTransform(mainContext.CurrentScene.History, (del as RailHandleSceneObj)!, (del as RailHandleSceneObj)!.Offset, System.Numerics.Vector3.Zero, false);
-                        unselect = !(mainContext.CurrentScene!.SelectedObjects.Count() < 2);
+                        unselect = !(mainContext.CurrentScene!.SelectedObjCount < 2);
                     }
                 }
                 if (unselect)
@@ -396,7 +396,7 @@ internal class ActionHandler
             enabled: window =>
                 window is MainWindowContext mainContext
                 && mainContext.CurrentScene is not null
-                && mainContext.CurrentScene.SelectedObjects.Any()
+                && mainContext.CurrentScene.SelectedObjCount > 0
                 && !mainContext.IsTransformActive,
             Command.CommandCategory.Selection
         );
@@ -409,7 +409,7 @@ internal class ActionHandler
                 if (window is not MainWindowContext mainContext)
                     return;
 
-                int count = mainContext.CurrentScene!.SelectedObjects.Count();
+                int count = mainContext.CurrentScene!.SelectedObjCount;
                 List<uint> newPickIds = new();
 
                 foreach (ISceneObj copy in mainContext.CurrentScene.SelectedObjects)
@@ -436,7 +436,7 @@ internal class ActionHandler
             enabled: window =>
                 window is MainWindowContext mainContext
                 && mainContext.CurrentScene is not null
-                && mainContext.CurrentScene.SelectedObjects.Any()
+                && mainContext.CurrentScene.SelectedObjCount > 0
                 && !mainContext.IsTransformActive,
             Command.CommandCategory.Selection
         );
@@ -466,7 +466,7 @@ internal class ActionHandler
                 ChangeHandler.ChangeHideMultiple(mainContext.CurrentScene!.History, mainContext.CurrentScene.SelectedObjects);
             },
             enabled: window =>
-                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjects.Any() && mainContext.IsSceneFocused,
+                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjCount > 0 && mainContext.IsSceneFocused,
             Command.CommandCategory.Selection
         );
     private static Command UnselectAll() =>
@@ -480,7 +480,7 @@ internal class ActionHandler
                 mainContext.CurrentScene!.UnselectAllObjects();
             },
             enabled: window =>
-                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjects.Any() && mainContext.IsSceneFocused,
+                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjCount > 0 && mainContext.IsSceneFocused,
             Command.CommandCategory.Selection
         );
 
@@ -497,7 +497,7 @@ internal class ActionHandler
                 else mainContext.FinishTransform();
             },
             enabled: window =>
-                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjects.Any() 
+                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjCount > 0 
                 && mainContext.IsSceneFocused && (mainContext.SceneTranslating != mainContext.IsSceneHovered)
                 && !ImGui.GetIO().WantTextInput && !mainContext.SceneScaling && !mainContext.SceneRotating,
             Command.CommandCategory.Transform
@@ -512,7 +512,7 @@ internal class ActionHandler
                 mainContext.MoveToPoint();
             },
             enabled: window =>
-                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjects.Any() && mainContext.IsSceneHovered
+                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjCount > 0 && mainContext.IsSceneHovered
                 && !ImGui.GetIO().WantTextInput && !mainContext.SceneScaling && !mainContext.SceneRotating && !mainContext.SceneTranslating,
             Command.CommandCategory.Transform
         );
@@ -528,7 +528,7 @@ internal class ActionHandler
                 else mainContext.FinishTransform();
             },
             enabled: window =>
-                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjects.Any() 
+                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjCount > 0 
                 && mainContext.IsSceneFocused && (mainContext.SceneRotating != mainContext.IsSceneHovered)
                 && !ImGui.GetIO().WantTextInput && !mainContext.SceneScaling && !mainContext.SceneTranslating,
             Command.CommandCategory.Transform
@@ -545,7 +545,7 @@ internal class ActionHandler
                 else mainContext.FinishTransform();
             },
             enabled: window =>
-                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjects.Any() 
+                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjCount > 0 
                 && mainContext.IsSceneFocused && (mainContext.SceneScaling != mainContext.IsSceneHovered)
                 && !ImGui.GetIO().WantTextInput && !mainContext.SceneTranslating && !mainContext.SceneRotating,
             Command.CommandCategory.Transform
@@ -571,7 +571,7 @@ internal class ActionHandler
 
             },
             enabled: window =>
-                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjects.Any() && mainContext.IsSceneFocused
+                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjCount > 0 && mainContext.IsSceneFocused
                 && (mainContext.CurrentScene.SelectedObjects.First() is RailSceneObj || mainContext.CurrentScene.SelectedObjects.First() is RailPointSceneObj),
             Command.CommandCategory.Rail
         );    
@@ -585,7 +585,7 @@ internal class ActionHandler
                 mainContext.CameraToObject();
             },
             enabled: window =>
-                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjects.Any() && mainContext.IsSceneFocused,
+                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjCount > 0 && mainContext.IsSceneFocused,
             Command.CommandCategory.Selection
         );
     private Command ShowHandles() =>
@@ -631,7 +631,7 @@ internal class ActionHandler
             },
             enabled: window =>
             {
-                if (window is not MainWindowContext mainContext || mainContext.CurrentScene is null || mainContext.CurrentScene.SelectedObjects.Count() != 1)
+                if (window is not MainWindowContext mainContext || mainContext.CurrentScene is null || mainContext.CurrentScene.SelectedObjCount != 1)
                     return false;
                 if (mainContext.CurrentScene.SelectedObjects.First() is IStageSceneObj stageSceneObj)
                 {

--- a/Autumn/ActionSystem/ActionHandler.cs
+++ b/Autumn/ActionSystem/ActionHandler.cs
@@ -66,6 +66,7 @@ internal class ActionHandler
 
     public void ExecuteShortcuts(WindowContext? focusedWindow)
     {
+        if (focusedWindow != null && focusedWindow is MainWindowContext && (focusedWindow as MainWindowContext)!.IsDialogOpen) return;
         foreach (var (command, shortcut) in Actions.Values)
         {
             if ((shortcut?.IsTriggered() ?? false) && command.Enabled(focusedWindow))

--- a/Autumn/ActionSystem/ActionHandler.cs
+++ b/Autumn/ActionSystem/ActionHandler.cs
@@ -47,6 +47,8 @@ internal class ActionHandler
                 CommandID.AddRailPoint => AddRailPoint(),
                 CommandID.ShowHandles => ShowHandles(),
                 CommandID.CamToObj => CamToObj(),
+                CommandID.Search => SearchObj(),
+                CommandID.FlyCamMode => ToggleFlyCam(),
                 #if DEBUG
                 CommandID.AddALL => AddAllStages(),
                 CommandID.SaveALL => SaveAllStages(),
@@ -66,7 +68,7 @@ internal class ActionHandler
 
     public void ExecuteShortcuts(WindowContext? focusedWindow)
     {
-        if (focusedWindow != null && focusedWindow is MainWindowContext && (focusedWindow as MainWindowContext)!.IsDialogOpen) return;
+        if (focusedWindow != null && focusedWindow is MainWindowContext && ((focusedWindow as MainWindowContext)!.IsDialogOpen || (focusedWindow as MainWindowContext)!.FlyCamOn)) return;
         foreach (var (command, shortcut) in Actions.Values)
         {
             if ((shortcut?.IsTriggered() ?? false) && command.Enabled(focusedWindow))
@@ -502,6 +504,34 @@ internal class ActionHandler
                 window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.IsSceneFocused ,
             Command.CommandCategory.Selection
         );
+
+    private Command ToggleFlyCam() => 
+        new(
+        displayName: "Toggle fly cam",
+        action: window =>
+        {
+            if (window is not MainWindowContext mainContext)
+                return;
+            mainContext.ToggleFlyCam();
+        },
+        enabled: window =>
+            window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.IsSceneFocused ,
+        Command.CommandCategory.General
+    );
+
+    private Command SearchObj() => 
+        new(
+        displayName: "Search Objects",
+        action: window =>
+        {
+            if (window is not MainWindowContext mainContext)
+                return;
+            mainContext.OpenSearchDialog();
+        },
+        enabled: window =>
+            window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.IsSceneFocused ,
+        Command.CommandCategory.Selection
+    );
 
 #region Scene Transform Actions
     private static Command TranslateObj() =>

--- a/Autumn/ActionSystem/ActionHandler.cs
+++ b/Autumn/ActionSystem/ActionHandler.cs
@@ -501,7 +501,7 @@ internal class ActionHandler
                     mainContext.CurrentScene!.SelectAllObjects();
             },
             enabled: window =>
-                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.IsSceneFocused ,
+                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.IsSceneFocused && !mainContext.IsTransformActive,
             Command.CommandCategory.Selection
         );
 

--- a/Autumn/ActionSystem/ActionHandler.cs
+++ b/Autumn/ActionSystem/ActionHandler.cs
@@ -39,7 +39,7 @@ internal class ActionHandler
                 CommandID.Undo => Undo(),
                 CommandID.Redo => Redo(),
                 CommandID.GotoRelative => GotoRelative(),
-                CommandID.UnselectAll => UnselectAll(),
+                CommandID.ToggleSelectAll => ToggleSelectAll(),
                 CommandID.TranslateObj => TranslateObj(),
                 CommandID.RotateObj => RotateObj(),
                 CommandID.ScaleObj => ScaleObj(),
@@ -485,9 +485,20 @@ internal class ActionHandler
                 window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.IsSceneFocused,
             Command.CommandCategory.Selection
         );
+    private static Command ToggleSelectAll() =>
+        new(
+            displayName: "Toggle selection for all objects",
+            action: window =>
+            {
+                if (window is not MainWindowContext mainContext)
+                    return;
+                if (mainContext.CurrentScene!.SelectedObjCount > 0)
+                    mainContext.CurrentScene!.UnselectAllObjects();
+                else
+                    mainContext.CurrentScene!.SelectAllObjects();
             },
             enabled: window =>
-                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjects.Any() && mainContext.IsSceneFocused,
+                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.IsSceneFocused ,
             Command.CommandCategory.Selection
         );
 

--- a/Autumn/ActionSystem/ActionHandler.cs
+++ b/Autumn/ActionSystem/ActionHandler.cs
@@ -35,6 +35,7 @@ internal class ActionHandler
                 CommandID.RemoveObj => RemoveObj(),
                 CommandID.DuplicateObj => DuplicateObj(),
                 CommandID.HideObj => HideObj(),
+                CommandID.ShowAllObjs => ShowAllObjs(),
                 CommandID.Undo => Undo(),
                 CommandID.Redo => Redo(),
                 CommandID.GotoRelative => GotoRelative(),
@@ -396,7 +397,7 @@ internal class ActionHandler
             enabled: window =>
                 window is MainWindowContext mainContext
                 && mainContext.CurrentScene is not null
-                && mainContext.CurrentScene.SelectedObjects.Any()
+                && mainContext.CurrentScene.SelectedObjCount > 0
                 && !mainContext.IsTransformActive,
             Command.CommandCategory.Selection
         );
@@ -436,7 +437,7 @@ internal class ActionHandler
             enabled: window =>
                 window is MainWindowContext mainContext
                 && mainContext.CurrentScene is not null
-                && mainContext.CurrentScene.SelectedObjects.Any()
+                && mainContext.CurrentScene.SelectedObjCount > 0
                 && !mainContext.IsTransformActive,
             Command.CommandCategory.Selection
         );
@@ -466,18 +467,24 @@ internal class ActionHandler
                 ChangeHandler.ChangeHideMultiple(mainContext.CurrentScene!.History, mainContext.CurrentScene.SelectedObjects);
             },
             enabled: window =>
-                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjects.Any() && mainContext.IsSceneFocused,
+                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjCount > 0 && mainContext.IsSceneFocused,
             Command.CommandCategory.Selection
         );
-    private static Command UnselectAll() =>
+    private static Command ShowAllObjs() =>
         new(
-            displayName: "Unselect all objects",
+            displayName: "Show all hidden objects",
             action: window =>
             {
                 if (window is not MainWindowContext mainContext)
                     return;
-
-                mainContext.CurrentScene!.UnselectAllObjects();
+                List<ISceneObj> changes = mainContext.CurrentScene!.EnumerateSceneObjs().Where(x => !x.IsVisible).ToList();
+                if (changes.Count > 0)
+                    ChangeHandler.ChangeHideMultiple(mainContext.CurrentScene!.History, changes);
+            },
+            enabled: window =>
+                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.IsSceneFocused,
+            Command.CommandCategory.Selection
+        );
             },
             enabled: window =>
                 window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjects.Any() && mainContext.IsSceneFocused,
@@ -497,7 +504,7 @@ internal class ActionHandler
                 else mainContext.FinishTransform();
             },
             enabled: window =>
-                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjects.Any() 
+                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjCount > 0 
                 && mainContext.IsSceneFocused && (mainContext.SceneTranslating != mainContext.IsSceneHovered)
                 && !ImGui.GetIO().WantTextInput && !mainContext.SceneScaling && !mainContext.SceneRotating,
             Command.CommandCategory.Transform
@@ -512,7 +519,7 @@ internal class ActionHandler
                 mainContext.MoveToPoint();
             },
             enabled: window =>
-                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjects.Any() && mainContext.IsSceneHovered
+                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjCount > 0 && mainContext.IsSceneHovered
                 && !ImGui.GetIO().WantTextInput && !mainContext.SceneScaling && !mainContext.SceneRotating && !mainContext.SceneTranslating,
             Command.CommandCategory.Transform
         );
@@ -528,7 +535,7 @@ internal class ActionHandler
                 else mainContext.FinishTransform();
             },
             enabled: window =>
-                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjects.Any() 
+                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjCount > 0
                 && mainContext.IsSceneFocused && (mainContext.SceneRotating != mainContext.IsSceneHovered)
                 && !ImGui.GetIO().WantTextInput && !mainContext.SceneScaling && !mainContext.SceneTranslating,
             Command.CommandCategory.Transform
@@ -545,7 +552,7 @@ internal class ActionHandler
                 else mainContext.FinishTransform();
             },
             enabled: window =>
-                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjects.Any() 
+                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjCount > 0
                 && mainContext.IsSceneFocused && (mainContext.SceneScaling != mainContext.IsSceneHovered)
                 && !ImGui.GetIO().WantTextInput && !mainContext.SceneTranslating && !mainContext.SceneRotating,
             Command.CommandCategory.Transform
@@ -571,7 +578,7 @@ internal class ActionHandler
 
             },
             enabled: window =>
-                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjects.Any() && mainContext.IsSceneFocused
+                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjCount > 0 && mainContext.IsSceneFocused
                 && (mainContext.CurrentScene.SelectedObjects.First() is RailSceneObj || mainContext.CurrentScene.SelectedObjects.First() is RailPointSceneObj),
             Command.CommandCategory.Rail
         );    
@@ -585,7 +592,7 @@ internal class ActionHandler
                 mainContext.CameraToObject();
             },
             enabled: window =>
-                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjects.Any() && mainContext.IsSceneFocused,
+                window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjCount > 0 && mainContext.IsSceneFocused,
             Command.CommandCategory.Selection
         );
     private Command ShowHandles() =>

--- a/Autumn/ActionSystem/ActionHandler.cs
+++ b/Autumn/ActionSystem/ActionHandler.cs
@@ -505,7 +505,7 @@ internal class ActionHandler
             Command.CommandCategory.Selection
         );
 
-    private Command ToggleFlyCam() => 
+    private static Command ToggleFlyCam() => 
         new(
         displayName: "Toggle fly cam",
         action: window =>
@@ -519,9 +519,9 @@ internal class ActionHandler
         Command.CommandCategory.General
     );
 
-    private Command SearchObj() => 
+    private static Command SearchObj() => 
         new(
-        displayName: "Search Objects",
+        displayName: "Search",
         action: window =>
         {
             if (window is not MainWindowContext mainContext)
@@ -602,7 +602,7 @@ internal class ActionHandler
 
 #endregion
     
-    private Command AddRailPoint() =>
+    private static Command AddRailPoint() =>
         new(
             displayName: "Add point to the selected rail",
             action: window =>
@@ -624,7 +624,7 @@ internal class ActionHandler
                 && (mainContext.CurrentScene.SelectedObjects.First() is RailSceneObj || mainContext.CurrentScene.SelectedObjects.First() is RailPointSceneObj),
             Command.CommandCategory.Rail
         );    
-    private Command CamToObj() =>
+    private static Command CamToObj() =>
         new(
             displayName: "Move camera to object",
             action: window =>
@@ -637,7 +637,7 @@ internal class ActionHandler
                 window is MainWindowContext mainContext && mainContext.CurrentScene is not null && mainContext.CurrentScene.SelectedObjCount > 0 && mainContext.IsSceneFocused,
             Command.CommandCategory.Selection
         );
-    private Command ShowHandles() =>
+    private static Command ShowHandles() =>
         new(
             displayName: "Moves the handles from their origin",
             action: window =>
@@ -650,7 +650,7 @@ internal class ActionHandler
             Command.CommandCategory.Rail
         );
 
-    private Command GotoRelative() =>
+    private static Command GotoRelative() =>
         new(
             displayName: "Select Parent // First Child",
             action: window =>

--- a/Autumn/ActionSystem/ActionHandler.cs
+++ b/Autumn/ActionSystem/ActionHandler.cs
@@ -27,10 +27,10 @@ internal class ActionHandler
                 CommandID.OpenProject => OpenProject(),
                 CommandID.CloseProject => CloseProject(),
                 CommandID.OpenSettings => OpenSettings(),
-                CommandID.CloseScene => CloseScene(),
                 CommandID.Exit => Exit(),
                 CommandID.AddStage => AddStage(),
                 CommandID.SaveStage => SaveStage(),
+                CommandID.CloseCurrentStage => CloseCurrentStage(),
                 CommandID.AddObject => AddObj(),
                 CommandID.RemoveObj => RemoveObj(),
                 CommandID.DuplicateObj => DuplicateObj(),
@@ -322,7 +322,7 @@ internal class ActionHandler
             },
             enabled: window => window is MainWindowContext && window.ContextHandler.IsProjectLoaded
         );
-    private static Command CloseScene() =>
+    private static Command CloseCurrentStage() =>
         new(
             displayName: "Close Current Scene",
             action: window =>
@@ -330,7 +330,7 @@ internal class ActionHandler
                 if (window is not MainWindowContext mainWindow)
                     return;
 
-                mainWindow.CloseCurrentScene();
+                mainWindow.CloseStage(mainWindow.CurrentScene!);
             },
             enabled: window => window is MainWindowContext mainContext && mainContext.CurrentScene is not null
         );

--- a/Autumn/Autumn.csproj
+++ b/Autumn/Autumn.csproj
@@ -29,8 +29,21 @@
     <ProjectReference Include="..\Libraries\tinyfiledialogs\src\TinyFileDialogsSharp.csproj" />
   </ItemGroup>
 
+
+  <Target Name="CopyTasks" AfterTargets="Build">
+    <ItemGroup>
+      <DBFiles Include="$(MSBuildProjectDirectory)\Resources\RedPepper-ClassDataBase\Data\*"/>
+      <ModifierFiles Include="$(MSBuildProjectDirectory)\Resources\Autumn-ClassModifiers\Modifiers\*"/>
+      <Icons Include="$(MSBuildProjectDirectory)\Resources\Icons\*"/>
+      <Themes Include="$(MSBuildProjectDirectory)\Resources\Themes\*"/>
+    </ItemGroup>
+    <Copy SourceFiles="@(ModifierFiles)" DestinationFolder="$(OutDir)\Resources\Modifiers\" SkipUnchangedFiles="true"/>
+    <Copy SourceFiles="@(DBFiles)" DestinationFolder="$(OutDir)\Resources\ClassDB\" SkipUnchangedFiles="True"/>
+    <Copy SourceFiles="@(Icons)" DestinationFolder="$(OutDir)\Resources\Icons\" SkipUnchangedFiles="True"/>
+    <Copy SourceFiles="@(Themes)" DestinationFolder="$(OutDir)\Resources\Themes\" SkipUnchangedFiles="True"/>
+  </Target>
   <ItemGroup>
-    <Content Include="$(MSBuildProjectDirectory)\Resources\**" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" />
+    <Content Include="$(MSBuildProjectDirectory)\Resources\*" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="Always" DestinationFolder="$(OutDir)\Resources\"/>
   </ItemGroup>
 
 </Project>

--- a/Autumn/Background/GLTaskScheduler.cs
+++ b/Autumn/Background/GLTaskScheduler.cs
@@ -36,7 +36,7 @@ internal class GLTaskScheduler
         {
             if (!_glQueue.TryDequeue(out Action<GL>? glTask))
                 break;
-
+            if (glTask is null) { Console.WriteLine("GL TASK WAS NULL"); continue;}
             glTask(gl);
 
             if (Stopwatch.GetElapsedTime(startTime) >= delta)

--- a/Autumn/Context/SystemSettings.cs
+++ b/Autumn/Context/SystemSettings.cs
@@ -32,6 +32,9 @@ internal class SystemSettings
     public GizmoPosition GizmoPosition = GizmoPosition.First;
     public HoverInfoMode ShowHoverInfo;
     public Yaz0Wrapper.CompressionLevel Yaz0Compression;
+    public bool EXPERIMENTAL_PostProcess = true;
+    public bool EXPERIMENTAL_SelectionOutline = true;
+    public bool EXPERIMENTAL_ActorShadows = true;
 
     public SystemSettings() => Reset();
 

--- a/Autumn/Context/SystemSettings.cs
+++ b/Autumn/Context/SystemSettings.cs
@@ -28,6 +28,7 @@ internal class SystemSettings
     public bool EnableDBEditor;
     public bool[] VisibleDefaults = [];
     public bool ShowRelationLines;
+    public bool SaveReminder = true;
     public TransformGizmo LastGizmo = TransformGizmo.None;
     public GizmoPosition GizmoPosition = GizmoPosition.First;
     public HoverInfoMode ShowHoverInfo;
@@ -59,9 +60,11 @@ internal class SystemSettings
         ZoomToMouse = false;
         RememberLayout = true;
         EnableDBEditor = false;
+        SaveReminder = true;
         ShowRelationLines = true;
         ShowHoverInfo = HoverInfoMode.Disabled;
         Yaz0Compression = Yaz0Wrapper.CompressionLevel.Medium;
+        GizmoPosition = GizmoPosition.First;
 
         // Areas, CameraAreas, Rails, Grid, TransparentWall
         VisibleDefaults = [false, true, true, true, false];

--- a/Autumn/Enums/CommandID.cs
+++ b/Autumn/Enums/CommandID.cs
@@ -28,4 +28,6 @@ internal enum CommandID
     CamToObj,
     AddALL,
     SaveALL,
+    Search,
+    FlyCamMode,
 }

--- a/Autumn/Enums/CommandID.cs
+++ b/Autumn/Enums/CommandID.cs
@@ -18,7 +18,7 @@ internal enum CommandID
     HideObj,
     ShowAllObjs,
     GotoRelative,
-    UnselectAll,
+    ToggleSelectAll,
     TranslateObj,
     MoveToPoint,
     RotateObj,

--- a/Autumn/Enums/CommandID.cs
+++ b/Autumn/Enums/CommandID.cs
@@ -6,7 +6,7 @@ internal enum CommandID
     OpenProject,
     OpenSettings,
     CloseProject,
-    CloseScene,
+    CloseCurrentStage,
     Exit,
     AddStage,
     SaveStage,

--- a/Autumn/Enums/CommandID.cs
+++ b/Autumn/Enums/CommandID.cs
@@ -16,6 +16,7 @@ internal enum CommandID
     DuplicateObj,
     RemoveObj,
     HideObj,
+    ShowAllObjs,
     GotoRelative,
     UnselectAll,
     TranslateObj,

--- a/Autumn/Enums/GeneralEnums.cs
+++ b/Autumn/Enums/GeneralEnums.cs
@@ -26,3 +26,10 @@ internal enum GizmoPosition : byte
     First = 1,
     Last = 2,
 }
+
+internal enum ArgType
+{
+    Unknown = 0,
+    AnimChange = 1,
+    Tower = 2,
+}

--- a/Autumn/Enums/GeneralEnums.cs
+++ b/Autumn/Enums/GeneralEnums.cs
@@ -52,6 +52,10 @@ internal enum ArgType
     /// </summary>
     ScaleAxis,
     /// <summary>
+    /// Sets the Y scale of this actor's shadow 
+    /// </summary>
+    ShadowHeight,
+    /// <summary>
     /// Sets the type of block for this slot of the BlockDragon, when edited it checks for the other args to set the dragon length
     /// </summary>
     BlockDragonBlock,

--- a/Autumn/Enums/GeneralEnums.cs
+++ b/Autumn/Enums/GeneralEnums.cs
@@ -32,4 +32,15 @@ internal enum ArgType
     Unknown = 0,
     AnimChange = 1,
     Tower = 2,
+    /// <summary>
+    /// Number of balls per line
+    /// </summary>
+    RotateCoreCount = 3,
+    /// <summary>
+    /// Number of lines attached to the core
+    /// </summary>
+    RotateCoreSides = 4,
+
+    SwingCoreLength = 5,
+    AddExtraModel = 6,
 }

--- a/Autumn/Enums/GeneralEnums.cs
+++ b/Autumn/Enums/GeneralEnums.cs
@@ -43,6 +43,20 @@ internal enum ArgType
 
     SwingCoreLength,
     AddExtraModel,
+    /// <summary>
+    /// ShadowObj Model
+    /// </summary>
     ShadowType,
+    /// <summary>
+    /// ShadowObj Scale axis
+    /// </summary>
     ScaleAxis,
+    /// <summary>
+    /// Sets the type of block for this slot of the BlockDragon, when edited it checks for the other args to set the dragon length
+    /// </summary>
+    BlockDragonBlock,
+    /// <summary>
+    /// Sets the object's Y position 
+    /// </summary>
+    PicketHeight,
 }

--- a/Autumn/Enums/GeneralEnums.cs
+++ b/Autumn/Enums/GeneralEnums.cs
@@ -30,17 +30,19 @@ internal enum GizmoPosition : byte
 internal enum ArgType
 {
     Unknown = 0,
-    AnimChange = 1,
-    Tower = 2,
+    AnimChange,
+    Tower,
     /// <summary>
     /// Number of balls per line
     /// </summary>
-    RotateCoreCount = 3,
+    RotateCoreCount,
     /// <summary>
     /// Number of lines attached to the core
     /// </summary>
-    RotateCoreSides = 4,
+    RotateCoreSides,
 
-    SwingCoreLength = 5,
-    AddExtraModel = 6,
+    SwingCoreLength,
+    AddExtraModel,
+    ShadowType,
+    ScaleAxis,
 }

--- a/Autumn/Enums/GeneralEnums.cs
+++ b/Autumn/Enums/GeneralEnums.cs
@@ -64,3 +64,16 @@ internal enum ArgType
     /// </summary>
     PicketHeight,
 }
+
+public enum FSPath
+{
+    Root,
+    Actors,
+    Stages,
+    Sound,
+    Layout,
+    System,
+    CCNT,
+    Effect,
+    Localization   
+}

--- a/Autumn/Enums/H3DEnums.cs
+++ b/Autumn/Enums/H3DEnums.cs
@@ -7,3 +7,10 @@ internal enum H3DMeshLayer
     Subtractive = 2,
     Additive = 3
 }
+
+internal enum H3DAnimation
+{
+    SkeletalAnim = 0b1,
+    MaterialAnim = 0b10,
+    VisibilityAnim = 0b100,
+}

--- a/Autumn/Enums/H3DMeshLayer.cs
+++ b/Autumn/Enums/H3DMeshLayer.cs
@@ -4,6 +4,6 @@ internal enum H3DMeshLayer
 {
     Opaque = 0,
     Translucent = 1,
-    Substractive = 2,
+    Subtractive = 2,
     Additive = 3
 }

--- a/Autumn/FileSystems/LayeredFSHandler.cs
+++ b/Autumn/FileSystems/LayeredFSHandler.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using Autumn.Background;
 using Autumn.Storage;
+using Autumn.Wrappers;
 using NARCSharp;
 
 namespace Autumn.FileSystems;
@@ -45,6 +46,10 @@ internal class LayeredFSHandler
 
         return new();
     }
+    public void ReadActorExtras(string actorName, string className, Actor actor, GLTaskScheduler scheduler)
+    {
+        OriginalFS.ReadActorExtras(actorName, className, actor, scheduler);
+    }
 
     public Actor ReadActor(string name, GLTaskScheduler scheduler)
     {
@@ -56,100 +61,89 @@ internal class LayeredFSHandler
         return new(name);
     }
 
-    public Actor ReadActor(string name, string? fallback, GLTaskScheduler scheduler)
+    public Actor ReadActorNewL(string actorName, string actorClass, GLTaskScheduler scheduler)
     {
-        if (fallback is null)
-            return ReadActor(name, scheduler);
+        if (ModFS is not null && ModFS.ExistsActor(actorName))
+            return ModFS.ReadActorNew(actorName, actorClass, scheduler);
+        else if (OriginalFS is not null && OriginalFS.ExistsActor(actorName))
+            return OriginalFS.ReadActorNew(actorName, actorClass, scheduler);
 
-        var hasMod = ModFS != null;
-        var hasOg = OriginalFS != null;
-        if (hasMod)
-        {
-            if (!ModFS.ExistsActor(name))
-            {
-                if (hasOg && OriginalFS.ExistsActor(name))
-                    return OriginalFS.ReadActor(name, scheduler);
-                else
-                {
-                    if (ModFS.ExistsActor(fallback))
-                        return ModFS.ReadActor(fallback, scheduler);
-                    else if (hasOg && OriginalFS.ExistsActor(fallback))
-                        return OriginalFS.ReadActor(fallback, scheduler);
-                }
-            }
-            else
-                return ModFS.ReadActor(name, scheduler);
-        }
-
-        if (hasOg)
-        {
-            if (!OriginalFS.ExistsActor(name))
-            {
-                if (OriginalFS.ExistsActor(fallback))
-                    return OriginalFS.ReadActor(fallback, scheduler);
-            }
-            else
-                return OriginalFS.ReadActor(name, scheduler);
-        }
-
-        return new(name);
+        return new(actorName);
     }
-    public Actor ReadActor(string name, string? dbArchive, string? fallback, GLTaskScheduler scheduler)
+    public Actor ReadActorNew(string actorName, string? className, GLTaskScheduler scheduler)
     {
-        if (dbArchive == null && fallback == null) return ReadActor(name, scheduler);
-        else if (dbArchive == null) return ReadActor(name, fallback, scheduler);
-        else if (fallback == null) return ReadActor(name, dbArchive, scheduler);
-
+        if (className == null) return ReadActor(actorName, scheduler);
 
         var hasMod = ModFS != null;
         var hasOg = OriginalFS != null;
 
+        bool replacementVariants = ClassModifiersWrapper.ModifierEntries.ContainsKey(className) && ClassModifiersWrapper.ModifierEntries[className].Variants != null && ClassModifiersWrapper.ModifierEntries[className].Variants!.ContainsKey(actorName);
+        bool replacementDefault = ClassModifiersWrapper.ModifierEntries.ContainsKey(className) && ClassModifiersWrapper.ModifierEntries[className].Default != null;
+        bool replacementDatabase = ClassDatabaseWrapper.DatabaseEntries.ContainsKey(className) && ClassDatabaseWrapper.DatabaseEntries[className].ArchiveName != null;
+
+        if (replacementVariants) // if we specify stuff for this particular type of the actor
+        {
+            if (ClassModifiersWrapper.ModifierEntries[className].Variants![actorName]!.Value.ModelReplace != null) 
+            {
+                return ReadActorNewL(ClassModifiersWrapper.ModifierEntries[className].Variants![actorName]!.Value.ModelReplace!, className, scheduler);
+            }
+        }
+        if (replacementDefault) // if we don't specify stuff for this particular case, and we have a default 
+        {
+            if (ClassModifiersWrapper.ModifierEntries[className].Default!.Value.ModelReplace != null) 
+            {
+                return ReadActorNewL(ClassModifiersWrapper.ModifierEntries[className].Default!.Value.ModelReplace!, className,scheduler);
+            }
+        }
+
+        string dbArchiveReplacement = replacementDatabase ? ClassDatabaseWrapper.DatabaseEntries[className].ArchiveName! : "";
+
         if (hasMod)
         {
-            if (!ModFS.ExistsActor(dbArchive))
+            if (!ModFS.ExistsActor(dbArchiveReplacement))
             {
-                if (hasOg && OriginalFS.ExistsActor(dbArchive))
-                    return OriginalFS.ReadActor(dbArchive, scheduler);
+                if (hasOg && OriginalFS.ExistsActor(dbArchiveReplacement))
+                    return OriginalFS.ReadActorNew(dbArchiveReplacement, className, scheduler);
                 else
                 {
-                    if (!ModFS.ExistsActor(name))
+                    if (!ModFS.ExistsActor(actorName))
                     {
-                        if (hasOg && OriginalFS.ExistsActor(name))
-                            return OriginalFS.ReadActor(name, scheduler);
+                        if (hasOg && OriginalFS.ExistsActor(actorName))
+                            return OriginalFS.ReadActorNew(actorName, className, scheduler);
                         else
                         {
-                            if (!ModFS.ExistsActor(fallback))
+                            if (!ModFS.ExistsActor(className))
                             {
-                                if (hasOg && OriginalFS.ExistsActor(fallback))
-                                    return OriginalFS.ReadActor(fallback, scheduler);
+                                if (hasOg && OriginalFS.ExistsActor(className))
+                                    return OriginalFS.ReadActorNew(className, className, scheduler);
                             }
                             else
-                                return ModFS.ReadActor(fallback, scheduler);
+                                return ModFS.ReadActorNew(className, className, scheduler);
                         }
                     }
                     else
-                        return ModFS.ReadActor(name, scheduler);
+                        return ModFS.ReadActorNew(actorName, className, scheduler);
                 }
             }
             else
-                return ModFS.ReadActor(dbArchive, scheduler);
+                return ModFS.ReadActorNew(dbArchiveReplacement, className, scheduler);
         }
         if (hasOg)
         {
-            if (!OriginalFS!.ExistsActor(dbArchive))
+            if (!OriginalFS!.ExistsActor(dbArchiveReplacement))
             {
-                if (!OriginalFS.ExistsActor(name))
+                if (!OriginalFS.ExistsActor(actorName))
                 {
-                    if (OriginalFS.ExistsActor(fallback))
-                        return OriginalFS.ReadActor(fallback, scheduler);
+                    if (OriginalFS.ExistsActor(className))
+                        return OriginalFS.ReadActorNew(className, className, scheduler);
                 }
                 else
-                    return OriginalFS.ReadActor(name, scheduler);
+                    return OriginalFS.ReadActorNew(actorName, className, scheduler);
             }
             else
-                return OriginalFS.ReadActor(dbArchive, scheduler);
+                return OriginalFS.ReadActorNew(dbArchiveReplacement, className, scheduler);
         }
-        return new(name);
+        return new(actorName);
     }
 
     public bool WriteStage(Stage stage, bool _useClassNames)

--- a/Autumn/FileSystems/LayeredFSHandler.cs
+++ b/Autumn/FileSystems/LayeredFSHandler.cs
@@ -90,9 +90,9 @@ internal class LayeredFSHandler
 
         if (replacementVariants) // if we specify stuff for this particular type of the actor
         {
-            if (ClassModifiersWrapper.ModifierEntries[className].Variants![actorName]!.Value.ModelReplace != null) 
+            if (ClassModifiersWrapper.ModifierEntries[className].Variants![actorName]!.ModelReplace != null) 
             {
-                return ReadActorNew(actorName, ClassModifiersWrapper.ModifierEntries[className].Variants![actorName]!.Value.ModelReplace!, className, scheduler);
+                return ReadActorNew(actorName, ClassModifiersWrapper.ModifierEntries[className].Variants![actorName]!.ModelReplace!, className, scheduler);
             }
         }
         if (replacementDefault) // if we don't specify stuff for this particular case, and we have a default 

--- a/Autumn/FileSystems/LayeredFSHandler.cs
+++ b/Autumn/FileSystems/LayeredFSHandler.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using Autumn.Background;
+using Autumn.Rendering.Storage;
 using Autumn.Storage;
 using Autumn.Wrappers;
 using NARCSharp;
@@ -46,9 +47,15 @@ internal class LayeredFSHandler
 
         return new();
     }
-    public void ReadActorExtras(string actorName, string className, Actor actor, GLTaskScheduler scheduler)
+    
+    #warning TODO -> NEEDS REFACTOR MAKE IT READ FROM EITHER FILESYSTEM
+    public void ReadActorExtras(string actorName, string className, ActorSceneObj actor, GLTaskScheduler scheduler)
     {
         OriginalFS.ReadActorExtras(actorName, className, actor, scheduler);
+    }
+    public Actor? ReadActorExtrasArg(string subActorName, GLTaskScheduler scheduler)
+    {
+        return OriginalFS.ReadActorExtrasArg(subActorName, scheduler);
     }
 
     public Actor ReadActor(string name, GLTaskScheduler scheduler)

--- a/Autumn/FileSystems/LayeredFSHandler.cs
+++ b/Autumn/FileSystems/LayeredFSHandler.cs
@@ -61,12 +61,12 @@ internal class LayeredFSHandler
         return new(name);
     }
 
-    public Actor ReadActorNewL(string actorName, string actorClass, GLTaskScheduler scheduler)
+    public Actor ReadActorNew(string actorName, string baseModelName, string actorClass, GLTaskScheduler scheduler)
     {
-        if (ModFS is not null && ModFS.ExistsActor(actorName))
-            return ModFS.ReadActorNew(actorName, actorClass, scheduler);
-        else if (OriginalFS is not null && OriginalFS.ExistsActor(actorName))
-            return OriginalFS.ReadActorNew(actorName, actorClass, scheduler);
+        if (ModFS is not null && ModFS.ExistsActor(baseModelName))
+            return ModFS.ReadActorNew(actorName, baseModelName, actorClass, scheduler);
+        else if (OriginalFS is not null && OriginalFS.ExistsActor(baseModelName))
+            return OriginalFS.ReadActorNew(actorName, baseModelName, actorClass, scheduler);
 
         return new(actorName);
     }
@@ -85,14 +85,14 @@ internal class LayeredFSHandler
         {
             if (ClassModifiersWrapper.ModifierEntries[className].Variants![actorName]!.Value.ModelReplace != null) 
             {
-                return ReadActorNewL(ClassModifiersWrapper.ModifierEntries[className].Variants![actorName]!.Value.ModelReplace!, className, scheduler);
+                return ReadActorNew(actorName, ClassModifiersWrapper.ModifierEntries[className].Variants![actorName]!.Value.ModelReplace!, className, scheduler);
             }
         }
         if (replacementDefault) // if we don't specify stuff for this particular case, and we have a default 
         {
             if (ClassModifiersWrapper.ModifierEntries[className].Default!.Value.ModelReplace != null) 
             {
-                return ReadActorNewL(ClassModifiersWrapper.ModifierEntries[className].Default!.Value.ModelReplace!, className,scheduler);
+                return ReadActorNew(actorName, ClassModifiersWrapper.ModifierEntries[className].Default!.Value.ModelReplace!, className, scheduler);
             }
         }
 
@@ -103,30 +103,30 @@ internal class LayeredFSHandler
             if (!ModFS.ExistsActor(dbArchiveReplacement))
             {
                 if (hasOg && OriginalFS.ExistsActor(dbArchiveReplacement))
-                    return OriginalFS.ReadActorNew(dbArchiveReplacement, className, scheduler);
+                    return OriginalFS.ReadActorNew(actorName, dbArchiveReplacement, className, scheduler);
                 else
                 {
                     if (!ModFS.ExistsActor(actorName))
                     {
                         if (hasOg && OriginalFS.ExistsActor(actorName))
-                            return OriginalFS.ReadActorNew(actorName, className, scheduler);
+                            return OriginalFS.ReadActorNew(actorName, actorName, className, scheduler);
                         else
                         {
                             if (!ModFS.ExistsActor(className))
                             {
                                 if (hasOg && OriginalFS.ExistsActor(className))
-                                    return OriginalFS.ReadActorNew(className, className, scheduler);
+                                    return OriginalFS.ReadActorNew(actorName, className, className, scheduler);
                             }
                             else
-                                return ModFS.ReadActorNew(className, className, scheduler);
+                                return ModFS.ReadActorNew(actorName, className, className, scheduler);
                         }
                     }
                     else
-                        return ModFS.ReadActorNew(actorName, className, scheduler);
+                        return ModFS.ReadActorNew(actorName, actorName, className, scheduler);
                 }
             }
             else
-                return ModFS.ReadActorNew(dbArchiveReplacement, className, scheduler);
+                return ModFS.ReadActorNew(actorName, dbArchiveReplacement, className, scheduler);
         }
         if (hasOg)
         {
@@ -135,13 +135,13 @@ internal class LayeredFSHandler
                 if (!OriginalFS.ExistsActor(actorName))
                 {
                     if (OriginalFS.ExistsActor(className))
-                        return OriginalFS.ReadActorNew(className, className, scheduler);
+                        return OriginalFS.ReadActorNew(actorName, className, className, scheduler);
                 }
                 else
-                    return OriginalFS.ReadActorNew(actorName, className, scheduler);
+                    return OriginalFS.ReadActorNew(actorName, actorName, className, scheduler);
             }
             else
-                return OriginalFS.ReadActorNew(dbArchiveReplacement, className, scheduler);
+                return OriginalFS.ReadActorNew(actorName, dbArchiveReplacement, className, scheduler);
         }
         return new(actorName);
     }

--- a/Autumn/FileSystems/LayeredFSHandler.cs
+++ b/Autumn/FileSystems/LayeredFSHandler.cs
@@ -117,28 +117,28 @@ internal class LayeredFSHandler
         return FS.ReadActorExtrasArg(subActorName, ex, scheduler);
     }
 
-    public Actor ReadActor(string name, GLTaskScheduler scheduler)
+    public Actor ReadActorBasic(string name, GLTaskScheduler scheduler)
     {
         if (ModFS is not null && ModFS.ExistsActor(name))
-            return ModFS.ReadActor(name, scheduler);
+            return ModFS.ReadActorBasic(name, scheduler);
         else if (OriginalFS is not null && OriginalFS.ExistsActor(name))
-            return OriginalFS.ReadActor(name, scheduler);
+            return OriginalFS.ReadActorBasic(name, scheduler);
 
         return new(name);
     }
 
-    public Actor ReadActorNew(string actorName, string baseModelName, string actorClass, GLTaskScheduler scheduler)
+    public Actor ReadActorBaseModelReplace(string actorName, string baseModelName, string actorClass, GLTaskScheduler scheduler)
     {
         if (ModFS is not null && ModFS.ExistsActor(baseModelName))
-            return ModFS.ReadActorNew(actorName, baseModelName, actorClass, scheduler);
+            return ModFS.ReadKnownActor(actorName, baseModelName, actorClass, scheduler);
         else if (OriginalFS is not null && OriginalFS.ExistsActor(baseModelName))
-            return OriginalFS.ReadActorNew(actorName, baseModelName, actorClass, scheduler);
+            return OriginalFS.ReadKnownActor(actorName, baseModelName, actorClass, scheduler);
 
         return new(actorName);
     }
-    public Actor ReadActorNew(string actorName, string? className, GLTaskScheduler scheduler)
+    public Actor ReadActor(string actorName, string? className, GLTaskScheduler scheduler)
     {
-        if (className == null) return ReadActor(actorName, scheduler);
+        if (className == null) return ReadActorBasic(actorName, scheduler);
 
         var hasMod = ModFS != null;
         var hasOg = OriginalFS != null;
@@ -151,14 +151,14 @@ internal class LayeredFSHandler
         {
             if (ClassModifiersWrapper.ModifierEntries[className].Variants![actorName]!.ModelReplace != null) 
             {
-                return ReadActorNew(actorName, ClassModifiersWrapper.ModifierEntries[className].Variants![actorName]!.ModelReplace!, className, scheduler);
+                return ReadActorBaseModelReplace(actorName, ClassModifiersWrapper.ModifierEntries[className].Variants![actorName]!.ModelReplace!, className, scheduler);
             }
         }
         if (replacementDefault) // if we don't specify stuff for this particular case, and we have a default 
         {
             if (ClassModifiersWrapper.ModifierEntries[className].Default!.Value.ModelReplace != null) 
             {
-                return ReadActorNew(actorName, ClassModifiersWrapper.ModifierEntries[className].Default!.Value.ModelReplace!, className, scheduler);
+                return ReadActorBaseModelReplace(actorName, ClassModifiersWrapper.ModifierEntries[className].Default!.Value.ModelReplace!, className, scheduler);
             }
         }
 
@@ -169,30 +169,30 @@ internal class LayeredFSHandler
             if (!ModFS.ExistsActor(dbArchiveReplacement))
             {
                 if (hasOg && OriginalFS.ExistsActor(dbArchiveReplacement))
-                    return OriginalFS.ReadActorNew(actorName, dbArchiveReplacement, className, scheduler);
+                    return OriginalFS.ReadKnownActor(actorName, dbArchiveReplacement, className, scheduler);
                 else
                 {
                     if (!ModFS.ExistsActor(actorName))
                     {
                         if (hasOg && OriginalFS.ExistsActor(actorName))
-                            return OriginalFS.ReadActorNew(actorName, actorName, className, scheduler);
+                            return OriginalFS.ReadKnownActor(actorName, actorName, className, scheduler);
                         else
                         {
                             if (!ModFS.ExistsActor(className))
                             {
                                 if (hasOg && OriginalFS.ExistsActor(className))
-                                    return OriginalFS.ReadActorNew(actorName, className, className, scheduler);
+                                    return OriginalFS.ReadKnownActor(actorName, className, className, scheduler);
                             }
                             else
-                                return ModFS.ReadActorNew(actorName, className, className, scheduler);
+                                return ModFS.ReadKnownActor(actorName, className, className, scheduler);
                         }
                     }
                     else
-                        return ModFS.ReadActorNew(actorName, actorName, className, scheduler);
+                        return ModFS.ReadKnownActor(actorName, actorName, className, scheduler);
                 }
             }
             else
-                return ModFS.ReadActorNew(actorName, dbArchiveReplacement, className, scheduler);
+                return ModFS.ReadKnownActor(actorName, dbArchiveReplacement, className, scheduler);
         }
         if (hasOg)
         {
@@ -201,13 +201,13 @@ internal class LayeredFSHandler
                 if (!OriginalFS.ExistsActor(actorName))
                 {
                     if (OriginalFS.ExistsActor(className))
-                        return OriginalFS.ReadActorNew(actorName, className, className, scheduler);
+                        return OriginalFS.ReadKnownActor(actorName, className, className, scheduler);
                 }
                 else
-                    return OriginalFS.ReadActorNew(actorName, actorName, className, scheduler);
+                    return OriginalFS.ReadKnownActor(actorName, actorName, className, scheduler);
             }
             else
-                return OriginalFS.ReadActorNew(actorName, dbArchiveReplacement, className, scheduler);
+                return OriginalFS.ReadKnownActor(actorName, dbArchiveReplacement, className, scheduler);
         }
         return new(actorName);
     }

--- a/Autumn/FileSystems/LayeredFSHandler.cs
+++ b/Autumn/FileSystems/LayeredFSHandler.cs
@@ -1,9 +1,18 @@
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using Autumn.Background;
+using Autumn.Enums;
 using Autumn.Rendering.Storage;
 using Autumn.Storage;
 using Autumn.Wrappers;
 using NARCSharp;
+using SPICA.Formats.CtrGfx;
+using SPICA.Formats.CtrH3D;
+using SPICA.Formats.CtrH3D.LUT;
+using SPICA.Formats.CtrH3D.Model;
+using SPICA.Formats.CtrH3D.Model.Material;
+using SPICA.Formats.CtrH3D.Model.Mesh;
+using SPICA.Formats.CtrH3D.Texture;
 
 namespace Autumn.FileSystems;
 
@@ -47,15 +56,65 @@ internal class LayeredFSHandler
 
         return new();
     }
-    
-    #warning TODO -> NEEDS REFACTOR MAKE IT READ FROM EITHER FILESYSTEM
+
     public void ReadActorExtras(string actorName, string className, ActorSceneObj actor, GLTaskScheduler scheduler)
     {
-        OriginalFS.ReadActorExtras(actorName, className, actor, scheduler);
+        if (ClassModifiersWrapper.ModifierEntries.ContainsKey(className))
+        {
+            ClassModifiersWrapper.ModifierEntry act;
+            if (ClassModifiersWrapper.ModifierEntries[className].Variants != null && ClassModifiersWrapper.ModifierEntries[className].Variants!.ContainsKey(actorName))
+            {
+                act = ClassModifiersWrapper.ModifierEntries[className].Variants![actorName]!;
+            }
+            else if (ClassModifiersWrapper.ModifierEntries[className].Default != null)
+            {
+                act = ClassModifiersWrapper.ModifierEntries[className].Default!.Value;
+            }
+            else return;
+            
+            if (act.ExtraModels != null)
+            {
+                foreach (string s in act.ExtraModels!.Keys)
+                {
+                    string ex;
+                    RomFSHandler? FS;
+                    if (ModFS != null && File.Exists(Path.Join(ModFS.GetPath(FSPath.Actors), s + ".szs")))
+                    {
+                        FS = ModFS;
+                    }
+                    else if (OriginalFS != null && File.Exists(Path.Join(OriginalFS.GetPath(FSPath.Actors), s + ".szs")))
+                    {
+                        FS = OriginalFS;
+                    }
+                    else continue;
+                    ex = Path.Join(FS.GetPath(FSPath.Actors), s + ".szs");
+                    if(FS.CachedActors.ContainsKey(s))
+                    {
+                        actor.SubActors.Add(FS.CachedActors[s]);
+                        continue;
+                    }
+                    FS.ReadActorExtras(s, ex, actor, scheduler);
+                }
+            }
+        }
     }
     public Actor? ReadActorExtrasArg(string subActorName, GLTaskScheduler scheduler)
     {
-        return OriginalFS.ReadActorExtrasArg(subActorName, scheduler);
+        string ex;
+        RomFSHandler? FS;
+        if (ModFS != null && File.Exists(Path.Join(ModFS.GetPath(FSPath.Actors), subActorName + ".szs")))
+        {
+            FS = ModFS;
+        }
+        else if (OriginalFS != null && File.Exists(Path.Join(OriginalFS.GetPath(FSPath.Actors), subActorName + ".szs")))
+        {
+            FS = OriginalFS;
+        }
+        else return null;
+        ex = Path.Join(FS.GetPath(FSPath.Actors), subActorName + ".szs");
+        if (FS.CachedActors.ContainsKey(subActorName))
+            return FS.CachedActors[subActorName];
+        return FS.ReadActorExtrasArg(subActorName, ex, scheduler);
     }
 
     public Actor ReadActor(string name, GLTaskScheduler scheduler)

--- a/Autumn/FileSystems/RomFSHandler.cs
+++ b/Autumn/FileSystems/RomFSHandler.cs
@@ -631,9 +631,9 @@ internal partial class RomFSHandler
             }
 
         List<string> hidden = new();
-        if (replacementVariants && ClassModifiersWrapper.ModifierEntries[actorClass].Variants![actorName]!.Value.HiddenMeshes != null)
+        if (replacementVariants && ClassModifiersWrapper.ModifierEntries[actorClass].Variants![actorName]!.HiddenMeshes != null)
         {
-            hidden = ClassModifiersWrapper.ModifierEntries[actorClass].Variants![actorName]!.Value.HiddenMeshes!;
+            hidden = ClassModifiersWrapper.ModifierEntries[actorClass].Variants![actorName]!.HiddenMeshes!;
         }
         else if (replacementDefault && ClassModifiersWrapper.ModifierEntries[actorClass].Default!.Value.HiddenMeshes != null)
         {
@@ -707,7 +707,7 @@ internal partial class RomFSHandler
             ClassModifiersWrapper.ModifierEntry act;
             if (ClassModifiersWrapper.ModifierEntries[actorClass].Variants != null && ClassModifiersWrapper.ModifierEntries[actorClass].Variants.ContainsKey(actorName))
             {
-                act = ClassModifiersWrapper.ModifierEntries[actorClass].Variants![actorName]!.Value;
+                act = ClassModifiersWrapper.ModifierEntries[actorClass].Variants![actorName]!;
             }
             else if (ClassModifiersWrapper.ModifierEntries[actorClass].Default != null)
             {

--- a/Autumn/FileSystems/RomFSHandler.cs
+++ b/Autumn/FileSystems/RomFSHandler.cs
@@ -547,10 +547,254 @@ internal partial class RomFSHandler
         }
 
         // Cache the actor
+        if (!_cachedActors.ContainsKey(path))
+        {
+            _cachedActors.Add(path, actor);
+            _cachedActorsTimestamps.Add(path, File.GetLastWriteTime(path));
+        }
+        else // if we edited the actor between scenes
+        {
+            _cachedActors[path] = actor;
+            _cachedActorsTimestamps[path] = File.GetLastWriteTime(path);
+        }
+
+        return actor;
+    }
+
+    public Actor ReadActorNew(string actorName, string actorClass, GLTaskScheduler scheduler)
+    {
+        string path = Path.Join(_actorsPath, actorName + ".szs");
+
+        // Return cached actor if valid (not modified externally)
+        if (_cachedActors.TryGetValue(path, out Actor? cachedActor))
+        {
+            DateTime timestamp = File.GetLastWriteTime(path);
+
+            if (_cachedActorsTimestamps.TryGetValue(path, out DateTime oldTimestamp) && oldTimestamp == timestamp)
+                return cachedActor;
+        }
+
+        Actor actor = new(actorName);
+
+        bool replacementVariants = ClassModifiersWrapper.ModifierEntries.ContainsKey(actorClass) && ClassModifiersWrapper.ModifierEntries[actorClass].Variants != null && ClassModifiersWrapper.ModifierEntries[actorClass].Variants!.ContainsKey(actorName);
+        bool replacementDefault = ClassModifiersWrapper.ModifierEntries.ContainsKey(actorClass) && ClassModifiersWrapper.ModifierEntries[actorClass].Default != null;
+        //ClassModifiersWrapper.ModifierEntries[actorClass].Variants[actorName].Value.HiddenMeshes        
+
+        // The actor will result in an empty model if the narc is null (not found or
+        // not a narc) or if the narc does not contain the properly-named cgfx file.
+
+        if (!File.Exists(path))
+            return actor;
+
+        NARCFileSystem? narc = SZSWrapper.ReadFile(path);
+
+        if (narc is null)
+            return actor;
+
+        bool found = narc.TryGetFile(actorName + ".bcmdl", out byte[] cgfx);
+
+        if (!found)
+            return actor;
+
+        if (narc.TryGetFile("InitLight.byml", out byte[] light))
+        {
+            BYAML act_lights = BYAMLParser.Read(light, s_byamlEncoding);
+            if (act_lights.RootNode.NodeType == BYAMLNodeType.Dictionary)
+            {
+                var lrt = act_lights.RootNode.GetValueAs<Dictionary<string, BYAMLNode>>();
+                if (lrt!.ContainsKey("LightCalcType"))
+                    actor.InitLight.GetCalcType((string)lrt["LightCalcType"].Value!);
+                if (lrt!.ContainsKey("LightType"))
+                    actor.InitLight.GetType((string)lrt["LightType"].Value!);
+            }
+        }
+
+        H3D h3D;
+
+        try
+        {
+            using MemoryStream stream = new(cgfx);
+            h3D = Gfx.OpenAsH3D(stream);
+        }
+        catch
+        {
+            Debug.Write($"The actor's cgfx could not be read ({actorName})", "Error");
+            return actor;
+        }
+
+        foreach (H3DTexture texture in h3D.Textures)
+        {
+            scheduler.EnqueueGLTask(gl => actor.AddTexture(gl, texture));
+        }
+
+        foreach (H3DLUT lut in h3D.LUTs)
+            foreach (H3DLUTSampler sampler in lut.Samplers)
+            {
+                scheduler.EnqueueGLTask(gl => actor.AddLUTTexture(gl, lut.Name, sampler));
+            }
+
+        List<string> hidden = new();
+        if (replacementVariants && ClassModifiersWrapper.ModifierEntries[actorClass].Variants![actorName]!.Value.HiddenMeshes != null)
+        {
+            hidden = ClassModifiersWrapper.ModifierEntries[actorClass].Variants![actorName]!.Value.HiddenMeshes!;
+        }
+        else if (replacementDefault && ClassModifiersWrapper.ModifierEntries[actorClass].Default!.Value.HiddenMeshes != null)
+        {
+            hidden = ClassModifiersWrapper.ModifierEntries[actorClass].Default!.Value.HiddenMeshes!;
+        }
+
+        foreach (H3DModel model in h3D.Models)
+        {
+            List<H3DMesh>[] meshLists =
+            [
+                model.MeshesLayer0, // Opaque layer
+                model.MeshesLayer1, // Translucent layer
+                model.MeshesLayer2, // Subtractive layer
+                model.MeshesLayer3 // Additive layer
+            ];
+
+
+            for (int i = 0; i < meshLists.Length; i++)
+            {
+
+                foreach (H3DMesh mesh in meshLists[i])
+                {
+                    if (hidden.Contains(mesh.Name)) continue;
+                    actor.ForceModelNotEmpty();
+                    // Obtain the mesh's material by its index.
+                    int matIdx = mesh.MaterialIndex;
+                    H3DMaterial material = model.Materials[matIdx];
+
+                    // Obtain submesh culling.
+                    int meshIdx = model.Meshes.IndexOf(mesh);
+
+                    H3DSubMeshCulling? subMeshCulling = null;
+
+                    if (model.SubMeshCullings.Count > meshIdx)
+                        subMeshCulling = model.SubMeshCullings[meshIdx];
+
+                    var skeleton = model.Skeleton;
+
+                    H3DMeshLayer meshLayer = (H3DMeshLayer)i;
+
+                    scheduler.EnqueueGLTask(gl =>
+                        actor.AddMesh(gl, meshLayer, mesh, subMeshCulling, material, skeleton)
+                    );
+
+                    if (mesh.MetaData is not null)
+                    {
+                        for (int m = 0; m < mesh.MetaData.Count; m++)
+                        {
+                            if (mesh.MetaData[m].Name == "OBBox")
+                            {    
+                                actor.AABB.BoundBox((H3DBoundingBox)mesh.MetaData[m].Values[0]!);
+                                actor.AABB.Center += ((H3DBoundingBox)mesh.MetaData[m].Values[0]!).Center;
+                            }
+                        }
+                    }
+                    //actor.AABB.Center += mesh.MeshCenter;
+                }
+            }
+            //actor.AABB.Center /= meshLists.Length;
+        }
+
+        // Cache the actor
         _cachedActors.Add(path, actor);
         _cachedActorsTimestamps.Add(path, File.GetLastWriteTime(path));
 
         return actor;
+    }
+
+    public void ReadActorExtras(string actorName, string actorClass, Actor actor, GLTaskScheduler scheduler)
+    {
+        if (ClassModifiersWrapper.ModifierEntries.ContainsKey(actorClass))
+        {
+            ClassModifiersWrapper.ModifierEntry act;
+            if (ClassModifiersWrapper.ModifierEntries[actorClass].Variants != null && ClassModifiersWrapper.ModifierEntries[actorClass].Variants.ContainsKey(actorName))
+            {
+                act = ClassModifiersWrapper.ModifierEntries[actorClass].Variants![actorName]!.Value;
+            }
+            else if (ClassModifiersWrapper.ModifierEntries[actorClass].Default != null)
+            {
+                act = ClassModifiersWrapper.ModifierEntries[actorClass].Default!.Value;
+            }
+            else return;
+            
+            if (act.ExtraModels != null)
+            {
+                foreach (string s in act.ExtraModels!.Keys)
+                {
+                    string ex = Path.Join(_actorsPath, s + ".szs");
+                    NARCFileSystem? narc = SZSWrapper.ReadFile(ex);
+
+                    if (narc is null || (narc is not null && !narc.TryGetFile(s + ".bcmdl", out byte[] cgfx)))
+                        continue;
+                    narc!.TryGetFile(s + ".bcmdl", out cgfx);
+                    H3D h3D;
+
+                    try
+                    {
+                        using MemoryStream stream = new(cgfx);
+                        h3D = Gfx.OpenAsH3D(stream);
+                    }
+                    catch
+                    {
+                        Debug.Write($"The actor's cgfx could not be read ({s})", "Error");
+                        continue;
+                    }
+
+                    foreach (H3DTexture texture in h3D.Textures)
+                    {
+                        scheduler.EnqueueGLTask(gl => actor.AddTexture(gl, texture));
+                    }
+
+                    foreach (H3DLUT lut in h3D.LUTs)
+                        foreach (H3DLUTSampler sampler in lut.Samplers)
+                        {
+                            scheduler.EnqueueGLTask(gl => actor.AddLUTTexture(gl, lut.Name, sampler));
+                        }
+
+                    foreach (H3DModel model in h3D.Models)
+                    {
+                        List<H3DMesh>[] meshLists =
+                        [
+                            model.MeshesLayer0, // Opaque layer
+                                model.MeshesLayer1, // Translucent layer
+                                model.MeshesLayer2, // Subtractive layer
+                                model.MeshesLayer3 // Additive layer
+                        ];
+
+                        for (int i = 0; i < meshLists.Length; i++)
+                        {
+                            foreach (H3DMesh mesh in meshLists[i])
+                            {
+                                actor.ForceModelNotEmpty();
+
+                                // Obtain the mesh's material by its index.
+                                int matIdx = mesh.MaterialIndex;
+                                H3DMaterial material = model.Materials[matIdx];
+
+                                // Obtain submesh culling.
+                                int meshIdx = model.Meshes.IndexOf(mesh);
+
+                                H3DSubMeshCulling? subMeshCulling = null;
+
+                                if (model.SubMeshCullings.Count > meshIdx)
+                                    subMeshCulling = model.SubMeshCullings[meshIdx];
+
+                                var skeleton = model.Skeleton;
+
+                                H3DMeshLayer meshLayer = (H3DMeshLayer)i;
+
+                                scheduler.EnqueueGLTask(gl =>
+                                    actor.AddMesh(gl, meshLayer, mesh, subMeshCulling, material, skeleton)
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     public ReadOnlyDictionary<string, string> ReadCreatorClassNameTable()

--- a/Autumn/FileSystems/RomFSHandler.cs
+++ b/Autumn/FileSystems/RomFSHandler.cs
@@ -605,6 +605,34 @@ internal partial class RomFSHandler
                     actor.InitLight.GetType((string)lrt["LightType"].Value!);
             }
         }
+        if (narc.TryGetFile("InitShadow.byml", out byte[] shadows))
+        {
+            BYAML act_sh = BYAMLParser.Read(shadows, s_byamlEncoding);
+            if (act_sh.RootNode.NodeType == BYAMLNodeType.Dictionary)
+            {
+                var srt = act_sh.RootNode.GetValueAs<Dictionary<string, BYAMLNode>>();
+                if (srt!.ContainsKey("Category") && srt["Category"].Value != null)
+                {
+                    if (srt["Category"].NodeType == BYAMLNodeType.String && !string.IsNullOrEmpty((string)srt["Category"].Value!))
+                        Console.WriteLine($"{actor.Name} Shadows Contains actual category");
+                }
+                if (srt!.ContainsKey("Shadows"))
+                {
+                    //Console.WriteLine("Contains Shadows");
+                    var shArr = srt["Shadows"];
+                    if (shArr.NodeType == BYAMLNodeType.Array)
+                    {
+                        BYAMLNode[] shs = shArr.GetValueAs<BYAMLNode[]>()!;
+                        foreach (BYAMLNode shd in shs)
+                        {
+                            if (shd.NodeType is not BYAMLNodeType.Dictionary) continue;
+                            actor.InitShadow.Add(new (shd.GetValueAs<Dictionary<string, BYAMLNode>>()!));
+                        }
+                    }
+                    //srt.TryGetValue("", out BYAMLNode SName)
+                }
+            }
+        }
 
         H3D h3D;
 
@@ -726,6 +754,7 @@ internal partial class RomFSHandler
                         continue;
                     narc!.TryGetFile(s + ".bcmdl", out cgfx);
                     H3D h3D;
+
 
                     try
                     {

--- a/Autumn/FileSystems/RomFSHandler.cs
+++ b/Autumn/FileSystems/RomFSHandler.cs
@@ -540,8 +540,10 @@ internal partial class RomFSHandler
                                 actor.AABB.BoundBox((H3DBoundingBox)mesh.MetaData[m].Values[0]!);
                         }
                     }
+                    //actor.AABB.Center += mesh.MeshCenter;
                 }
             }
+            //actor.AABB.Center /= meshLists.Length;
         }
 
         // Cache the actor
@@ -1435,7 +1437,7 @@ internal partial class RomFSHandler
 
             NARCFileSystem narcFS = new(new());
             byte[] binFile = BYAMLParser.Write(file);
-            SortedDictionary<string, byte[]> files = new(); 
+            SortedDictionary<string, byte[]> files = new();
             foreach (var (key, value) in st.EnumerateAdditionalFiles())
             {
                 files.Add(key, value);
@@ -1444,7 +1446,7 @@ internal partial class RomFSHandler
             {
                 var stageInfoBYML = MakeStageInfo(stage);
                 if (stageInfoBYML != null)
-                    files.Add("StageInfo" + stage.Scenario + ".byml", BYAMLParser.Write((BYAML)stageInfoBYML));                   
+                    files.Add("StageInfo" + stage.Scenario + ".byml", BYAMLParser.Write((BYAML)stageInfoBYML));
                 if (stage.CameraParams.Cameras.Count > 0)
                     files.Add("CameraParam.byml", BYAMLParser.Write(MakeCameraParam(stage)));
             }

--- a/Autumn/FileSystems/RomFSHandler.cs
+++ b/Autumn/FileSystems/RomFSHandler.cs
@@ -740,6 +740,19 @@ internal partial class RomFSHandler
 
                     Actor subActor = new(s);
 
+                    if (narc.TryGetFile("InitLight.byml", out byte[] light))
+                    {
+                        BYAML act_lights = BYAMLParser.Read(light, s_byamlEncoding);
+                        if (act_lights.RootNode.NodeType == BYAMLNodeType.Dictionary)
+                        {
+                            var lrt = act_lights.RootNode.GetValueAs<Dictionary<string, BYAMLNode>>();
+                            if (lrt!.ContainsKey("LightCalcType"))
+                                subActor.InitLight.GetCalcType((string)lrt["LightCalcType"].Value!);
+                            if (lrt!.ContainsKey("LightType"))
+                                subActor.InitLight.GetType((string)lrt["LightType"].Value!);
+                        }
+                    }
+
                     foreach (H3DTexture texture in h3D.Textures)
                     {
                         scheduler.EnqueueGLTask(gl => subActor.AddTexture(gl, texture));
@@ -807,6 +820,19 @@ internal partial class RomFSHandler
             return null;
         narc!.TryGetFile(subActorName + ".bcmdl", out cgfx);
         H3D h3D;
+
+        if (narc.TryGetFile("InitLight.byml", out byte[] light))
+        {
+            BYAML act_lights = BYAMLParser.Read(light, s_byamlEncoding);
+            if (act_lights.RootNode.NodeType == BYAMLNodeType.Dictionary)
+            {
+                var lrt = act_lights.RootNode.GetValueAs<Dictionary<string, BYAMLNode>>();
+                if (lrt!.ContainsKey("LightCalcType"))
+                    subActor.InitLight.GetCalcType((string)lrt["LightCalcType"].Value!);
+                if (lrt!.ContainsKey("LightType"))
+                    subActor.InitLight.GetType((string)lrt["LightType"].Value!);
+            }
+        }
 
         try
         {

--- a/Autumn/FileSystems/RomFSHandler.cs
+++ b/Autumn/FileSystems/RomFSHandler.cs
@@ -593,46 +593,7 @@ internal partial class RomFSHandler
         if (!found)
             return actor;
 
-        if (narc.TryGetFile("InitLight.byml", out byte[] light))
-        {
-            BYAML act_lights = BYAMLParser.Read(light, s_byamlEncoding);
-            if (act_lights.RootNode.NodeType == BYAMLNodeType.Dictionary)
-            {
-                var lrt = act_lights.RootNode.GetValueAs<Dictionary<string, BYAMLNode>>();
-                if (lrt!.ContainsKey("LightCalcType"))
-                    actor.InitLight.GetCalcType((string)lrt["LightCalcType"].Value!);
-                if (lrt!.ContainsKey("LightType"))
-                    actor.InitLight.GetType((string)lrt["LightType"].Value!);
-            }
-        }
-        if (narc.TryGetFile("InitShadow.byml", out byte[] shadows))
-        {
-            BYAML act_sh = BYAMLParser.Read(shadows, s_byamlEncoding);
-            if (act_sh.RootNode.NodeType == BYAMLNodeType.Dictionary)
-            {
-                var srt = act_sh.RootNode.GetValueAs<Dictionary<string, BYAMLNode>>();
-                if (srt!.ContainsKey("Category") && srt["Category"].Value != null)
-                {
-                    if (srt["Category"].NodeType == BYAMLNodeType.String && !string.IsNullOrEmpty((string)srt["Category"].Value!))
-                        Console.WriteLine($"{actor.Name} Shadows Contains actual category");
-                }
-                if (srt!.ContainsKey("Shadows"))
-                {
-                    //Console.WriteLine("Contains Shadows");
-                    var shArr = srt["Shadows"];
-                    if (shArr.NodeType == BYAMLNodeType.Array)
-                    {
-                        BYAMLNode[] shs = shArr.GetValueAs<BYAMLNode[]>()!;
-                        foreach (BYAMLNode shd in shs)
-                        {
-                            if (shd.NodeType is not BYAMLNodeType.Dictionary) continue;
-                            actor.InitShadow.Add(new (shd.GetValueAs<Dictionary<string, BYAMLNode>>()!));
-                        }
-                    }
-                    //srt.TryGetValue("", out BYAMLNode SName)
-                }
-            }
-        }
+        actor.ReadActorInits(narc, s_byamlEncoding);
 
         H3D h3D;
 
@@ -769,18 +730,7 @@ internal partial class RomFSHandler
 
                     Actor subActor = new(s);
 
-                    if (narc.TryGetFile("InitLight.byml", out byte[] light))
-                    {
-                        BYAML act_lights = BYAMLParser.Read(light, s_byamlEncoding);
-                        if (act_lights.RootNode.NodeType == BYAMLNodeType.Dictionary)
-                        {
-                            var lrt = act_lights.RootNode.GetValueAs<Dictionary<string, BYAMLNode>>();
-                            if (lrt!.ContainsKey("LightCalcType"))
-                                subActor.InitLight.GetCalcType((string)lrt["LightCalcType"].Value!);
-                            if (lrt!.ContainsKey("LightType"))
-                                subActor.InitLight.GetType((string)lrt["LightType"].Value!);
-                        }
-                    }
+                    subActor.ReadActorInits(narc, s_byamlEncoding);
 
                     foreach (H3DTexture texture in h3D.Textures)
                     {
@@ -850,18 +800,7 @@ internal partial class RomFSHandler
         narc!.TryGetFile(subActorName + ".bcmdl", out cgfx);
         H3D h3D;
 
-        if (narc.TryGetFile("InitLight.byml", out byte[] light))
-        {
-            BYAML act_lights = BYAMLParser.Read(light, s_byamlEncoding);
-            if (act_lights.RootNode.NodeType == BYAMLNodeType.Dictionary)
-            {
-                var lrt = act_lights.RootNode.GetValueAs<Dictionary<string, BYAMLNode>>();
-                if (lrt!.ContainsKey("LightCalcType"))
-                    subActor.InitLight.GetCalcType((string)lrt["LightCalcType"].Value!);
-                if (lrt!.ContainsKey("LightType"))
-                    subActor.InitLight.GetType((string)lrt["LightType"].Value!);
-            }
-        }
+        subActor.ReadActorInits(narc, s_byamlEncoding);
 
         try
         {

--- a/Autumn/FileSystems/RomFSHandler.cs
+++ b/Autumn/FileSystems/RomFSHandler.cs
@@ -561,17 +561,13 @@ internal partial class RomFSHandler
         return actor;
     }
 
-    public Actor ReadActorNew(string actorName, string actorClass, GLTaskScheduler scheduler)
+    public Actor ReadActorNew(string actorName, string baseModelName, string actorClass, GLTaskScheduler scheduler)
     {
-        string path = Path.Join(_actorsPath, actorName + ".szs");
-
+        string path = Path.Join(_actorsPath, baseModelName + ".szs");
         // Return cached actor if valid (not modified externally)
-        if (_cachedActors.TryGetValue(path, out Actor? cachedActor))
+        if (_cachedActors.TryGetValue(actorName, out Actor? cachedActor))
         {
-            DateTime timestamp = File.GetLastWriteTime(path);
-
-            if (_cachedActorsTimestamps.TryGetValue(path, out DateTime oldTimestamp) && oldTimestamp == timestamp)
-                return cachedActor;
+            return cachedActor;
         }
 
         Actor actor = new(actorName);
@@ -591,7 +587,7 @@ internal partial class RomFSHandler
         if (narc is null)
             return actor;
 
-        bool found = narc.TryGetFile(actorName + ".bcmdl", out byte[] cgfx);
+        bool found = narc.TryGetFile(baseModelName + ".bcmdl", out byte[] cgfx);
 
         if (!found)
             return actor;
@@ -699,9 +695,7 @@ internal partial class RomFSHandler
         }
 
         // Cache the actor
-        _cachedActors.Add(path, actor);
-        _cachedActorsTimestamps.Add(path, File.GetLastWriteTime(path));
-
+        _cachedActors.Add(actorName, actor);
         return actor;
     }
 

--- a/Autumn/FileSystems/RomFSHandler.cs
+++ b/Autumn/FileSystems/RomFSHandler.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Autumn.Background;
 using Autumn.Enums;
+using Autumn.Rendering.Storage;
 using Autumn.Storage;
 using Autumn.Utils;
 using Autumn.Wrappers;
@@ -699,7 +700,7 @@ internal partial class RomFSHandler
         return actor;
     }
 
-    public void ReadActorExtras(string actorName, string actorClass, Actor actor, GLTaskScheduler scheduler)
+    public void ReadActorExtras(string actorName, string actorClass, ActorSceneObj actor, GLTaskScheduler scheduler)
     {
         if (ClassModifiersWrapper.ModifierEntries.ContainsKey(actorClass))
         {
@@ -733,19 +734,21 @@ internal partial class RomFSHandler
                     }
                     catch
                     {
-                        Debug.Write($"The actor's cgfx could not be read ({s})", "Error");
+                        Debug.Write($"The subactor's cgfx could not be read ({s})", "Error");
                         continue;
                     }
 
+                    Actor subActor = new(s);
+
                     foreach (H3DTexture texture in h3D.Textures)
                     {
-                        scheduler.EnqueueGLTask(gl => actor.AddTexture(gl, texture));
+                        scheduler.EnqueueGLTask(gl => subActor.AddTexture(gl, texture));
                     }
 
                     foreach (H3DLUT lut in h3D.LUTs)
                         foreach (H3DLUTSampler sampler in lut.Samplers)
                         {
-                            scheduler.EnqueueGLTask(gl => actor.AddLUTTexture(gl, lut.Name, sampler));
+                            scheduler.EnqueueGLTask(gl => subActor.AddLUTTexture(gl, lut.Name, sampler));
                         }
 
                     foreach (H3DModel model in h3D.Models)
@@ -762,7 +765,7 @@ internal partial class RomFSHandler
                         {
                             foreach (H3DMesh mesh in meshLists[i])
                             {
-                                actor.ForceModelNotEmpty();
+                                subActor.ForceModelNotEmpty();
 
                                 // Obtain the mesh's material by its index.
                                 int matIdx = mesh.MaterialIndex;
@@ -781,14 +784,93 @@ internal partial class RomFSHandler
                                 H3DMeshLayer meshLayer = (H3DMeshLayer)i;
 
                                 scheduler.EnqueueGLTask(gl =>
-                                    actor.AddMesh(gl, meshLayer, mesh, subMeshCulling, material, skeleton)
+                                    subActor.AddMesh(gl, meshLayer, mesh, subMeshCulling, material, skeleton)
                                 );
                             }
                         }
                     }
+
+                    actor.SubActors.Add(subActor);
                 }
             }
         }
+    }
+    public Actor?  ReadActorExtrasArg(string subActorName, GLTaskScheduler scheduler)
+    {
+        if (_cachedActors.ContainsKey(subActorName))
+            return _cachedActors[subActorName];
+        Actor subActor = new(subActorName);
+        string ex = Path.Join(_actorsPath, subActorName + ".szs");
+        NARCFileSystem? narc = SZSWrapper.ReadFile(ex);
+
+        if (narc is null || (narc is not null && !narc.TryGetFile(subActorName + ".bcmdl", out byte[] cgfx)))
+            return null;
+        narc!.TryGetFile(subActorName + ".bcmdl", out cgfx);
+        H3D h3D;
+
+        try
+        {
+            using MemoryStream stream = new(cgfx);
+            h3D = Gfx.OpenAsH3D(stream);
+        }
+        catch
+        {
+            Debug.Write($"The subactor's cgfx could not be read ({subActorName})", "Error");
+            return null;
+        }
+
+
+        foreach (H3DTexture texture in h3D.Textures)
+        {
+            scheduler.EnqueueGLTask(gl => subActor.AddTexture(gl, texture));
+        }
+
+        foreach (H3DLUT lut in h3D.LUTs)
+            foreach (H3DLUTSampler sampler in lut.Samplers)
+            {
+                scheduler.EnqueueGLTask(gl => subActor.AddLUTTexture(gl, lut.Name, sampler));
+            }
+
+        foreach (H3DModel model in h3D.Models)
+        {
+            List<H3DMesh>[] meshLists =
+            [
+                model.MeshesLayer0, // Opaque layer
+                    model.MeshesLayer1, // Translucent layer
+                    model.MeshesLayer2, // Subtractive layer
+                    model.MeshesLayer3 // Additive layer
+            ];
+
+            for (int i = 0; i < meshLists.Length; i++)
+            {
+                foreach (H3DMesh mesh in meshLists[i])
+                {
+                    subActor.ForceModelNotEmpty();
+
+                    // Obtain the mesh's material by its index.
+                    int matIdx = mesh.MaterialIndex;
+                    H3DMaterial material = model.Materials[matIdx];
+
+                    // Obtain submesh culling.
+                    int meshIdx = model.Meshes.IndexOf(mesh);
+
+                    H3DSubMeshCulling? subMeshCulling = null;
+
+                    if (model.SubMeshCullings.Count > meshIdx)
+                        subMeshCulling = model.SubMeshCullings[meshIdx];
+
+                    var skeleton = model.Skeleton;
+
+                    H3DMeshLayer meshLayer = (H3DMeshLayer)i;
+
+                    scheduler.EnqueueGLTask(gl =>
+                        subActor.AddMesh(gl, meshLayer, mesh, subMeshCulling, material, skeleton)
+                    );
+                }
+            }
+        }
+        _cachedActors.Add(subActorName, subActor);
+        return subActor;
     }
 
     public ReadOnlyDictionary<string, string> ReadCreatorClassNameTable()

--- a/Autumn/FileSystems/RomFSHandler.cs
+++ b/Autumn/FileSystems/RomFSHandler.cs
@@ -145,7 +145,7 @@ internal partial class RomFSHandler
     {
 
         Stage stage = new(initialize: false) { Name = name, Scenario = scenario };
-        stage.UserPath = dir+ Path.DirectorySeparatorChar + name + scenario;
+        stage.UserPath = dir + Path.DirectorySeparatorChar + name + scenario;
         (string, StageFileType)[] paths =
         [
             (Path.Join(dir, $"{name}Design{scenario}.szs"), StageFileType.Design),
@@ -466,7 +466,7 @@ internal partial class RomFSHandler
             {
                 var lrt = act_lights.RootNode.GetValueAs<Dictionary<string, BYAMLNode>>();
                 if (lrt!.ContainsKey("LightCalcType"))
-                    actor.InitLight.GetCalcType((string)lrt["LightCalcType"].Value!); 
+                    actor.InitLight.GetCalcType((string)lrt["LightCalcType"].Value!);
                 if (lrt!.ContainsKey("LightType"))
                     actor.InitLight.GetType((string)lrt["LightType"].Value!);
             }
@@ -502,7 +502,7 @@ internal partial class RomFSHandler
             [
                 model.MeshesLayer0, // Opaque layer
                 model.MeshesLayer1, // Translucent layer
-                model.MeshesLayer2, // Substractive layer
+                model.MeshesLayer2, // Subtractive layer
                 model.MeshesLayer3 // Additive layer
             ];
 

--- a/Autumn/FileSystems/RomFSHandler.cs
+++ b/Autumn/FileSystems/RomFSHandler.cs
@@ -439,8 +439,13 @@ internal partial class RomFSHandler
         return stage;
     }
 
-
-    public Actor ReadActor(string name, GLTaskScheduler scheduler)
+    /// <summary>
+    /// Called for actors where their model name is the same as the actor name
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="scheduler"></param>
+    /// <returns>The actor if it's found, and an empty actor otherwise</returns>
+    public Actor ReadActorBasic(string name, GLTaskScheduler scheduler)
     {
         string path = Path.Join(_actorsPath, name + ".szs");
 
@@ -573,7 +578,13 @@ internal partial class RomFSHandler
         return actor;
     }
 
-    public Actor ReadActorNew(string actorName, string baseModelName, string actorClass, GLTaskScheduler scheduler)
+    /// <summary>
+    /// Called for actors where their model name differs from the actor name
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="scheduler"></param>
+    /// <returns>The actor if it's found, and an empty actor otherwise</returns>
+    public Actor ReadKnownActor(string actorName, string baseModelName, string actorClass, GLTaskScheduler scheduler)
     {
         string path = Path.Join(_actorsPath, baseModelName + ".szs");
         // Return cached actor if valid (not modified externally)

--- a/Autumn/FileSystems/RomFSHandler.cs
+++ b/Autumn/FileSystems/RomFSHandler.cs
@@ -33,12 +33,23 @@ internal partial class RomFSHandler
     public string Root { get; }
 
     private readonly string _stagesPath;
-    public string StagesPath { get { return _stagesPath; } }
     private readonly string _soundPath;
-    private readonly string _actorsPath;
-    private readonly string _ccntPath;
+    public readonly string _actorsPath;
+    public readonly string _ccntPath;
 
-    private readonly Dictionary<string, Actor> _cachedActors = new();
+    public string GetPath(FSPath p)
+    {
+        return p switch
+        {
+            FSPath.Stages => _stagesPath,
+            FSPath.Actors => _actorsPath,
+            FSPath.Sound => _soundPath,
+            FSPath.CCNT => _ccntPath,
+            _ => Root,
+        };
+    }
+
+    public readonly Dictionary<string, Actor> CachedActors = new();
     private readonly Dictionary<string, DateTime> _cachedActorsTimestamps = new();
 
     private ReadOnlyDictionary<string, string>? _creatorClassNameTable = null;
@@ -434,7 +445,7 @@ internal partial class RomFSHandler
         string path = Path.Join(_actorsPath, name + ".szs");
 
         // Return cached actor if valid (not modified externally)
-        if (_cachedActors.TryGetValue(path, out Actor? cachedActor))
+        if (CachedActors.TryGetValue(path, out Actor? cachedActor))
         {
             DateTime timestamp = File.GetLastWriteTime(path);
 
@@ -548,14 +559,14 @@ internal partial class RomFSHandler
         }
 
         // Cache the actor
-        if (!_cachedActors.ContainsKey(path))
+        if (!CachedActors.ContainsKey(path))
         {
-            _cachedActors.Add(path, actor);
+            CachedActors.Add(path, actor);
             _cachedActorsTimestamps.Add(path, File.GetLastWriteTime(path));
         }
         else // if we edited the actor between scenes
         {
-            _cachedActors[path] = actor;
+            CachedActors[path] = actor;
             _cachedActorsTimestamps[path] = File.GetLastWriteTime(path);
         }
 
@@ -566,7 +577,7 @@ internal partial class RomFSHandler
     {
         string path = Path.Join(_actorsPath, baseModelName + ".szs");
         // Return cached actor if valid (not modified externally)
-        if (_cachedActors.TryGetValue(actorName, out Actor? cachedActor))
+        if (CachedActors.TryGetValue(actorName, out Actor? cachedActor))
         {
             return cachedActor;
         }
@@ -672,7 +683,7 @@ internal partial class RomFSHandler
                         for (int m = 0; m < mesh.MetaData.Count; m++)
                         {
                             if (mesh.MetaData[m].Name == "OBBox")
-                            {    
+                            {
                                 actor.AABB.BoundBox((H3DBoundingBox)mesh.MetaData[m].Values[0]!);
                                 actor.AABB.Center += ((H3DBoundingBox)mesh.MetaData[m].Values[0]!).Center;
                             }
@@ -685,115 +696,91 @@ internal partial class RomFSHandler
         }
 
         // Cache the actor
-        _cachedActors.Add(actorName, actor);
+        CachedActors.Add(actorName, actor);
         return actor;
     }
 
-    public void ReadActorExtras(string actorName, string actorClass, ActorSceneObj actor, GLTaskScheduler scheduler)
+    public void ReadActorExtras(string subactName, string path, ActorSceneObj actor, GLTaskScheduler scheduler)
     {
-        if (ClassModifiersWrapper.ModifierEntries.ContainsKey(actorClass))
+        NARCFileSystem? narc = SZSWrapper.ReadFile(path);
+        if (narc is null || (narc is not null && !narc.TryGetFile(subactName + ".bcmdl", out byte[] cgfx)))
+            return;
+        narc!.TryGetFile(subactName + ".bcmdl", out cgfx);
+        H3D h3D;
+
+        try
         {
-            ClassModifiersWrapper.ModifierEntry act;
-            if (ClassModifiersWrapper.ModifierEntries[actorClass].Variants != null && ClassModifiersWrapper.ModifierEntries[actorClass].Variants.ContainsKey(actorName))
+            using MemoryStream stream = new(cgfx);
+            h3D = Gfx.OpenAsH3D(stream);
+        }
+        catch
+        {
+            Debug.Write($"The subactor's cgfx could not be read ({subactName})", "Error");
+            return;
+        }
+
+        Actor subActor = new(subactName);
+
+        subActor.ReadActorInits(narc, s_byamlEncoding);
+
+        foreach (H3DTexture texture in h3D.Textures)
+        {
+            scheduler.EnqueueGLTask(gl => subActor.AddTexture(gl, texture));
+        }
+
+        foreach (H3DLUT lut in h3D.LUTs)
+            foreach (H3DLUTSampler sampler in lut.Samplers)
             {
-                act = ClassModifiersWrapper.ModifierEntries[actorClass].Variants![actorName]!;
+                scheduler.EnqueueGLTask(gl => subActor.AddLUTTexture(gl, lut.Name, sampler));
             }
-            else if (ClassModifiersWrapper.ModifierEntries[actorClass].Default != null)
+
+        foreach (H3DModel model in h3D.Models)
+        {
+            List<H3DMesh>[] meshLists =
+            [
+                model.MeshesLayer0, // Opaque layer
+                model.MeshesLayer1, // Translucent layer
+                model.MeshesLayer2, // Subtractive layer
+                model.MeshesLayer3 // Additive layer
+            ];
+
+            for (int i = 0; i < meshLists.Length; i++)
             {
-                act = ClassModifiersWrapper.ModifierEntries[actorClass].Default!.Value;
-            }
-            else return;
-            
-            if (act.ExtraModels != null)
-            {
-                foreach (string s in act.ExtraModels!.Keys)
+                foreach (H3DMesh mesh in meshLists[i])
                 {
-                    string ex = Path.Join(_actorsPath, s + ".szs");
-                    NARCFileSystem? narc = SZSWrapper.ReadFile(ex);
+                    subActor.ForceModelNotEmpty();
 
-                    if (narc is null || (narc is not null && !narc.TryGetFile(s + ".bcmdl", out byte[] cgfx)))
-                        continue;
-                    narc!.TryGetFile(s + ".bcmdl", out cgfx);
-                    H3D h3D;
+                    // Obtain the mesh's material by its index.
+                    int matIdx = mesh.MaterialIndex;
+                    H3DMaterial material = model.Materials[matIdx];
 
+                    //  Obtain submesh culling.
+                    int meshIdx = model.Meshes.IndexOf(mesh);
 
-                    try
-                    {
-                        using MemoryStream stream = new(cgfx);
-                        h3D = Gfx.OpenAsH3D(stream);
-                    }
-                    catch
-                    {
-                        Debug.Write($"The subactor's cgfx could not be read ({s})", "Error");
-                        continue;
-                    }
+                    H3DSubMeshCulling? subMeshCulling = null;
 
-                    Actor subActor = new(s);
+                    if (model.SubMeshCullings.Count > meshIdx)
+                        subMeshCulling = model.SubMeshCullings[meshIdx];
 
-                    subActor.ReadActorInits(narc, s_byamlEncoding);
+                    var skeleton = model.Skeleton;
 
-                    foreach (H3DTexture texture in h3D.Textures)
-                    {
-                        scheduler.EnqueueGLTask(gl => subActor.AddTexture(gl, texture));
-                    }
+                    H3DMeshLayer meshLayer = (H3DMeshLayer)i;
 
-                    foreach (H3DLUT lut in h3D.LUTs)
-                        foreach (H3DLUTSampler sampler in lut.Samplers)
-                        {
-                            scheduler.EnqueueGLTask(gl => subActor.AddLUTTexture(gl, lut.Name, sampler));
-                        }
-
-                    foreach (H3DModel model in h3D.Models)
-                    {
-                        List<H3DMesh>[] meshLists =
-                        [
-                            model.MeshesLayer0, // Opaque layer
-                                model.MeshesLayer1, // Translucent layer
-                                model.MeshesLayer2, // Subtractive layer
-                                model.MeshesLayer3 // Additive layer
-                        ];
-
-                        for (int i = 0; i < meshLists.Length; i++)
-                        {
-                            foreach (H3DMesh mesh in meshLists[i])
-                            {
-                                subActor.ForceModelNotEmpty();
-
-                                // Obtain the mesh's material by its index.
-                                int matIdx = mesh.MaterialIndex;
-                                H3DMaterial material = model.Materials[matIdx];
-
-                                // Obtain submesh culling.
-                                int meshIdx = model.Meshes.IndexOf(mesh);
-
-                                H3DSubMeshCulling? subMeshCulling = null;
-
-                                if (model.SubMeshCullings.Count > meshIdx)
-                                    subMeshCulling = model.SubMeshCullings[meshIdx];
-
-                                var skeleton = model.Skeleton;
-
-                                H3DMeshLayer meshLayer = (H3DMeshLayer)i;
-
-                                scheduler.EnqueueGLTask(gl =>
-                                    subActor.AddMesh(gl, meshLayer, mesh, subMeshCulling, material, skeleton)
-                                );
-                            }
-                        }
-                    }
-
-                    actor.SubActors.Add(subActor);
+                    scheduler.EnqueueGLTask(gl =>
+                        subActor.AddMesh(gl, meshLayer, mesh, subMeshCulling, material, skeleton)
+                    );
                 }
             }
         }
+
+        actor.SubActors.Add(subActor);
+        CachedActors.Add(subActor.Name, subActor);
+
     }
-    public Actor?  ReadActorExtrasArg(string subActorName, GLTaskScheduler scheduler)
+    public Actor? ReadActorExtrasArg(string subActorName, string path, GLTaskScheduler scheduler)
     {
-        if (_cachedActors.ContainsKey(subActorName))
-            return _cachedActors[subActorName];
         Actor subActor = new(subActorName);
-        string ex = Path.Join(_actorsPath, subActorName + ".szs");
-        NARCFileSystem? narc = SZSWrapper.ReadFile(ex);
+        NARCFileSystem? narc = SZSWrapper.ReadFile(path);
 
         if (narc is null || (narc is not null && !narc.TryGetFile(subActorName + ".bcmdl", out byte[] cgfx)))
             return null;
@@ -863,7 +850,7 @@ internal partial class RomFSHandler
                 }
             }
         }
-        _cachedActors.Add(subActorName, subActor);
+        CachedActors.Add(subActorName, subActor);
         return subActor;
     }
 

--- a/Autumn/GUI/ChangeHandler.cs
+++ b/Autumn/GUI/ChangeHandler.cs
@@ -21,14 +21,14 @@ internal static class ChangeHandler
         bool isSelected = context.CurrentScene.IsObjectSelected(id);
 
         // If the only selected object is the one that has been clicked, then nothing is done.
-        if (context.CurrentScene.SelectedObjects.Count() == 1 && isSelected && clear)
+        if (context.CurrentScene.SelectedObjCount == 1 && isSelected && clear)
             return;
 
         if (clear)
         {
             cleared = context.CurrentScene.SelectedObjects.ToArray();
 
-            if (context.CurrentScene.SelectedObjects.Count() > 1 && isSelected) // prevent it getting unselected when clicking on 1 of the multiselected
+            if (context.CurrentScene.SelectedObjCount > 1 && isSelected) // prevent it getting unselected when clicking on 1 of the multiselected
                 isSelected = false;
         }
         // if (context.CurrentScene.TryGetPickableObj(id, out ISceneObj? sceneObj))

--- a/Autumn/GUI/ChangeHandler.cs
+++ b/Autumn/GUI/ChangeHandler.cs
@@ -117,7 +117,7 @@ internal static class ChangeHandler
                 if (sceneObj is ActorSceneObj actorSceneObj)
                 {
                     actorSceneObj.StageObj.Name = prior;
-                    actorSceneObj.UpdateActor(window.ContextHandler.FSHandler, window.GLTaskScheduler);
+                    actorSceneObj.UpdateActor(window.ContextHandler.FSHandler, window.CurrentScene!, window.GLTaskScheduler);
                 }
                 if (sceneObj is BasicSceneObj basicSceneObj && basicSceneObj.StageObj.IsArea())
                 {
@@ -130,7 +130,7 @@ internal static class ChangeHandler
                 if (sceneObj is ActorSceneObj actorSceneObj)
                 {
                     actorSceneObj.StageObj.Name = final;
-                    actorSceneObj.UpdateActor(window.ContextHandler.FSHandler, window.GLTaskScheduler);
+                    actorSceneObj.UpdateActor(window.ContextHandler.FSHandler, window.CurrentScene!, window.GLTaskScheduler);
                 }
                 if (sceneObj is BasicSceneObj basicSceneObj && basicSceneObj.StageObj.IsArea())
                 {

--- a/Autumn/GUI/Dialogs/AddObjectDialog.cs
+++ b/Autumn/GUI/Dialogs/AddObjectDialog.cs
@@ -825,15 +825,17 @@ internal class AddObjectDialog(MainWindowContext window)
                 newRail.Properties.Add($"Arg{i}", _args[i]);
 
             Vector3 off = new(trans.X * 100, trans.Y * 100, trans.Z * 100);
+            RailPoint[] newRailPoints = new RailPoint[_points.Length];
             for (int i = 0; i < _points.Length; i++)
             {
-                _points[i] *= 200;
-                _points[i].Point0Trans += off;
-                _points[i].Point1Trans += off;
-                _points[i].Point2Trans += off;
+                newRailPoints[i] = _points[i].Clone(); 
+                newRailPoints[i] *= 200;
+                newRailPoints[i].Point0Trans += off;
+                newRailPoints[i].Point1Trans += off;
+                newRailPoints[i].Point2Trans += off;
                 for (int b = 0; b < 8; b++)
-                    _points[i].Properties.Add($"Arg{b}", -1);
-                newRail.Points.Add(_points[i]);
+                    newRailPoints[i].Properties.Add($"Arg{b}", -1);
+                newRail.Points.Add(newRailPoints[i]);
             }
 
             ChangeHandler.ChangeCreate(window, window.CurrentScene.History, newRail);

--- a/Autumn/GUI/Dialogs/AddObjectDialog.cs
+++ b/Autumn/GUI/Dialogs/AddObjectDialog.cs
@@ -17,6 +17,7 @@ namespace Autumn.GUI.Dialogs;
 internal class AddObjectDialog(MainWindowContext window)
 {
     private bool _isOpened = false;
+    public bool IsOpen => _isOpened;
 
     private string _name = "";
     private string _class = "";

--- a/Autumn/GUI/Dialogs/AddObjectDialog.cs
+++ b/Autumn/GUI/Dialogs/AddObjectDialog.cs
@@ -513,7 +513,7 @@ internal class AddObjectDialog(MainWindowContext window)
                 ImGui.Text("Shape:");
                 ImGui.SameLine();
                 ImGui.SetNextItemWidth(ImGui.GetWindowWidth() - ImGui.CalcTextSize("Shape:").X - style.ItemSpacing.X * 2);
-                ImGui.Combo("##Shape1", ref _shape, ["Cube", "Sphere", "Cylinder"], 3);
+                ImGui.Combo("##Shape1", ref _shape, ["Cube (Base)", "Cube (Middle)", "Sphere", "Cylinder"], 4);
             }
             ImGui.EndChild();
         }

--- a/Autumn/GUI/Dialogs/AddStageDialog.cs
+++ b/Autumn/GUI/Dialogs/AddStageDialog.cs
@@ -15,6 +15,7 @@ internal class AddStageDialog
     private readonly MainWindowContext _window;
 
     private bool _isOpened = false;
+    public bool IsOpen => _isOpened;
     public void Open() => _isOpened = true;
     private string _name = string.Empty;
     private int _scenarioNo = 1;

--- a/Autumn/GUI/Dialogs/AddStageDialog.cs
+++ b/Autumn/GUI/Dialogs/AddStageDialog.cs
@@ -295,10 +295,12 @@ internal class AddStageDialog
                                 ref manager.StatusMessageSecondary
                             );
 
-                        _window.Scenes.Add(scene);
 
                         Reset();
                         scene.ResetCamera();
+                        _window.Scenes.Add(scene);
+                        _window.CurrentScene = scene;
+                        _window.SetSceneChange();
                         ImGui.SetWindowFocus("Objects");
                     }
                 );
@@ -382,10 +384,12 @@ internal class AddStageDialog
                         ref manager.StatusMessageSecondary
                     );
 
-                _window.Scenes.Add(scene);
 
                 Reset();
                 scene.ResetCamera();
+                _window.Scenes.Add(scene);
+                _window.CurrentScene = scene;
+                _window.SetSceneChange();
                 ImGui.SetWindowFocus("Objects");
             }
         );

--- a/Autumn/GUI/Dialogs/ClosingDialog.cs
+++ b/Autumn/GUI/Dialogs/ClosingDialog.cs
@@ -12,6 +12,7 @@ namespace Autumn.GUI.Dialogs;
 internal class ClosingDialog(MainWindowContext window)
 {
     private bool _isOpened = false;
+    public bool IsOpen => _isOpened;
 
     public void Open() => _isOpened = true;
 

--- a/Autumn/GUI/Dialogs/DatabaseEditorDialog.cs
+++ b/Autumn/GUI/Dialogs/DatabaseEditorDialog.cs
@@ -578,7 +578,7 @@ internal class DatabaseEditor(MainWindowContext _window)
             {
                 foreach (string s in _modifiedEntries)
                 {
-                    string pth = Path.Join("Resources", "RedPepper-ClassDataBase", "Data", s + ".yml");
+                    string pth = Path.Join("Resources", "ClassDB", s + ".yml");
                     if (!_dbEntries.ContainsKey(s))
                     {
                         File.Delete(pth); // Erase the files that will no longer be there

--- a/Autumn/GUI/Dialogs/DatabaseEditorDialog.cs
+++ b/Autumn/GUI/Dialogs/DatabaseEditorDialog.cs
@@ -11,6 +11,7 @@ namespace Autumn.GUI.Dialogs;
 internal class DatabaseEditor(MainWindowContext _window)
 {
     private bool _isOpened = false;
+    public bool IsOpen => _isOpened;
     private SortedDictionary<string, ClassDatabaseWrapper.DatabaseEntry> _dbEntries;
     private int _argsel = -1;
     readonly string[] switches = ["A", "B", "Appear", "DeadOn", "Kill"];

--- a/Autumn/GUI/Dialogs/EditCCNTDialog.cs
+++ b/Autumn/GUI/Dialogs/EditCCNTDialog.cs
@@ -19,6 +19,7 @@ internal class EditCreatorClassNameTable(MainWindowContext _window)
 {
 
     private bool _isOpened = false;
+    public bool IsOpen => _isOpened;
     private Dictionary<string, string> _tmpCCNT = new();
     private string _search = "";
     private string _oname = "";

--- a/Autumn/GUI/Dialogs/EditChildrenDialog.cs
+++ b/Autumn/GUI/Dialogs/EditChildrenDialog.cs
@@ -14,6 +14,7 @@ internal class EditChildrenDialog(MainWindowContext _window)
 {
 
     private bool _isOpened = false;
+    public bool IsOpen => _isOpened;
     private string _name = string.Empty;
     private List<StageObj>[] _selectedObjs = [new(), new()]; // General / Children
     private List<StageObj> _newChildren = new();

--- a/Autumn/GUI/Dialogs/EditExtraPropsDialog.cs
+++ b/Autumn/GUI/Dialogs/EditExtraPropsDialog.cs
@@ -12,6 +12,7 @@ internal class EditExtraPropsDialog(MainWindowContext _window)
 {
 
     private bool _isOpened = false;
+    public bool IsOpen => _isOpened;
     private bool _isnew = false;
     private string _oname = "";
     private string _name = "NewProperty";

--- a/Autumn/GUI/Dialogs/SaveReminderDialog.cs
+++ b/Autumn/GUI/Dialogs/SaveReminderDialog.cs
@@ -1,0 +1,101 @@
+using System.Numerics;
+using Autumn.Enums;
+using Autumn.GUI.Windows;
+using Autumn.Rendering;
+using Autumn.Storage;
+using ImGuiNET;
+
+namespace Autumn.GUI.Dialogs;
+
+/// <summary>
+/// A popup that prompts the user to save when the stage is about to be closed.
+/// </summary>
+internal class SaveReminderDialog(MainWindowContext window)
+{
+    private bool _isOpened = false;
+    public bool IsOpen => _isOpened;
+    Scene _closingScene;
+
+    public void Open(Scene closingScene)
+    {
+        _closingScene = closingScene;
+        _isOpened = true;
+    }
+    public void Render()
+    {
+        if (!_isOpened || _closingScene is null)
+            return;
+
+        if (ImGui.IsKeyPressed(ImGuiKey.Escape))
+        {
+            _isOpened = false;
+            ImGui.CloseCurrentPopup();
+        }
+
+        ImGui.OpenPopup("Warning!##SaveReminder");
+
+        Vector2 dimensions = new(500 * window.ScalingFactor, 0);
+        ImGui.SetNextWindowSize(dimensions, ImGuiCond.Appearing);
+
+        ImGui.SetNextWindowPos(
+            ImGui.GetMainViewport().GetCenter(),
+            ImGuiCond.Appearing,
+            new(0.5f, 0.5f)
+        );
+
+        if (
+            !ImGui.BeginPopupModal(
+                "Warning!##SaveReminder",
+                ref _isOpened,
+                    ImGuiWindowFlags.NoSavedSettings | ImGuiWindowFlags.NoResize
+            )
+        )
+            return;
+
+        ImGui.TextWrapped(
+            "The stage seems to have been modified, do you want to save before closing?"
+        );
+
+        ImGui.Spacing();
+
+        Vector2 buttonSize = new(50 * window.ScalingFactor, 0);
+        if (ImGui.Button("Cancel", buttonSize))
+        {
+            ImGui.CloseCurrentPopup();
+            _isOpened = false;
+        }
+        ImGui.SameLine();
+        ImGui.SetCursorPosX(ImGui.GetContentRegionAvail().X - buttonSize.X * 3.3f);
+        if (ImGui.Button("Close without saving"))
+        {
+            ImGui.CloseCurrentPopup();
+            _closingScene.IsSaved = true;
+            _isOpened = false;
+            window.CloseStage(_closingScene);
+        }
+        ImGui.SameLine();
+        if (ImGui.Button("Save and close"))
+        {
+            ImGui.CloseCurrentPopup();
+            window.BackgroundManager.Add(
+                "Saving...",
+                manager =>
+                {
+                    Scene scene = _closingScene!;
+                    Stage stage = _closingScene!.Stage!;
+                    window.ContextHandler.FSHandler.WriteStage(stage, window.ContextHandler.Settings.UseClassNames);
+                    scene.SaveUndoCount = _closingScene.History.UndoSteps;
+                    if (!window.ContextHandler.ProjectStages.Contains(new(stage.Name, stage.Scenario)))
+                    {
+                        window.ContextHandler.AddProjectStage(stage.Name, stage.Scenario);
+                    }
+                });
+            _closingScene.IsSaved = true;
+            window.CloseStage(_closingScene);
+            _isOpened = false;
+        }
+
+
+        ImGui.EndPopup();
+    }
+}

--- a/Autumn/GUI/Dialogs/SettingsDialog.cs
+++ b/Autumn/GUI/Dialogs/SettingsDialog.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using Autumn.GUI.Theming;
 using Autumn.GUI.Windows;
@@ -32,6 +33,9 @@ internal class SettingsDialog
     private bool _viewrelationLine = true;
     private int _hoverInfo = 0;
     private int _gizmoPos = 0;
+    private bool EXPERIMENTAL_PostProcess = true;
+    private bool EXPERIMENTAL_SelectionOutline = true;
+    private bool EXPERIMENTAL_ActorShadows = true;
 
     private string[] compressionLevels = Enum.GetNames(typeof(Yaz0Wrapper.CompressionLevel));
     private int _oldTheme = 0;
@@ -76,6 +80,9 @@ internal class SettingsDialog
         _viewrelationLine = _window.ContextHandler.SystemSettings.ShowRelationLines;
         _hoverInfo = (int)_window.ContextHandler.SystemSettings.ShowHoverInfo;
         _gizmoPos = (int)_window.ContextHandler.SystemSettings.GizmoPosition;
+        EXPERIMENTAL_PostProcess = _window.ContextHandler.SystemSettings.EXPERIMENTAL_PostProcess;
+        EXPERIMENTAL_SelectionOutline = _window.ContextHandler.SystemSettings.EXPERIMENTAL_SelectionOutline;
+        EXPERIMENTAL_ActorShadows = _window.ContextHandler.SystemSettings.EXPERIMENTAL_ActorShadows;
 
         ReloadThemes();
     }
@@ -277,6 +284,22 @@ internal class SettingsDialog
                 ImGuiWidgets.HelpTooltip("Shows a line between child objects and their parents");
                 ImGui.EndTabItem();
             }
+
+            #if DEBUG
+            if (ImGui.BeginTabItem("EXPERIMENTAL"))
+            {
+                ImGui.Checkbox("Enable post processing effects", ref EXPERIMENTAL_PostProcess);
+                ImGui.SetItemTooltip("Changes the way the viewport is rendered to enable shadows like the ones ingame and outlines for selected objects.");
+                if (!EXPERIMENTAL_PostProcess) ImGui.BeginDisabled();
+                ImGui.Checkbox("Visible actor shadows", ref EXPERIMENTAL_ActorShadows);
+                ImGui.SetItemTooltip("When enabled, all actors will display shadows (set by InitShadow.byml) not just ShadowObj.\r\nThis setting is marked as experimental because the rendering is buggy.");
+                ImGui.Checkbox("Selection outlines", ref EXPERIMENTAL_SelectionOutline);
+                ImGui.SetItemTooltip("When enabled, selected objects will have an outline around them.");
+                if (!EXPERIMENTAL_PostProcess) ImGui.EndDisabled();
+
+                ImGui.EndTabItem();
+            }
+            #endif
             ImGui.EndTabBar();
         }
         ImGui.SeparatorText("Reset");
@@ -367,6 +390,12 @@ internal class SettingsDialog
             _window.ContextHandler.SystemSettings.ShowRelationLines = _viewrelationLine;
             _window.ContextHandler.SystemSettings.ShowHoverInfo = (Enums.HoverInfoMode)_hoverInfo;
             _window.ContextHandler.SystemSettings.GizmoPosition = (Enums.GizmoPosition)_gizmoPos;
+            
+            _window.ContextHandler.SystemSettings.EXPERIMENTAL_PostProcess = EXPERIMENTAL_PostProcess;
+            _window.ContextHandler.SystemSettings.EXPERIMENTAL_SelectionOutline = EXPERIMENTAL_SelectionOutline;
+            _window.ContextHandler.SystemSettings.EXPERIMENTAL_ActorShadows = EXPERIMENTAL_ActorShadows;
+
+
 
             if (_availableThemes.Count > 0)
                 _window.ContextHandler.SystemSettings.Theme = _availableThemes[_selectedTheme];

--- a/Autumn/GUI/Dialogs/SettingsDialog.cs
+++ b/Autumn/GUI/Dialogs/SettingsDialog.cs
@@ -18,6 +18,7 @@ internal class SettingsDialog
     private readonly MainWindowContext _window;
 
     private bool _isOpened = false;
+    public bool IsOpen => _isOpened;
     private bool _useClassNames = false;
     private bool _dbEditor = false;
     private bool _rememberLayout = false;

--- a/Autumn/GUI/Dialogs/SettingsDialog.cs
+++ b/Autumn/GUI/Dialogs/SettingsDialog.cs
@@ -21,6 +21,7 @@ internal class SettingsDialog
     public bool IsOpen => _isOpened;
     private bool _useClassNames = false;
     private bool _dbEditor = false;
+    private bool _saveRem = false;
     private bool _rememberLayout = false;
     private bool _prevlightonload = false;
     private bool _wasd = false;
@@ -81,6 +82,7 @@ internal class SettingsDialog
         _viewrelationLine = _window.ContextHandler.SystemSettings.ShowRelationLines;
         _hoverInfo = (int)_window.ContextHandler.SystemSettings.ShowHoverInfo;
         _gizmoPos = (int)_window.ContextHandler.SystemSettings.GizmoPosition;
+        _saveRem = _window.ContextHandler.SystemSettings.SaveReminder;
         EXPERIMENTAL_PostProcess = _window.ContextHandler.SystemSettings.EXPERIMENTAL_PostProcess;
         EXPERIMENTAL_SelectionOutline = _window.ContextHandler.SystemSettings.EXPERIMENTAL_SelectionOutline;
         EXPERIMENTAL_ActorShadows = _window.ContextHandler.SystemSettings.EXPERIMENTAL_ActorShadows;
@@ -232,6 +234,7 @@ internal class SettingsDialog
             if (ImGui.BeginTabItem("Editor Functionality"))
             {
                 ImGui.Checkbox("Use ClassNames", ref _useClassNames);
+                ImGui.Checkbox("Warn the user when trying to close an unsaved stage", ref _saveRem);
                 ImGui.Checkbox("Enable Database Editor", ref _dbEditor);
                 ImGui.Checkbox("Restore Native File Dialogs", ref _restoreNativeFileDialogs);
                 ImGui.Checkbox("Enable VSync", ref _enableVSync);
@@ -376,6 +379,7 @@ internal class SettingsDialog
             _window.ContextHandler.SetGlobalSetting("RomFSPath", _romfspath);
             _window.ContextHandler.SetProjectSetting("UseClassNames", _useClassNames);
             _window.ContextHandler.SystemSettings.UseWASD = _wasd;
+            _window.ContextHandler.SystemSettings.SaveReminder = _saveRem;
             _window.ContextHandler.SystemSettings.UseMiddleMouse = _middleMovesCamera;
             _window.ContextHandler.SystemSettings.EnableVSync = _enableVSync;
             _window.ContextHandler.SystemSettings.MouseSpeed = _mouseSpeed;

--- a/Autumn/GUI/Dialogs/ShortcutsDialog.cs
+++ b/Autumn/GUI/Dialogs/ShortcutsDialog.cs
@@ -9,6 +9,7 @@ namespace Autumn.GUI.Dialogs;
 internal class ShortcutsDialog(MainWindowContext window)
 {
     private bool _isOpened = false;
+    public bool IsOpen => _isOpened;
 
     public void Open()
     {

--- a/Autumn/GUI/Dialogs/ShortcutsDialog.cs
+++ b/Autumn/GUI/Dialogs/ShortcutsDialog.cs
@@ -3,6 +3,8 @@ using Autumn.ActionSystem;
 using Autumn.Enums;
 using Autumn.GUI.Windows;
 using ImGuiNET;
+using Silk.NET.Input.Extensions;
+using Silk.NET.SDL;
 
 namespace Autumn.GUI.Dialogs;
 
@@ -10,7 +12,8 @@ internal class ShortcutsDialog(MainWindowContext window)
 {
     private bool _isOpened = false;
     public bool IsOpen => _isOpened;
-
+    private bool changingKey = false;
+    private CommandID? changingCommand = null;
     public void Open()
     {
         _isOpened = true;
@@ -24,7 +27,7 @@ internal class ShortcutsDialog(MainWindowContext window)
             }
             categories[c].Add(cid);
         }
-        
+
     }
     Dictionary<Command.CommandCategory, List<CommandID>> categories = new();
     public void Render()
@@ -34,7 +37,7 @@ internal class ShortcutsDialog(MainWindowContext window)
 
         ImGui.OpenPopup("Autumn Shortcuts");
 
-        Vector2 dimensions = new(450 * window.ScalingFactor, 0);
+        Vector2 dimensions = new(450 * window.ScalingFactor, 300);
         ImGui.SetNextWindowSize(dimensions, ImGuiCond.Always);
 
         ImGui.SetNextWindowPos(
@@ -53,15 +56,57 @@ internal class ShortcutsDialog(MainWindowContext window)
             )
         )
             return;
-        foreach (Command.CommandCategory cat in categories.Keys)
+        if (ImGui.BeginTabBar("ShortcutsTabs"))
         {
-            ImGui.SeparatorText($"{cat} Shortcuts");
-            foreach (CommandID id in categories[cat])
+            foreach (Command.CommandCategory cat in categories.Keys)
             {
-                ShortcutText(id);
+                if (ImGui.BeginTabItem($"{cat}"))
+                {
+                    if (ImGui.BeginTable("TabTable", 2, ImGuiTableFlags.Resizable 
+                                        | ImGuiTableFlags.RowBg | ImGuiTableFlags.BordersOuter
+                                        | ImGuiTableFlags.BordersV | ImGuiTableFlags.ScrollY))
+                    {
+                        ImGui.TableSetupScrollFreeze(0, 1); // Makes top row always visible.
+                        ImGui.TableSetupColumn("Name", ImGuiTableColumnFlags.None);
+                        ImGui.TableSetupColumn("Keys", ImGuiTableColumnFlags.None);
+                        ImGui.TableHeadersRow();
+                        foreach (CommandID id in categories[cat])
+                        {
+                            ImGui.TableNextRow();
+                            ShortcutText(id);
+                        }
+                        ImGui.EndTable();
+                    }
+                    ImGui.EndTabItem();
+                }
             }
         }
-        ImGui.Spacing();
+        if (changingKey)
+        {
+            var st = window.Keyboard.CaptureState();
+            if (st.GetPressedKeys().Length > 0)
+            {
+                foreach (Silk.NET.Input.Key k in st.GetPressedKeys())
+                {
+                    if (k == Silk.NET.Input.Key.Escape)
+                    {
+                        changingKey = false;
+                        changingCommand = null;
+                        break;
+                    }
+                    window.ImGuiController!.TryMapKey(k, out ImGuiKey ik);
+                    if (ik == ImGuiKey.LeftCtrl || ik == ImGuiKey.RightCtrl) continue;
+                    if (ik == ImGuiKey.LeftShift|| ik == ImGuiKey.RightShift) continue;
+                    if (ik == ImGuiKey.LeftAlt  || ik == ImGuiKey.RightAlt) continue;
+                    window.ContextHandler.ActionHandler.SetShortcut(changingCommand!.Value, new Shortcut(ImGui.IsKeyDown(ImGuiKey.ModCtrl), 
+                                                                                        ImGui.IsKeyDown(ImGuiKey.ModShift), 
+                                                                                        ImGui.IsKeyDown(ImGuiKey.ModAlt), ik));
+                    changingKey = false;
+                    changingCommand = null;
+                    break;
+                }
+            }
+        }
 
 
         ImGui.EndPopup();
@@ -70,16 +115,40 @@ internal class ShortcutsDialog(MainWindowContext window)
     void ShortcutText(CommandID command)
     {
         var act = window.ContextHandler.ActionHandler.GetAction(command);
+        ImGui.TableSetColumnIndex(0);
         if (act.Command != null)
         {
-            ImGui.BulletText(act.Command.DisplayName);
-            ImGui.SameLine();
+            ImGui.Text(act.Command.DisplayName);
         }
-        if (act.Shortcut != null)
+        else return;
+        ImGui.TableSetColumnIndex(1);
+        string display;
+        if (changingKey && changingCommand == command)
         {
-            ImGui.Text("- " + act.Shortcut.DisplayString);
+            display = "Waiting for key...";
         }
         else
-            ImGui.Text("- No shortcut assigned.");
+        {
+            if (act.Shortcut != null)
+            {
+                display = act.Shortcut.DisplayString;
+            }
+            else
+            {
+                display = "No shortcut assigned.";
+            }
+        }
+        ImGui.PushStyleVar(ImGuiStyleVar.SelectableTextAlign, Vector2.One*0.5f);
+        if (ImGui.Selectable($"{display}##commandSelectable{command}", false, ImGuiSelectableFlags.SpanAllColumns))
+        {
+            changingKey = true;
+            changingCommand = command;
+        }
+        if (ImGui.IsItemClicked(ImGuiMouseButton.Middle))
+        {
+            window.ContextHandler.ActionHandler.SetShortcut(command, null);
+        }
+        ImGui.SetItemTooltip(act.Command.DisplayName);
+        ImGui.PopStyleVar();
     }
 }

--- a/Autumn/GUI/Dialogs/WelcomeDialog.cs
+++ b/Autumn/GUI/Dialogs/WelcomeDialog.cs
@@ -11,7 +11,7 @@ internal class WelcomeDialog
     private readonly MainWindowContext _window;
 
     private bool _isOpened = false;
-    public bool IsOpened => _isOpened;
+    public bool IsOpen => _isOpened;
 
     private byte _currentPage = 0;
 

--- a/Autumn/GUI/Editors/ObjectWindow.cs
+++ b/Autumn/GUI/Editors/ObjectWindow.cs
@@ -161,7 +161,7 @@ internal class ObjectWindow(MainWindowContext window)
                 ImGui.SetItemTooltip(name);
 
                 if (
-                    window.CurrentScene.SelectedObjects.Count() <= 1
+                    window.CurrentScene.SelectedObjCount <= 1
                     && !lastKeyPressed
                     && selectedIndex != (int)obj.PickingId
                     && obj.Selected

--- a/Autumn/GUI/Editors/ObjectWindow.cs
+++ b/Autumn/GUI/Editors/ObjectWindow.cs
@@ -114,9 +114,6 @@ internal class ObjectWindow(MainWindowContext window)
                     );
                 }
 
-                ImGui.PopStyleColor(4);
-                //ImGui.PopFont();
-
                 ImGui.TableSetColumnIndex(1);
 
                 ImGui.PushID("SceneObjSelectable" + obj.PickingId);

--- a/Autumn/GUI/Editors/ParamsEditors/CameraParamsWindow.cs
+++ b/Autumn/GUI/Editors/ParamsEditors/CameraParamsWindow.cs
@@ -885,7 +885,7 @@ internal class CameraParamsWindow(MainWindowContext window)
 
             window.CameraFramebuffer.Use(window.GL!);
             window.GL!.Clear(Silk.NET.OpenGL.ClearBufferMask.ColorBufferBit | Silk.NET.OpenGL.ClearBufferMask.DepthBufferBit);
-            window.CurrentScene?.Render(window.GL, viewMatrix, projectionMatrix, camera.Rotation, camera.Eye);
+            window.CurrentScene?.Render(window, viewMatrix, projectionMatrix, camera.Rotation, camera.Eye);
             ImGui.End();
         }
     }

--- a/Autumn/GUI/Editors/ParamsEditors/CameraParamsWindow.cs
+++ b/Autumn/GUI/Editors/ParamsEditors/CameraParamsWindow.cs
@@ -562,11 +562,11 @@ internal class CameraParamsWindow(MainWindowContext window)
     bool CopyVec3Button(bool isCamera)
     {
         bool rb = false;
-        if (!isCamera && window.CurrentScene.SelectedObjects.Count() < 1)
+        if (!isCamera && window.CurrentScene.SelectedObjCount < 1)
             ImGui.BeginDisabled();
         rb = ImGui.Button(isCamera ? IconUtils.CAMERA : IconUtils.USER);
         ImGui.SetItemTooltip(isCamera ? "Copy Camera position" : "Copy selected object position");
-        if (!isCamera && window.CurrentScene.SelectedObjects.Count() < 1)
+        if (!isCamera && window.CurrentScene.SelectedObjCount < 1)
             ImGui.EndDisabled();
         return rb;
     }

--- a/Autumn/GUI/Editors/ParamsEditors/FogParamsWindow.cs
+++ b/Autumn/GUI/Editors/ParamsEditors/FogParamsWindow.cs
@@ -10,7 +10,7 @@ namespace Autumn.GUI.Editors;
 internal class FogParamsWindow(MainWindowContext window)
 {
     public bool IsOpen = false;
-    int _selectedfog = -1;
+    public int SelectedFog = -1;
     private const ImGuiTableFlags _stageTableFlags = ImGuiTableFlags.RowBg
                 | ImGuiTableFlags.BordersOuter
                 | ImGuiTableFlags.ScrollY
@@ -64,9 +64,9 @@ internal class FogParamsWindow(MainWindowContext window)
                 ImGui.PushID("fogselect" + _i);
                 var st = _i == 0 ? "Main" : scn.Stage.StageFogs[_i].AreaId.ToString();
 
-                if (ImGui.Selectable(st, _i == _selectedfog, ImGuiSelectableFlags.SpanAllColumns))
+                if (ImGui.Selectable(st, _i == SelectedFog, ImGuiSelectableFlags.SpanAllColumns))
                 {
-                    _selectedfog = _i;
+                    SelectedFog = _i;
                 }
 
                 ImGui.PopID();
@@ -79,10 +79,10 @@ internal class FogParamsWindow(MainWindowContext window)
 
         //                ImGui.Text("Currently unsupported");
 
-        if (scn.Stage.StageFogs.Count > _selectedfog && _selectedfog > -1)
+        if (scn.Stage.StageFogs.Count > SelectedFog && SelectedFog > -1)
         {
 
-            string sfog = scn.Stage.StageFogs[_selectedfog].AreaId == -1 ? "Main Fog" : "Fog " + scn.Stage.StageFogs[_selectedfog].AreaId.ToString() + ":";
+            string sfog = scn.Stage.StageFogs[SelectedFog].AreaId == -1 ? "Main Fog" : "Fog " + scn.Stage.StageFogs[SelectedFog].AreaId.ToString() + ":";
             ImGuiWidgets.TextHeader(sfog);
             // ImGui.SetWindowFontScale(1.20f);
             // if (scn.Stage.StageFogs[selectedfog].AreaId == -1)
@@ -91,29 +91,29 @@ internal class FogParamsWindow(MainWindowContext window)
             //     ImGui.Text("Fog " + scn.Stage.StageFogs[selectedfog].AreaId.ToString() + ":");
             // ImGui.Separator();
             // ImGui.SetWindowFontScale(1f);
-            bool _disabled = _selectedfog == 0;
+            bool _disabled = SelectedFog == 0;
             float w = ImGui.GetContentRegionAvail().X;
             if (_disabled)
                 ImGui.BeginDisabled();
             if (ImGui.Button(IconUtils.MINUS, new(w / 3 - style.ItemSpacing.X / 3, default)))
             {
-                scn.RemoveFogAt(_selectedfog);
-                _selectedfog -= 1;
+                scn.RemoveFogAt(SelectedFog);
+                SelectedFog -= 1;
             }
             if (_disabled)
                 ImGui.EndDisabled();
             ImGui.SameLine(default, style.ItemSpacing.X / 2);
             if (ImGui.Button(IconUtils.PASTE, new(w / 3 - style.ItemSpacing.X / 3, default)))
             {
-                scn.DuplicateFog(_selectedfog);
-                _selectedfog = scn.CountFogs() - 1;
+                scn.DuplicateFog(SelectedFog);
+                SelectedFog = scn.CountFogs() - 1;
             }
             ImGui.SetItemTooltip("Duplicate Fog");
             ImGui.SameLine(default, style.ItemSpacing.X / 2);
             if (ImGui.Button(IconUtils.PLUS, new(w / 3 - style.ItemSpacing.X / 3, default)))
             {
                 scn.AddFog(new() { AreaId = 0 });
-                _selectedfog = scn.CountFogs() - 1;
+                SelectedFog = scn.CountFogs() - 1;
             }
 
             if (_disabled)
@@ -122,33 +122,41 @@ internal class FogParamsWindow(MainWindowContext window)
 
             ImGui.PushItemWidth(prevW - PROP_WIDTH);
 
-            var old = scn.Stage.StageFogs[_selectedfog].AreaId;
-            if (ImGuiWidgets.InputInt("Area Id", ref scn.Stage.StageFogs[_selectedfog].AreaId))
+            var old = scn.Stage.StageFogs[SelectedFog].AreaId;
+            if (ImGuiWidgets.InputInt("Area Id", ref scn.Stage.StageFogs[SelectedFog].AreaId))
             {
-                scn.Stage.StageFogs[_selectedfog].AreaId = int.Clamp(scn.Stage.StageFogs[_selectedfog].AreaId, 0, 9999);
-                scn.UpdateFog(_selectedfog, old);
+                scn.Stage.StageFogs[SelectedFog].AreaId = int.Clamp(scn.Stage.StageFogs[SelectedFog].AreaId, 0, 9999);
+                scn.UpdateFog(SelectedFog, old);
             }
             if (_disabled)
                 ImGui.EndDisabled();
 
-            ImGuiWidgets.DragFloat("Density", ref scn.Stage.StageFogs[_selectedfog].Density);
-            ImGuiWidgets.DragFloat("Min depth", ref scn.Stage.StageFogs[_selectedfog].MinDepth);
-            ImGuiWidgets.DragFloat("Max depth", ref scn.Stage.StageFogs[_selectedfog].MaxDepth);
-            ImGuiWidgets.InputInt("Interpolation", ref scn.Stage.StageFogs[_selectedfog].InterpFrame);
-            if (_selectedfog == 0)
+            if (ImGuiWidgets.DragFloat("Density", ref scn.Stage.StageFogs[SelectedFog].Density, 0.01f))
+                scn.Stage.StageFogs[SelectedFog].Density = float.Max(scn.Stage.StageFogs[SelectedFog].Density, 0);
+            ImGui.SetItemTooltip("Used when the fog type is not linear");
+
+            if (ImGuiWidgets.DragFloat("Min depth", ref scn.Stage.StageFogs[SelectedFog].MinDepth))
+                scn.Stage.StageFogs[SelectedFog].MinDepth = float.Max(scn.Stage.StageFogs[SelectedFog].MinDepth, 0);
+            ImGui.SetItemTooltip("Used when the fog type is linear");
+            if (ImGuiWidgets.DragFloat("Max depth", ref scn.Stage.StageFogs[SelectedFog].MaxDepth))
+                scn.Stage.StageFogs[SelectedFog].MaxDepth = float.Max(scn.Stage.StageFogs[SelectedFog].MaxDepth, 0);
+            ImGui.SetItemTooltip("Used when the fog type is linear");
+            if (ImGuiWidgets.InputInt("Interpolation", ref scn.Stage.StageFogs[SelectedFog].InterpFrame))
+                scn.Stage.StageFogs[SelectedFog].InterpFrame = int.Max(scn.Stage.StageFogs[SelectedFog].InterpFrame, -1);
+            if (SelectedFog == 0)
             {
-                int fogtype = (int)scn.Stage.StageFogs[_selectedfog].FogType;
+                int fogtype = (int)scn.Stage.StageFogs[SelectedFog].FogType-1;
 
                 ImGui.Text("Type:");
                 ImGui.SameLine();
                 ImGuiWidgets.SetPropertyWidthGen("Type:");
                 ImGui.Combo("##Type", ref fogtype, Enum.GetNames(typeof(StageFog.FogTypes)), 3);
-                scn.Stage.StageFogs[_selectedfog].FogType = (StageFog.FogTypes)fogtype;
+                scn.Stage.StageFogs[SelectedFog].FogType = (StageFog.FogTypes)(fogtype + 1);
             }
             ImGui.Text("Color:");
             ImGui.SameLine();
             ImGuiWidgets.SetPropertyWidthGen("Color:");
-            ImGui.ColorEdit3("##Color", ref scn.Stage.StageFogs[_selectedfog].Color,
+            ImGui.ColorEdit3("##Color", ref scn.Stage.StageFogs[SelectedFog].Color,
             _colorEditFlags);
             ImGui.PopItemWidth();
             // ImGui.Text("Fogareas that use this fog");

--- a/Autumn/GUI/Editors/ParamsEditors/LightParamsWindow.cs
+++ b/Autumn/GUI/Editors/ParamsEditors/LightParamsWindow.cs
@@ -14,11 +14,12 @@ internal class LightParamsWindow(MainWindowContext window)
     StageLight? _selectedlight;
     int _lightIdx;
     int _selectedlightarea = -1;
-    int selectedlightName = -1;
+    public int ExternalLightSelect = -1;
+
     ImGuiWidgets.InputComboBox lightAreaCombo = new();
 
     string[] lightTypes = ["Map Obj Light", "Obj Light", "Player Light", "Stage Map Light"];
-    int copyLight = 0;
+    int _copyLight = 0;
 
     private const ImGuiTableFlags _stageTableFlags = ImGuiTableFlags.RowBg
                 | ImGuiTableFlags.BordersOuter
@@ -73,6 +74,7 @@ internal class LightParamsWindow(MainWindowContext window)
         if (ImGui.BeginTabBar("Ltabs", ImGuiTabBarFlags.None))
         {
             ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X / 2);
+            bool f = true;
             if (ImGui.BeginTabItem("Light Params"))
             {
                 scn.UseLightArea = false;
@@ -96,7 +98,7 @@ internal class LightParamsWindow(MainWindowContext window)
             else
                 scn.PreviewLight = null;
             ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
-            if (ImGui.BeginTabItem("Light Areas"))
+            if (ImGui.BeginTabItem("Light Areas", ref f, ExternalLightSelect > -1 ? ImGuiTabItemFlags.SetSelected : ImGuiTabItemFlags.None))
             {
                 scn.UseLightArea = true;
                 LightAreaTab(scn, prevW, style);
@@ -165,7 +167,7 @@ internal class LightParamsWindow(MainWindowContext window)
         {
             if (ImGui.Button("Copy to:"))
             {
-                switch (copyLight)
+                switch (_copyLight)
                 {
                     case 0:
                         scn.Stage.LightParams.MapObjectLight = new(_selectedlight);
@@ -184,7 +186,7 @@ internal class LightParamsWindow(MainWindowContext window)
             }
             ImGui.SameLine(0, style.ItemInnerSpacing.X);
             ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X);
-            ImGui.Combo("##CopyTo", ref copyLight, lightTypes, lightTypes.Length);
+            ImGui.Combo("##CopyTo", ref _copyLight, lightTypes, lightTypes.Length);
             ImGui.Separator();
             int A = 22;
             int B = 30;
@@ -285,7 +287,11 @@ internal class LightParamsWindow(MainWindowContext window)
                     ImGui.TableSetColumnIndex(0);
                     ImGui.PushID("lightarea" + scn.Stage.LightAreaNames.Keys.ElementAt(_i));
                     var st = scn.Stage.LightAreaNames.Keys.ElementAt(_i).ToString();
-
+                    if (ExternalLightSelect > -1 && scn.Stage.LightAreaNames.Keys.ElementAt(_i) == ExternalLightSelect)
+                    {
+                        _selectedlightarea = _i;
+                        ExternalLightSelect = -1;
+                    }
                     if (ImGui.Selectable(st, _i == _selectedlightarea, ImGuiSelectableFlags.SpanAllColumns))
                     {
                         _selectedlightarea = _i;
@@ -333,7 +339,8 @@ internal class LightParamsWindow(MainWindowContext window)
             string prevRefStr = refStr;
 
             int aId = scn.Stage.LightAreaNames.Keys.ElementAt(_selectedlightarea);
-            ImGui.InputInt("Area Id", ref aId);
+            ImGuiWidgets.PrePropertyWidthName("Area Id");
+            ImGui.InputInt("##AreaIdint", ref aId);
             if (aId != scn.Stage.LightAreaNames.Keys.ElementAt(_selectedlightarea) && !scn.Stage.LightAreaNames.ContainsKey(aId))
             {
                 string tmpS = scn.Stage.LightAreaNames.Values.ElementAt(_selectedlightarea);
@@ -350,7 +357,7 @@ internal class LightParamsWindow(MainWindowContext window)
                 ImGui.Text("Light Name:");
                 ImGui.SameLine();
                 var keyArray = ReadLightAreas.Keys.ToArray();
-                lightAreaCombo.Use("Light Name", ref refStr, ReadLightAreas.Keys.ToList(), ImGui.GetContentRegionAvail().X);
+                lightAreaCombo.Use("Light Name", ref refStr, ReadLightAreas.Keys.ToList(), ImGuiWidgets.SetPropertyWidthGen("Light Name"));
                 ImGui.SetCursorPosX(p);
                 //ImGui.Combo("Light Name", ref selectedlightName, keyArray, ReadLightAreas.Keys.Count - 1);
 
@@ -366,8 +373,8 @@ internal class LightParamsWindow(MainWindowContext window)
                     if (scn.PreviewLightAreas != area) scn.PreviewLightAreas = area;
 
                     ImGui.BeginDisabled();
-                    ImGui.DragInt("InterpolateFrame", ref area.InterpolateFrame, 1);
-                    ImGui.InputText("Name", ref area.Name, 128);
+                    ImGuiWidgets.DragInt("InterpolateFrame", ref area.InterpolateFrame, 1);
+                    ImGuiWidgets.InputText("Name", ref area.Name, 128);
                     ImGui.PopItemWidth();
                     ImGui.PushItemWidth(prevW - style.ItemSpacing.X);
                     ImGui.EndDisabled();

--- a/Autumn/GUI/Editors/ParamsEditors/SearchObjDialog.cs
+++ b/Autumn/GUI/Editors/ParamsEditors/SearchObjDialog.cs
@@ -1,0 +1,439 @@
+using System.Numerics;
+using Autumn.Enums;
+using Autumn.GUI.Windows;
+using Autumn.Rendering;
+using Autumn.Rendering.Storage;
+using Autumn.Storage;
+using Autumn.Utils;
+using ImGuiNET;
+
+namespace Autumn.GUI.Editors;
+
+/// <summary>
+/// Dialog window that lets the user search for objects in the current stage
+/// </summary>
+/// <param name="window"></param>
+internal class SearchWindow
+{
+    public SearchWindow(MainWindowContext _window)
+    {
+        window = _window;
+        objTypes = [.. objTypes, .. Enum.GetNames<StageObjType>()];
+    }
+    private MainWindowContext window;
+    public bool IsOpen = false;
+    private string _name = "";
+    private string _class = "";
+    private string _layer = "";
+    private StageCamera? _camera;
+    private RailObj? _rail;
+    private int _type = 0; // None / StageObjType +1 -> Regular = 1 instead of 0
+    private int _vid = -1;
+    private int _clipId = -1;
+    private bool _switchAll = false;
+    private int _switch = -1;
+    private int[] _switches = [-1, -1, -1, -1, -1];
+    private readonly int[] _baseswitches = [-1, -1, -1, -1, -1];
+    HashSet<ISceneObj> _foundObjects = new();
+    public string[] objTypes = ["Any"];
+
+    private const float PROP_WIDTH = 105f;
+    ImGuiWindowClass windowClass = new() { DockNodeFlagsOverrideSet = ImGuiDockNodeFlags.NoDockingOverCentralNode | ImGuiWidgets.NO_WINDOW_MENU_BUTTON }; // | ImGuiDockNodeFlags.NoUndocking };
+    private bool updateCameras = true;
+    private string[] cameraStrings = [];
+    private List<StageCamera> cameraslinks = new();
+    private bool searchRailOnly = false;
+    private int _railpoints = 2;
+    private bool _closed = false;
+
+    public void Render()
+    {
+        if (!IsOpen)
+        {
+            return;
+        }
+        unsafe
+        {
+            fixed (ImGuiWindowClass* tmp = &windowClass)
+                ImGui.SetNextWindowClass(new ImGuiWindowClassPtr(tmp));
+        }
+
+        if (!ImGui.Begin("Search##SearchWindow", ref IsOpen, ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.UnsavedDocument))
+            return;
+        if (window.CurrentScene == null)
+        {
+            ImGui.TextDisabled("Please load a stage first");
+            ImGui.End();
+            return;
+        }
+
+
+        var style = ImGui.GetStyle();
+        float prevW = ImGui.GetContentRegionAvail().X;
+        Scene scn = window.CurrentScene;
+        if (updateCameras)
+        {
+            var cams = scn.Stage.CameraParams.Cameras;
+            if (_type == 0) cameraslinks = cams;
+            else if (_type == (int)StageObjType.CameraArea + 1) cameraslinks = cams.Where(x => x.Category == StageCamera.CameraCategory.Map).ToList();
+            // if (stageObj.Name == "EntranceCameraObj") cameraslinks = cams.Where(x => x.Category == StageCamera.CameraCategory.Entrance).ToList();
+            else if (_type == (int)StageObjType.DemoScene + 1) cameraslinks = cams.Where(x => x.Category == StageCamera.CameraCategory.Event).ToList();
+            else cameraslinks = cams.Where(x => x.Category == StageCamera.CameraCategory.Object).ToList();
+
+            cameraStrings = new string[cameraslinks.Count + 1];
+            cameraStrings[0] = "No camera selected";
+            for (int cs = 1; cs < cameraStrings.Length; cs++)
+            {
+                cameraStrings[cs] = cameraslinks[cs - 1].CameraName();
+            }
+            updateCameras = false;
+        }
+        
+        
+        ImGuiWidgets.TextHeader("Search:");
+        if (ImGui.Button("Clear Search", new Vector2(-1, default)))
+        {
+            _name = "";
+            _class = "";
+            _layer = "";
+            _camera = null;
+            _rail = null;
+            _type = 0; // None / StageObjType +1 -> Regular = 1 instead of 0
+            _vid = -1;
+            _clipId = -1;
+            _switches = [-1, -1, -1, -1, -1];
+            _switch = -1;
+            _switchAll = false;
+            _foundObjects.Clear();
+        }
+        bool UpdateS = false;
+        ImGui.SeparatorText("By text:");
+        ImGui.SetNextItemWidth(prevW);
+        if (ImGui.InputTextWithHint("##SearchName", "Name", ref _name, 128))
+            UpdateS = true;
+        ImGui.SetNextItemWidth(prevW);
+        if (ImGui.InputTextWithHint("##SearchClassName", "ClassName", ref _class, 128))
+            UpdateS = true;
+        ImGui.SetNextItemWidth(prevW);
+        if (ImGui.InputTextWithHint("##SearchLayer", "Layer", ref _layer, 128))
+            UpdateS = true;
+
+        ImGui.SeparatorText("By values:");
+
+        int rff = 0;
+        if (_camera != null) rff = cameraslinks.IndexOf(_camera) + 1;
+        int orff = rff;
+        ImGuiWidgets.PrePropertyWidthName("Camera Id");
+        ImGui.Combo("##CAMERASearch", ref rff, cameraStrings, cameraStrings.Length);
+        if (rff != orff)
+        {
+            if (rff == 0) _camera = null;
+            else _camera = cameraslinks[rff - 1];
+            UpdateS = true;
+        }
+
+
+        var rails = scn!.EnumerateRailSceneObjs();
+        string[] railStrings = new string[rails.Count() + 1];
+        int bbbb = 1;
+        railStrings[0] = "No rail selected";
+        foreach (RailSceneObj rail in rails)
+        {
+            railStrings[bbbb] = rail.RailObj.Name;
+            bbbb += 1;
+        }
+        int rfrail = 0;
+        if (_rail is not null)
+        {
+            var rals = rails.FirstOrDefault(x => x.RailObj.Name == _rail.Name);
+            if (rals != null)
+                rfrail = rails.ToList().IndexOf(rals) + 1;
+        }
+        int rfr2 = rfrail;
+        ImGuiWidgets.PrePropertyWidthName("Rail");
+
+        ImGui.Combo("##SearchRailselector", ref rfr2, railStrings, rails.Count() + 1);
+        if (rfr2 != rfrail)
+        {
+            if (rfr2 > 0)
+            {
+                _rail = rails.ElementAt(rfr2 - 1).RailObj;
+            }
+            else _rail = null;
+            UpdateS = true;
+        }
+        
+        ImGuiWidgets.PrePropertyWidthName("View Id");
+        if (ImGui.InputInt("##SearchViewId", ref _vid, 1)) UpdateS = true;
+        ImGuiWidgets.PrePropertyWidthName("Clipping Group Id");
+        if (ImGui.InputInt("##ClippingGroupId", ref _clipId, 1)) UpdateS = true;
+        
+        if (ImGui.CollapsingHeader("Rail Specific"))
+        {
+
+            ImGuiWidgets.PrePropertyWidthName("Search Rails only");
+            if (ImGui.Checkbox("##SearchRails", ref searchRailOnly)) UpdateS = true;
+            if (!searchRailOnly) ImGui.BeginDisabled();
+            ImGuiWidgets.PrePropertyWidthName("Closed loop");
+            if (ImGui.Checkbox("##SearchClose", ref _closed)) UpdateS = true;
+            ImGuiWidgets.PrePropertyWidthName("Number of points");
+            if (ImGui.InputInt("##SearchNoPt", ref _railpoints)) UpdateS = true;
+            if (!searchRailOnly) ImGui.EndDisabled();
+        }
+
+
+
+        ImGui.SeparatorText("By switches:");
+        if (ImGui.Checkbox("Search by id", ref _switchAll)) UpdateS = true;
+        if (!_switchAll) ImGui.BeginDisabled();
+        ImGuiWidgets.PrePropertyWidthName("Switch");
+        if (ImGui.InputInt("##SearchSwitch", ref _switch, 1)) UpdateS = true;
+        if (!_switchAll) ImGui.EndDisabled();
+        if (_switchAll) ImGui.BeginDisabled();
+        ImGuiWidgets.PrePropertyWidthName("Switch A");
+        if (ImGui.InputInt("##SearchSwitchA", ref _switches[0], 1)) UpdateS = true;
+        ImGuiWidgets.PrePropertyWidthName("Switch B");
+        if (ImGui.InputInt("##SearchSwitchB", ref _switches[1], 1)) UpdateS = true;
+        ImGuiWidgets.PrePropertyWidthName("Switch Appear");
+        if (ImGui.InputInt("##SearchSwitchAppear", ref _switches[2], 1)) UpdateS = true;
+        ImGuiWidgets.PrePropertyWidthName("Switch DeadOn");
+        if (ImGui.InputInt("##SearchSwitchDeadOn", ref _switches[3], 1)) UpdateS = true;
+        ImGuiWidgets.PrePropertyWidthName("Switch Kill");
+        if (ImGui.InputInt("##SearchSwitchKill", ref _switches[4], 1)) UpdateS = true;
+        if (_switchAll) ImGui.EndDisabled();
+
+        // Check specific properties / values in the future -> ArgX, MultiFileName...
+
+        if (UpdateS) 
+            UpdateSearch(scn);
+            
+        int obj = 0;
+        ImGui.SeparatorText("Search results:");
+        ImGui.SetNextItemWidth(prevW);
+
+        if (ImGui.BeginTable("searchTable", 3,
+            ImGuiTableFlags.RowBg
+            | ImGuiTableFlags.BordersOuter
+            | ImGuiTableFlags.BordersV
+            | ImGuiTableFlags.ScrollY))
+        {
+            ImGui.TableSetupScrollFreeze(0, 1); // Makes top row always visible.
+            ImGui.TableSetupColumn("Find", ImGuiTableColumnFlags.None);
+            ImGui.TableSetupColumn("Object", ImGuiTableColumnFlags.WidthStretch, 3.0f);
+            ImGui.TableSetupColumn("Type", ImGuiTableColumnFlags.None);
+            ImGui.TableHeadersRow();
+            //if (autoResize) ImGui.SetScrollY(0);
+            int cidx = 0;
+            if (_foundObjects.Count > 0)
+            foreach (ISceneObj ch in _foundObjects)
+            {
+                string name = "";
+                string tp = "";
+                if (ch is not RailSceneObj && ch is not IStageSceneObj) continue;
+                if (ch is RailSceneObj ro) 
+                {
+                    name = ro.RailObj.Name;
+                    tp = "Rail"; 
+                }
+                else
+                {
+                    name = (ch as IStageSceneObj)!.StageObj.Name;
+                    tp = (ch as IStageSceneObj)!.StageObj.Type.ToString();
+                }
+                ImGui.TableNextRow();
+
+                ImGui.TableSetColumnIndex(1);
+
+                ImGui.PushID("SearchSelectable" + cidx);
+                if (ImGui.Selectable(name, false, ImGuiSelectableFlags.None, new(ImGui.GetColumnWidth(), 30)))
+                {
+                    ChangeHandler.ToggleObjectSelection(window, scn.History,
+                        ch.PickingId, !window.Keyboard?.IsCtrlPressed() ?? true);
+                    window.CameraToObject(ch);
+                }
+
+                ImGui.TableSetColumnIndex(2);
+
+                ImGui.Text(tp);
+
+                ImGui.TableSetColumnIndex(0);
+                ImGui.PushID("SearchView" + cidx);
+                if (ImGuiWidgets.HoverButton(IconUtils.MAG_GLASS, new(ImGui.GetColumnWidth(), 30)))
+                {
+                    window.CameraToObject(ch);
+                }
+
+                cidx++;
+            }
+
+            ImGui.EndTable();
+            ImGui.Spacing();
+        }
+
+        ImGui.End();
+    }
+
+    void UpdateSearch(Scene scn)
+    {
+        // If no search filters, show no results
+        _foundObjects.Clear();
+        if (String.IsNullOrWhiteSpace(_name) &&
+        String.IsNullOrWhiteSpace(_class) &&
+        String.IsNullOrWhiteSpace(_layer) &&
+        _camera is null && 
+        _rail is null && 
+        _type == 0 &&
+        _vid == -1 &&
+        _clipId == -1 &&
+        _switches == _baseswitches)
+        {
+            return;
+        }
+        bool add;
+        bool remove;
+        if (!searchRailOnly)
+        foreach (ISceneObj sco in scn.EnumerateSceneObjs())
+        {
+            add = false;
+            remove = false;
+            if (sco is RailSceneObj ro)
+            {
+                if (!String.IsNullOrWhiteSpace(_name))
+                {
+                    if (ro.RailObj.Name.Contains(_name, StringComparison.InvariantCultureIgnoreCase)) add = true;
+                    else remove = true;
+                }
+                
+                if (!String.IsNullOrWhiteSpace(_layer))
+                {
+                    if (ro.RailObj.Layer.Contains(_layer, StringComparison.InvariantCultureIgnoreCase)) add = true;
+                    else remove = true;
+                }
+                
+            }
+            else if (sco is IStageSceneObj st)
+            {
+                if (!String.IsNullOrWhiteSpace(_name))
+                {
+                    if (st.StageObj.Name.Contains(_name, StringComparison.InvariantCultureIgnoreCase)) add = true;
+                    else remove = true;
+                }
+                if (!String.IsNullOrWhiteSpace(_class))
+                {
+                    if (GetClassFromCCNT(st.StageObj.Name)?.Contains(_class, StringComparison.InvariantCultureIgnoreCase) ?? false) add = true;
+                    else remove = true;
+                }
+                if (!String.IsNullOrWhiteSpace(_layer))
+                {
+                    if (st.StageObj.Layer.Contains(_layer, StringComparison.InvariantCultureIgnoreCase)) add = true;
+                    else remove = true;
+                }
+                
+                if (_vid != -1)
+                {
+                    if (st.StageObj.Name == "ViewCtrlArea" && st.StageObj.Properties.ContainsKey("Arg0"))
+                    {
+                        if ((int)st.StageObj.Properties["Arg0"]! == _vid) add = true;
+                        else remove = true;
+                    }
+                    else
+                    {
+                        if ( st.StageObj.ViewId == _vid) add = true;
+                        else remove = true;
+                    }
+                }
+                if (_clipId != -1)
+                {
+                    if ( st.StageObj.ClippingGroupId == _clipId) add = true;
+                    else remove = true;
+                }
+                if (_rail is not null)
+                {
+                    if (st.StageObj.Rail is not null && st.StageObj.Rail == _rail) add = true;
+                    else remove = true;
+                }
+                if (_camera is not null)
+                {
+                    if (st.StageObj.CameraId == _camera.UserGroupId) add = true;
+                    else remove = true;
+                }
+
+                if (_switchAll)
+                {
+                    if (_switch != -1)
+                    {
+                        if (st.StageObj.SwitchA == _switch ||
+                            st.StageObj.SwitchB == _switch ||
+                            st.StageObj.SwitchAppear == _switch ||
+                            st.StageObj.SwitchDeadOn == _switch ||
+                            st.StageObj.SwitchKill == _switch) add = true;
+                        else remove = true;
+                    }
+                }
+                else
+                {
+                    if (_switches[0] != -1)
+                    {
+                        if (st.StageObj.SwitchA == _switches[0]) add = true;
+                        else remove = true;
+                    }
+                    if (_switches[1] != -1)
+                    {
+                        if (st.StageObj.SwitchB == _switches[1]) add = true;
+                        else remove = true;
+                    }
+                    if (_switches[2] != -1)
+                    {
+                        if (st.StageObj.SwitchAppear == _switches[2]) add = true;
+                        else remove = true;
+                    }
+                    if (_switches[3] != -1)
+                    {
+                        if (st.StageObj.SwitchDeadOn == _switches[3]) add = true;
+                        else remove = true;
+                    }
+                    if (_switches[4] != -1)
+                    {
+                        if (st.StageObj.SwitchKill == _switches[4]) add = true;
+                        else remove = true;
+                    }
+                }
+            }
+            if (!remove && add) _foundObjects.Add(sco);
+        }
+        else
+        foreach (RailSceneObj ro in scn.EnumerateRailSceneObjs())
+        {
+            add = false;
+            remove = false;
+            if (!String.IsNullOrWhiteSpace(_name))
+            {
+                if (ro.RailObj.Name.Contains(_name, StringComparison.CurrentCultureIgnoreCase)) add = true;
+                else remove = true;
+            }
+            if (!String.IsNullOrWhiteSpace(_layer))
+            {
+                if (ro.RailObj.Layer.Contains(_layer, StringComparison.CurrentCultureIgnoreCase)) add = true;
+                else remove = true;
+            }
+            if (ro.RailObj.Closed == _closed) add = true;
+            else remove = true;
+            if (ro.RailObj.Points.Count == _railpoints) add = true;
+            else remove = true;
+            if (!remove && add) _foundObjects.Add(ro);
+        }
+
+        
+        // Ignore all fields that are empty or have no value
+        // Console.WriteLine("Updated.");
+    }
+    private string? GetClassFromCCNT(string objectName)
+    {
+        var table = window.ContextHandler.FSHandler.ReadCreatorClassNameTable();
+
+        if (!table.TryGetValue(objectName, out string? className))
+            return null;
+
+        return className;
+    }
+}

--- a/Autumn/GUI/Editors/ParamsEditors/SearchObjDialog.cs
+++ b/Autumn/GUI/Editors/ParamsEditors/SearchObjDialog.cs
@@ -209,13 +209,14 @@ internal class SearchWindow
             
         int obj = 0;
         ImGui.SeparatorText("Search results:");
-        ImGui.SetNextItemWidth(prevW);
-
+        float autoResize = -1;
+        if (ImGui.GetContentRegionAvail().Y < 220 * window.ScalingFactor) 
+            autoResize = 220 * window.ScalingFactor;
         if (ImGui.BeginTable("searchTable", 3,
             ImGuiTableFlags.RowBg
             | ImGuiTableFlags.BordersOuter
             | ImGuiTableFlags.BordersV
-            | ImGuiTableFlags.ScrollY))
+            | ImGuiTableFlags.ScrollY, new Vector2(prevW, autoResize)))
         {
             ImGui.TableSetupScrollFreeze(0, 1); // Makes top row always visible.
             ImGui.TableSetupColumn("Find", ImGuiTableColumnFlags.None);

--- a/Autumn/GUI/Editors/PropertiesWindow.cs
+++ b/Autumn/GUI/Editors/PropertiesWindow.cs
@@ -479,7 +479,7 @@ internal class PropertiesWindow(MainWindowContext window)
                                 var entry = ClassModifiersWrapper.GetEntry(stageObj.Name, cls);
                                 if (entry != null && entry!.Value.Args != null && entry!.Value.Args.ContainsKey(name))
                                 {
-                                    (sceneObj as ActorSceneObj)!.UpdateActorFromArg(window.ContextHandler.FSHandler, (ClassModifiersWrapper.ModifierEntry)entry, name, scn, window.GLTaskScheduler);
+                                    (sceneObj as ActorSceneObj)!.UpdateActorFromArg(window.ContextHandler.FSHandler, (ClassModifiersWrapper.ModifierEntry)entry, name, window.GLTaskScheduler);
                                     if (valueChanged) Console.WriteLine(name);
                                     if (valueChanged) Console.WriteLine(stageObj.Properties[name]);
                                 }

--- a/Autumn/GUI/Editors/PropertiesWindow.cs
+++ b/Autumn/GUI/Editors/PropertiesWindow.cs
@@ -75,7 +75,7 @@ internal class PropertiesWindow(MainWindowContext window)
         var scn = window.CurrentScene;
 
         IEnumerable<ISceneObj> selectedObjects = scn.SelectedObjects;
-        int selectedCount = selectedObjects.Count();
+        int selectedCount = scn.SelectedObjCount;
 
         if (selectedCount < 2 &&
         (multiselector.Layer != mLayer

--- a/Autumn/GUI/Editors/PropertiesWindow.cs
+++ b/Autumn/GUI/Editors/PropertiesWindow.cs
@@ -353,6 +353,7 @@ internal class PropertiesWindow(MainWindowContext window)
                                 return;
                             }
                             if (!name.Contains("Arg")) continue;
+                            bool valueChanged = false;
                             string cls = GetClassFromCCNT(stageObj.Name);
                             if (!ClassDatabaseWrapper.DatabaseEntries.ContainsKey(cls))
                             {
@@ -360,18 +361,17 @@ internal class PropertiesWindow(MainWindowContext window)
                                 {
                                     case int:
                                         int intBuf = (int)(property ?? -1);
-                                        InputIntProperties(name, ref intBuf, 1, ref stageObj);
-
+                                        valueChanged = InputIntProperties(name, ref intBuf, 1, ref stageObj);
                                         break;
 
                                     case string:
                                         string strBuf = (string)(property ?? string.Empty);
-                                        InputTextProperties(name, ref strBuf, 128, ref stageObj);
+                                        valueChanged = InputTextProperties(name, ref strBuf, 128, ref stageObj);
                                         break;
 
                                     case float:
                                         float flBuf = (float)(property ?? -1);
-                                        InputFloatProperties(name, ref flBuf, 1, ref stageObj);
+                                        valueChanged = InputFloatProperties(name, ref flBuf, 1, ref stageObj);
                                         break;
 
                                     default:
@@ -404,6 +404,7 @@ internal class PropertiesWindow(MainWindowContext window)
                                                     if (intBuf != rf)
                                                     {
                                                         ChangeHandler.ChangeDictionaryValue(scn.History, stageObj.Properties, name, intBuf, rf);
+                                                        valueChanged = true;
                                                     }
                                                 }
                                                 else
@@ -417,6 +418,7 @@ internal class PropertiesWindow(MainWindowContext window)
                                                     if (intBuf != argEntry.Values.Keys.ElementAt(rf))
                                                     {
                                                         ChangeHandler.ChangeDictionaryValue(scn.History, stageObj.Properties, name, intBuf, argEntry.Values.Keys.ElementAt(rf));
+                                                        valueChanged = true;
                                                     }
                                                 }
                                             }
@@ -429,6 +431,7 @@ internal class PropertiesWindow(MainWindowContext window)
                                                 if ((intBuf != -1) != rf)
                                                 {
                                                     ChangeHandler.ChangeDictionaryValue(scn.History, stageObj.Properties, name, intBuf, rf ? 1 : -1);
+                                                    valueChanged = true;
                                                 }
                                             }
                                             else // if (argEntry.Type is null || argEntry.Type == "int")
@@ -441,6 +444,7 @@ internal class PropertiesWindow(MainWindowContext window)
                                                 if (intBuf != rf)
                                                 {
                                                     ChangeHandler.ChangeDictionaryValue(scn.History, stageObj.Properties, name, intBuf, rf);
+                                                    valueChanged = true;
                                                     //stageObj.Properties[name] = rf;
                                                 }
                                             }
@@ -448,19 +452,19 @@ internal class PropertiesWindow(MainWindowContext window)
                                         }
                                         else
                                         {
-                                            InputIntProperties(name, ref intBuf, 1, ref stageObj);
+                                            valueChanged = InputIntProperties(name, ref intBuf, 1, ref stageObj);
                                             ImGui.SetItemTooltip("No description");
                                         }
                                         break;
 
                                     case string:
                                         string strBuf = (string)(property ?? string.Empty);
-                                        InputTextProperties(name, ref strBuf, 128, ref stageObj);
+                                        valueChanged = InputTextProperties(name, ref strBuf, 128, ref stageObj);
                                         break;
 
                                     case float:
                                         float flBuf = (float)(property ?? -1);
-                                        InputFloatProperties(name, ref flBuf, 1, ref stageObj);
+                                        valueChanged = InputFloatProperties(name, ref flBuf, 1, ref stageObj);
                                         break;
 
                                     default:
@@ -468,6 +472,16 @@ internal class PropertiesWindow(MainWindowContext window)
                                             "The property type " + property?.GetType().FullName
                                                 ?? "null" + " is not supported."
                                         );
+                                }
+                            }
+                            if (valueChanged && ClassModifiersWrapper.ModifierEntries.ContainsKey(cls))
+                            {
+                                var entry = ClassModifiersWrapper.GetEntry(stageObj.Name, cls);
+                                if (entry != null && entry!.Value.Args != null && entry!.Value.Args.ContainsKey(name))
+                                {
+                                    (sceneObj as ActorSceneObj)!.UpdateActorFromArg(window.ContextHandler.FSHandler, (ClassModifiersWrapper.ModifierEntry)entry, name, scn, window.GLTaskScheduler);
+                                    if (valueChanged) Console.WriteLine(name);
+                                    if (valueChanged) Console.WriteLine(stageObj.Properties[name]);
                                 }
                             }
                         }
@@ -1590,8 +1604,8 @@ internal class PropertiesWindow(MainWindowContext window)
         if (ImGui.InputText("##" + str + "i", ref s, max, ImGuiInputTextFlags.EnterReturnsTrue))
         {
             ChangeHandler.ChangeDictionaryValue(window.CurrentScene!.History, sto.Properties, str, rf, s);
+            return true;
         }
-
         return false;
     }
 
@@ -1605,6 +1619,7 @@ internal class PropertiesWindow(MainWindowContext window)
         if (ImGui.InputInt("##" + str + "i", ref i, step, default, ImGuiInputTextFlags.EnterReturnsTrue))
         {
             ChangeHandler.ChangeDictionaryValue(window.CurrentScene!.History, sto.Properties, str, rf, i);
+            return true;
         }
         return false;
     }
@@ -1618,6 +1633,7 @@ internal class PropertiesWindow(MainWindowContext window)
         if (ImGui.InputInt("##" + str + "i", ref i, step, default, ImGuiInputTextFlags.EnterReturnsTrue))
         {
             ChangeHandler.ChangeDictionaryValue(window.CurrentScene!.History, sto.Properties, str, rf, i);
+            return true;
         }
         return false;
     }
@@ -1631,6 +1647,7 @@ internal class PropertiesWindow(MainWindowContext window)
         if (ImGui.InputInt("##" + str + "i", ref i, step, default, ImGuiInputTextFlags.EnterReturnsTrue))
         {
             ChangeHandler.ChangeDictionaryValue(window.CurrentScene!.History, sto.Properties, str, rf, i);
+            return true;
         }
         return false;
     }
@@ -1643,6 +1660,7 @@ internal class PropertiesWindow(MainWindowContext window)
         if (ImGui.InputFloat("##" + str + "i", ref i, step, default, default, ImGuiInputTextFlags.EnterReturnsTrue))
         {
             ChangeHandler.ChangeDictionaryValue(window.CurrentScene!.History, sto.Properties, str, rf, i);
+            return true;
         }
 
         return false;

--- a/Autumn/GUI/Editors/PropertiesWindow.cs
+++ b/Autumn/GUI/Editors/PropertiesWindow.cs
@@ -21,11 +21,12 @@ internal class PropertiesWindow(MainWindowContext window)
     private int mClip = -1;
     private int mCamera = -1;
     private string mLayer = "共通";
+    private bool localTr = true;
     private ISceneObj? prevObj = null;
     private StageObj multiselector = new();
-    DragFloat3 PosDrag = new(window);
-    DragFloat3 RotDrag = new(window);
-    LinkedDragFloat3 ScaleDrag = new(window);
+    DragFloat3 PosDrag = new(window, "Position");
+    DragFloat3 RotDrag = new(window, "Rotation");
+    LinkedDragFloat3 ScaleDrag = new(window, "Scale");
     ImGuiWidgets.InputComboBox namebox = new();
     ImGuiWindowClass windowClass = new() { DockNodeFlagsOverrideSet = ImGuiDockNodeFlags.AutoHideTabBar | ImGuiWidgets.NO_WINDOW_MENU_BUTTON}; //ImGuiWidgets.NO_TAB_BAR };
 
@@ -81,10 +82,32 @@ internal class PropertiesWindow(MainWindowContext window)
         (multiselector.Layer != mLayer
         || multiselector.ClippingGroupId != mClip
         || multiselector.ViewId != mView
-        || multiselector.CameraId != mCamera)
+        || multiselector.CameraId != mCamera
+        || multiselector.Translation != Vector3.Zero
+        || multiselector.Scale != Vector3.One
+        || multiselector.Rotation != Vector3.Zero)
         )
         {
             multiselector = new();
+            if (prevObj != null)
+            {
+                if (prevObj is IStageSceneObj prevStageSceneObj)
+                {
+                    PosDrag.Finish(ref prevStageSceneObj.StageObj.Translation, prevStageSceneObj);
+                    RotDrag.Finish(ref prevStageSceneObj.StageObj.Rotation, prevStageSceneObj);
+                    ScaleDrag.Finish(ref prevStageSceneObj.StageObj.Scale, prevStageSceneObj);
+                }
+                else if (prevObj is RailPointSceneObj rps)
+                {
+                    PosDrag.Finish(ref rps.RailPoint.Point0Trans, rps);
+                }
+                else if (prevObj is RailHandleSceneObj rph)
+                {
+                    PosDrag.Finish(ref rph.Offset, rph);
+                }
+
+                prevObj.UpdateTransform();
+            }
         }
         if (selectedCount <= 0)
         {
@@ -103,17 +126,17 @@ internal class PropertiesWindow(MainWindowContext window)
             {
                 if (prevObj is IStageSceneObj prevStageSceneObj)
                 {
-                    PosDrag.Finish(ref prevStageSceneObj.StageObj.Translation);
-                    RotDrag.Finish(ref prevStageSceneObj.StageObj.Rotation);
-                    ScaleDrag.Finish(ref prevStageSceneObj.StageObj.Scale);
+                    PosDrag.Finish(ref prevStageSceneObj.StageObj.Translation, prevStageSceneObj);
+                    RotDrag.Finish(ref prevStageSceneObj.StageObj.Rotation, prevStageSceneObj);
+                    ScaleDrag.Finish(ref prevStageSceneObj.StageObj.Scale, prevStageSceneObj);
                 }
                 else if (prevObj is RailPointSceneObj rps)
                 {
-                    PosDrag.Finish(ref rps.RailPoint.Point0Trans);
+                    PosDrag.Finish(ref rps.RailPoint.Point0Trans, rps);
                 }
                 else if (prevObj is RailHandleSceneObj rph)
                 {
-                    PosDrag.Finish(ref rph.Offset);
+                    PosDrag.Finish(ref rph.Offset, rph);
                 }
 
                 prevObj.UpdateTransform();
@@ -244,7 +267,7 @@ internal class PropertiesWindow(MainWindowContext window)
                     if (stageObj.Type != StageObjType.Start)
                     {
                         InputInt("ViewId", ref stageObj.ViewId, 1, ref stageObj);
-                        ImGui.Text("Camera Id:"); ImGui.SameLine();
+                        ImGui.Text("Camera:"); ImGui.SameLine();
                         for (int cs = 1; cs < cameraStrings.Length; cs++)
                         {
                             cameraStrings[cs] = cameraslinks[cs - 1].CameraName();
@@ -254,8 +277,7 @@ internal class PropertiesWindow(MainWindowContext window)
                         if (csd != null) rff = cameraslinks.IndexOf(csd) + 1;
                         else if (stageObj.CameraId != -1) stageObj.CameraId = -1; // Make sure cameras return to -1 if the camera is removed, since the combobox shows that, it should be coherent with it
                         int orff = rff;
-                        //ImGuiWidgets.PrePropertyWidthName("Camera Id", 30, 20);
-                        ImGui.SetNextItemWidth(ImGuiWidgets.SetPropertyWidth("Camera Id:") - ImGui.CalcTextSize(rff == 0 ? IconUtils.PLUS : IconUtils.PENCIL).X - 12);
+                        ImGui.SetNextItemWidth(ImGuiWidgets.SetPropertyWidth("Camera:") - ImGui.CalcTextSize(rff == 0 ? IconUtils.PLUS : IconUtils.PENCIL).X - 12);
                         ImGui.Combo("##CAMERA SELECT", ref rff, cameraStrings, cameraStrings.Length);
                         if (rff != orff)
                         {
@@ -348,9 +370,9 @@ internal class PropertiesWindow(MainWindowContext window)
                     ImGui.SetCursorPosY(ImGui.GetCursorPosY() - style.ItemSpacing.Y);
                     ImGui.BeginChild("trl", default, ImGuiChildFlags.AutoResizeY);
                     ImGui.SetCursorPosY(ImGui.GetCursorPosY() + 4);
-                    PosDrag.Use("Position", ref stageObj.Translation, ref sceneObj, 10);
-                    RotDrag.Use("Rotation", ref stageObj.Rotation, ref sceneObj, 0.5f);
-                    ScaleDrag.Use("Scale", ref stageObj.Scale, ref sceneObj, 0.01f, style);
+                    PosDrag.Use(ref stageObj.Translation, ref sceneObj, 10);
+                    RotDrag.Use(ref stageObj.Rotation, ref sceneObj, 0.5f);
+                    ScaleDrag.Use(ref stageObj.Scale, ref sceneObj, 0.01f, style);
                     ImGui.EndChild();
                 }
 
@@ -1009,8 +1031,8 @@ internal class PropertiesWindow(MainWindowContext window)
                             if (!autoResize) ImGui.Spacing();
                             if (delay != null) ChangeHandler.ChangeMovePoint(window, window.CurrentScene.History, railSceneObj, delay, railSceneObj.RailPoints.IndexOf(delay) + (n ? -1 : 1));
 
-                            if (sceneObj is RailPointSceneObj) PosDrag.Use("Position", ref (sceneObj as RailPointSceneObj)!.RailPoint.Point0Trans, ref sceneObj, 10);
-                            else if (sceneObj is RailHandleSceneObj) PosDrag.Use("Position", ref (sceneObj as RailHandleSceneObj)!.Offset, ref sceneObj, 10);
+                            if (sceneObj is RailPointSceneObj) PosDrag.Use(ref (sceneObj as RailPointSceneObj)!.RailPoint.Point0Trans, ref sceneObj, 10);
+                            else if (sceneObj is RailHandleSceneObj) PosDrag.Use(ref (sceneObj as RailHandleSceneObj)!.Offset, ref sceneObj, 10);
 
                             ImGui.PopItemWidth();
                             ImGui.EndChild();
@@ -1026,8 +1048,8 @@ internal class PropertiesWindow(MainWindowContext window)
                             ImGui.SetCursorPosY(ImGui.GetCursorPosY() + 4);
                             ImGui.PushItemWidth(ImGui.GetWindowWidth() - style.WindowPadding.X * 2 - PROP_WIDTH / 2);
 
-                            if (sceneObj is RailPointSceneObj) PosDrag.Use("Position", ref (sceneObj as RailPointSceneObj)!.RailPoint.Point0Trans, ref sceneObj, 10);
-                            else if (sceneObj is RailHandleSceneObj) PosDrag.Use("Position", ref (sceneObj as RailHandleSceneObj)!.Offset, ref sceneObj, 10);
+                            if (sceneObj is RailPointSceneObj) PosDrag.Use(ref (sceneObj as RailPointSceneObj)!.RailPoint.Point0Trans, ref sceneObj, 10);
+                            else if (sceneObj is RailHandleSceneObj) PosDrag.Use(ref (sceneObj as RailHandleSceneObj)!.Offset, ref sceneObj, 10);
 
                             ImGui.PopItemWidth();
                             ImGui.EndChild();
@@ -1206,24 +1228,123 @@ internal class PropertiesWindow(MainWindowContext window)
         else
         {
             // Multiple objects selected:
-            ImGui.TextDisabled("Multiple objects selected.");
-            InputText("Layer", ref multiselector.Layer, 30, ref multiselector);
-            InputInt("ViewId", ref multiselector.ViewId, 1, ref multiselector);
-            //InputInt("CameraId", ref multiselector.CameraId, 1, ref multiselector);
-            ImGui.Text("CameraId"); ImGui.SameLine();
+            SetTitle("Multiple objects", null);
+            bool propertyChanged = false;
+            propertyChanged = InputText("Layer", ref multiselector.Layer, 30, ref multiselector);
+            propertyChanged = InputInt("ViewId", ref multiselector.ViewId, 1, ref multiselector);
+            ImGui.Text("Camera:"); ImGui.SameLine();
             var cameraslinks = scn.Stage.CameraParams.Cameras.Where(x => x.Category == StageCamera.CameraCategory.Object).ToList();
             string[] cameraStrings = new string[cameraslinks.Count + 1];
             cameraStrings[0] = "No camera selected";
+            int rff = 0;
             for (int cs = 1; cs < cameraStrings.Length; cs++)
             {
                 cameraStrings[cs] = cameraslinks[cs - 1].Category.ToString();
                 cameraStrings[cs] += "Camera";
                 cameraStrings[cs] += cameraslinks[cs - 1].UserGroupId;
+                if (multiselector.CameraId == cameraslinks[cs -1].UserGroupId)
+                {
+                    rff = cs;
+                }
             }
-            int rff = 0;
-            ImGui.Combo("##CAMERA SELECT", ref rff, cameraStrings, cameraStrings.Length);
-            InputInt("ClippingGroupId", ref multiselector.ClippingGroupId, 1, ref multiselector);
+            ImGui.SetNextItemWidth(ImGuiWidgets.SetPropertyWidth("Camera:") - ImGui.CalcTextSize(rff == 0 ? IconUtils.PLUS : IconUtils.PENCIL).X - 12);
+            if (ImGui.Combo("##CAMERA SELECT", ref rff, cameraStrings, cameraStrings.Length))
+            // if (rff != multiselector.CameraId)
+            {
+                propertyChanged = true;
+                if (rff == 0) multiselector.CameraId = -1;
+                else multiselector.CameraId = cameraslinks[rff - 1].UserGroupId;
+            }
+            ImGui.SameLine(default, style.ItemSpacing.X / 2);
+            if (ImGui.Button(rff == 0 ? IconUtils.PLUS : IconUtils.PENCIL)) // Edit the camera -> open the camera window and select it. Add if no camera selected
+            {
 
+                ImGui.SetWindowFocus("Cameras");
+                if (rff == 0)
+                {
+                    StageCamera.CameraCategory camType = StageCamera.CameraCategory.Object;
+                    StageCamera newCam = new() { Category = camType };
+                    scn!.Stage.CameraParams.AddCamera(newCam);
+                    window.SetCameraSelected(scn.Stage.CameraParams.Cameras.Count - 1);
+                    window.UpdateCameraList();
+                    multiselector.CameraId = newCam.UserGroupId;
+                }
+                else
+                {
+                    StageCamera.CameraCategory camType = StageCamera.CameraCategory.Object;
+                    var cm = scn!.Stage.CameraParams.GetCamera(multiselector.CameraId, camType);
+                    window.SetCameraSelected(scn.Stage.CameraParams.Cameras.IndexOf(cm!));
+                }
+            }
+            propertyChanged = InputInt("ClippingGroupId", ref multiselector.ClippingGroupId, 1, ref multiselector);
+
+
+            if (ImGui.CollapsingHeader("Object Transform", ImGuiTreeNodeFlags.DefaultOpen))
+            {
+                ImGui.Checkbox($"Transform type: {(localTr ? "Relative" : "Global")}", ref localTr);
+                ImGui.SetCursorPosY(ImGui.GetCursorPosY() - style.ItemSpacing.Y);
+                ImGui.BeginChild("trl", default, ImGuiChildFlags.AutoResizeY);
+                ImGui.SetCursorPosY(ImGui.GetCursorPosY() + 4);
+                // Reimplement entirely for multiple?
+                Vector3 Dif = multiselector.Translation;
+                if (ImGui.DragFloat3("MultiPos", ref multiselector.Translation, 10))
+                {
+                    Dif = multiselector.Translation - Dif;
+                    foreach (ISceneObj obj in scn.SelectedObjects)
+                    {
+                        if (obj is RailPointSceneObj) 
+                        {
+                            (obj as RailPointSceneObj)!.RailPoint.Point0Trans = localTr ? (obj as RailPointSceneObj)!.RailPoint.Point0Trans + Dif : multiselector.Translation;
+                            (obj as RailPointSceneObj)!.UpdateModel();
+                        }
+                        else if (obj is RailHandleSceneObj)
+                        {
+                             (obj as RailHandleSceneObj)!.Offset = localTr ? (obj as RailHandleSceneObj)!.Offset + Dif : multiselector.Translation;
+                            (obj as RailHandleSceneObj)!.UpdateTransform();
+                        }
+                        else if (obj is IStageSceneObj stageScene) 
+                        {
+                            stageScene.StageObj.Translation = localTr ? stageScene.StageObj.Translation + Dif : multiselector.Translation;
+                            obj.UpdateTransform();
+                        }
+                    }
+                }
+                Dif = multiselector.Rotation;
+                if (ImGui.DragFloat3("MultiRot", ref multiselector.Rotation, 0.5f))
+                {
+                    Dif = multiselector.Rotation - Dif;
+                    foreach (ISceneObj obj in scn.SelectedObjects)
+                    {
+                        if (obj is not IStageSceneObj stageScene) continue;
+                        stageScene.StageObj.Rotation = localTr ? stageScene.StageObj.Rotation + Dif : multiselector.Rotation;
+                        stageScene.UpdateTransform();
+                    }
+                }
+                Dif = multiselector.Scale;
+                if (ImGui.DragFloat3("MultiScale", ref multiselector.Scale, 0.01f))
+                {
+                    Dif = multiselector.Scale - Dif;
+                    foreach (ISceneObj obj in scn.SelectedObjects)
+                    {
+                        if (obj is not IStageSceneObj stageScene) continue;
+                        stageScene.StageObj.Scale = localTr ? stageScene.StageObj.Scale + Dif : multiselector.Scale;
+                        stageScene.UpdateTransform();
+                    }
+                }
+                // if (PosDrag.Use("Position", ref multiselector.Translation, 10))
+                // {
+                //     foreach (ISceneObj obj in scn.SelectedObjects)
+                //     {
+                //         if (obj is not IStageSceneObj stageScene) continue;
+                //         stageScene.StageObj.Translation = localTr ? stageScene.StageObj.Translation + multiselector.Translation : multiselector.Translation;
+                //     }
+                // }
+                // RotDrag.Use("Rotation", ref multiselector.Rotation, ref sceneObj, 0.5f);
+                // ScaleDrag.Use("Scale", ref multiselector.Scale, ref sceneObj, 0.01f, style);
+                ImGui.EndChild();
+            }
+
+            //if (propertyChanged)
             foreach (ISceneObj obj in scn.SelectedObjects)
             {
                 if (obj is not IStageSceneObj stageScene) continue;
@@ -1236,7 +1357,9 @@ internal class PropertiesWindow(MainWindowContext window)
                     stageScene.StageObj.ClippingGroupId = multiselector.ClippingGroupId;
                 if (multiselector.Layer != mLayer)
                     stageScene.StageObj.Layer = multiselector.Layer;
+                
             }
+            
         }
 
         //ImGui.PopStyleColor();
@@ -1271,6 +1394,7 @@ internal class PropertiesWindow(MainWindowContext window)
         bool isFinished = true;
         Vector2 min, max = new();
         public float reference = 0.723764823f;
+        public bool IsActive => (isEditing || isDragging) && !isFinished;
 
         public bool Use(string str, ref float rf, ImGuiStylePtr style, float v_speed = 1, bool isSingle = true)
         {
@@ -1337,33 +1461,44 @@ internal class PropertiesWindow(MainWindowContext window)
 
     private class DragFloat3
     {
+        string RefString = "Position";
         CustomDragFloat DragFloatX;
         CustomDragFloat DragFloatY;
         CustomDragFloat DragFloatZ;
         Vector3 refVec3;
+        Vector3 baseValue;
         MainWindowContext _window;
-        public DragFloat3(MainWindowContext window)
+        public DragFloat3(MainWindowContext window, string name)
         {
             _window = window;
             DragFloatX = new();
             DragFloatY = new();
             DragFloatZ = new();
+            RefString = name;
         }
-        public bool Use(string str, ref Vector3 rf, ref ISceneObj sto, float v_speed = 1, float? width = null, bool linked = false)
+        bool isActive = false;
+        public bool Use(ref Vector3 rf, ref ISceneObj sto, float v_speed = 1, float? width = null, bool linked = false)
         {
+            if (!isActive)
+            {
+                baseValue = new(rf.X, rf.Y, rf.Z);
+                Console.WriteLine("Not active");
+            }
             if (refVec3 != rf)
             {
                 refVec3 = rf;
+                Console.WriteLine("RefUpdated");
             }
-            var style = ImGui.GetStyle();
             bool validate = false;
+            isActive = DragFloatX.IsActive || DragFloatY.IsActive || DragFloatZ.IsActive;
+            var style = ImGui.GetStyle();
 
-            float stringWidth = ImGui.CalcTextSize(str + ":").X;
+            float stringWidth = ImGui.CalcTextSize(RefString + ":").X;
             float itemWidth;// = width ?? (ImGui.GetWindowWidth() - stringWidth) / 3 - style.ItemSpacing.X * 2 - 4;
 
             if (width == null)
             {
-                ImGui.Text(str + ":");
+                ImGui.Text(RefString + ":");
                 ImGui.SameLine(default, style.ItemSpacing.X);
                 if (ImGui.GetWindowWidth() - (ImGui.GetWindowWidth() * 3 / 4 - ImGui.GetStyle().ItemSpacing.X / 2) > (stringWidth + 12))
                 {
@@ -1384,8 +1519,8 @@ internal class PropertiesWindow(MainWindowContext window)
             //ImGui.SetCursorPosY(ImGui.GetCursorPosY() + 0);
             itemWidth = itemWidth / 3 - style.ItemSpacing.X - 7;
 
-            ImGui.PushStyleColor(ImGuiCol.ChildBg, s_axisColors[0] & 0x7fffffff); // NEEDS CONSTANT
-            if (ImGui.BeginChild(str + "XTest", new(20 * _window.ScalingFactor, 20 * _window.ScalingFactor + style.ItemSpacing.Y)))
+            ImGui.PushStyleColor(ImGuiCol.ChildBg, s_axisColors[0] & 0x7fffffff);
+            if (ImGui.BeginChild(RefString + "XTest", new(20 * _window.ScalingFactor, 20 * _window.ScalingFactor + style.ItemSpacing.Y)))
             {
                 ImGui.SetCursorPos(ImGui.GetWindowSize() / 2 - ImGui.CalcTextSize("X") / 2);
                 ImGui.Text("X");
@@ -1394,14 +1529,14 @@ internal class PropertiesWindow(MainWindowContext window)
             ImGui.PopStyleColor();
             ImGui.SameLine(default, 0);
             ImGui.SetNextItemWidth(itemWidth);
-            if (DragFloatX.Use(str + "X", ref refVec3.X, style, v_speed, false))
+            if (DragFloatX.Use(RefString + "X", ref refVec3.X, style, v_speed, false))
                 validate = true;
 
 
             ImGui.SameLine(default, style.ItemSpacing.X / 2);
 
-            ImGui.PushStyleColor(ImGuiCol.ChildBg, s_axisColors[1] & 0x7fffffff); // NEEDS CONSTANT
-            if (ImGui.BeginChild(str + "YTest", new(20 * _window.ScalingFactor, 20 * _window.ScalingFactor + style.ItemSpacing.Y)))
+            ImGui.PushStyleColor(ImGuiCol.ChildBg, s_axisColors[1] & 0x7fffffff);
+            if (ImGui.BeginChild(RefString + "YTest", new(20 * _window.ScalingFactor, 20 * _window.ScalingFactor + style.ItemSpacing.Y)))
             {
                 ImGui.SetCursorPos(ImGui.GetWindowSize() / 2 - ImGui.CalcTextSize("Y") / 2);
                 ImGui.Text("Y");
@@ -1410,14 +1545,14 @@ internal class PropertiesWindow(MainWindowContext window)
             ImGui.PopStyleColor();
             ImGui.SameLine(default, 0);
             ImGui.SetNextItemWidth(itemWidth);
-            if (DragFloatY.Use(str + "Y", ref refVec3.Y, style, v_speed, false))
+            if (DragFloatY.Use(RefString + "Y", ref refVec3.Y, style, v_speed, false))
                 validate = true;
 
 
             ImGui.SameLine(default, style.ItemSpacing.X / 2);
 
-            ImGui.PushStyleColor(ImGuiCol.ChildBg, s_axisColors[2] & 0x7fffffff); // NEEDS CONSTANT
-            if (ImGui.BeginChild(str + "ZTest", new(20 * _window.ScalingFactor, 20 * _window.ScalingFactor + style.ItemSpacing.Y)))
+            ImGui.PushStyleColor(ImGuiCol.ChildBg, s_axisColors[2] & 0x7fffffff);
+            if (ImGui.BeginChild(RefString + "ZTest", new(20 * _window.ScalingFactor, 20 * _window.ScalingFactor + style.ItemSpacing.Y)))
             {
                 ImGui.SetCursorPos(ImGui.GetWindowSize() / 2 - ImGui.CalcTextSize("Z") / 2);
                 ImGui.Text("Z");
@@ -1427,7 +1562,7 @@ internal class PropertiesWindow(MainWindowContext window)
             ImGui.SameLine(default, 0);
 
             ImGui.SetNextItemWidth(itemWidth);
-            if (DragFloatZ.Use(str + "Z", ref refVec3.Z, style, v_speed, false))
+            if (DragFloatZ.Use(RefString + "Z", ref refVec3.Z, style, v_speed, false))
                 validate = true;
 
 
@@ -1455,39 +1590,34 @@ internal class PropertiesWindow(MainWindowContext window)
 
                 if (sto is IStageSceneObj stageSceneObj)
                 {
-                    switch (str)
+                    switch (RefString)
                     {
                         case "Position":
                         case "Translation":
                             stageSceneObj.StageObj.Translation = rV;
                             stageSceneObj.UpdateTransform();
-                            stageSceneObj.StageObj.Translation = tmprf;
                             break;
 
                         case "Rotation":
                             stageSceneObj.StageObj.Rotation = rV;
                             stageSceneObj.UpdateTransform();
-                            stageSceneObj.StageObj.Rotation = tmprf;
                             break;
 
                         case "Scale":
                             stageSceneObj.StageObj.Scale = rV;
                             stageSceneObj.UpdateTransform();
-                            stageSceneObj.StageObj.Scale = tmprf;
                             break;
                     }
                 }
-                else if (sto is RailPointSceneObj rps && str == "Position")
+                else if (sto is RailPointSceneObj rps && RefString == "Position")
                 {
                     rps.RailPoint.Point0Trans = rV;
                     rps.UpdateModel();
-                    rps.RailPoint.Point0Trans = tmprf;
                 }
-                else if (sto is RailHandleSceneObj rhs && str == "Position")
+                else if (sto is RailHandleSceneObj rhs && RefString == "Position")
                 {
                     rhs.Offset = rV;
                     rhs.UpdateTransform();
-                    rhs.Offset = tmprf;
                 }
             }
             if (validate)
@@ -1507,16 +1637,15 @@ internal class PropertiesWindow(MainWindowContext window)
                         refVec3 = new(refVec3.Z);
                     }
                 }
-                if (str == "Position") str = "Translation";
 
                 if (sto is IStageSceneObj stageSceneObj)
-                    ChangeHandler.ChangeStageObjTransform(_window.CurrentScene!.History, stageSceneObj, str, rf, refVec3);
+                    ChangeHandler.ChangeStageObjTransform(_window.CurrentScene!.History, stageSceneObj, RefString == "Position" ? "Translation" : RefString, baseValue, refVec3);
                 else if (sto is RailPointSceneObj rps)
                 {
                     ChangeHandler.ChangePointPosition(
                         _window.CurrentScene!.History,
                         rps,
-                        rf,
+                        baseValue,
                         refVec3,
                         false
                     );
@@ -1526,33 +1655,61 @@ internal class PropertiesWindow(MainWindowContext window)
                     ChangeHandler.ChangeHandleTransform(
                         _window.CurrentScene!.History,
                         rhs,
-                        rf,
+                        baseValue,
                         refVec3,
                         false
                     );
                 }
+                isActive = false;
                 return true;
             }
 
             return false;
         }
 
-        public void Finish(ref Vector3 rf)
+        public void Finish(ref Vector3 rf, ISceneObj sto)
         {
             DragFloatX.Finish(ref rf.X);
             DragFloatY.Finish(ref rf.Y);
             DragFloatZ.Finish(ref rf.Z);
+            if (baseValue != refVec3)
+            {
+                if (sto is IStageSceneObj stageSceneObj)
+                    ChangeHandler.ChangeStageObjTransform(_window.CurrentScene!.History, stageSceneObj, RefString == "Position" ? "Translation" : RefString, baseValue, refVec3);
+                else if (sto is RailPointSceneObj rps)
+                {
+                    ChangeHandler.ChangePointPosition(
+                        _window.CurrentScene!.History,
+                        rps,
+                        baseValue,
+                        refVec3,
+                        false
+                    );
+                }
+                else if (sto is RailHandleSceneObj rhs)
+                {
+                    ChangeHandler.ChangeHandleTransform(
+                        _window.CurrentScene!.History,
+                        rhs,
+                        baseValue,
+                        refVec3,
+                        false
+                    );
+                }
+            }
+            isActive = false;
         }
+        
     }
 
-    private class LinkedDragFloat3(MainWindowContext window)
+    private class LinkedDragFloat3(MainWindowContext window, string name)
     {
-        DragFloat3 ScaleDrag3 = new(window);
+        DragFloat3 ScaleDrag3 = new(window, name);
         bool isLinked = false;
-        public bool Use(string str, ref Vector3 rf, ref ISceneObj sto, float v_speed, ImGuiStylePtr style)
+        public bool Use(ref Vector3 rf, ref ISceneObj sto, float v_speed, ImGuiStylePtr style)
         {
-            ImGui.Text(str + ":");
-            float stringWidth = ImGui.CalcTextSize(str + ":").X;
+            ImGui.Text(name + ":");
+            float stringWidth = ImGui.CalcTextSize(name + ":").X;
             float itemWidth;
             ImGui.SameLine();
             if (ImGui.GetWindowWidth() - (ImGui.GetWindowWidth() * 3 / 4 - style.ItemSpacing.X / 2) > (stringWidth + 12))
@@ -1564,7 +1721,7 @@ internal class PropertiesWindow(MainWindowContext window)
             {
                 itemWidth = ImGui.GetWindowWidth() - stringWidth - style.ItemSpacing.X * 2 - 24 - 32;
             }
-            bool ret = ScaleDrag3.Use(str, ref rf, ref sto, v_speed, itemWidth, isLinked);
+            bool ret = ScaleDrag3.Use(ref rf, ref sto, v_speed, itemWidth, isLinked);
             ImGui.SameLine(default, style.ItemSpacing.X / 2);
             if (ImGui.Button(isLinked ? IconUtils.LINK : IconUtils.UNLINK))
             {
@@ -1573,9 +1730,9 @@ internal class PropertiesWindow(MainWindowContext window)
             return ret;
         }
 
-        public void Finish(ref Vector3 rf)
+        public void Finish(ref Vector3 rf, ISceneObj sco)
         {
-            ScaleDrag3.Finish(ref rf);
+            ScaleDrag3.Finish(ref rf, sco);
         }
     }
 

--- a/Autumn/GUI/Editors/PropertiesWindow.cs
+++ b/Autumn/GUI/Editors/PropertiesWindow.cs
@@ -372,6 +372,16 @@ internal class PropertiesWindow(MainWindowContext window)
                             if (!name.Contains("Arg")) continue;
                             bool valueChanged = false;
                             string cls = GetClassFromCCNT(stageObj.Name);
+                            if ((stageObj.Name.Contains("FogArea", StringComparison.InvariantCultureIgnoreCase)
+                                || stageObj.Name.Equals("LightArea", StringComparison.InvariantCultureIgnoreCase))
+                                && name == "Arg0")
+                            {
+                                bool isfog = stageObj.Name.Contains("FogArea", StringComparison.InvariantCultureIgnoreCase);
+                                string t = isfog ? "Fog" : "Light";
+                                int intBuf = (int)(property ?? -1);
+                                InputFogLight(t, intBuf, 1, ref stageSceneObj, isfog);
+                                continue;
+                            }
                             if (!ClassDatabaseWrapper.DatabaseEntries.ContainsKey(cls))
                             {
                                 switch (property)
@@ -1677,7 +1687,43 @@ internal class PropertiesWindow(MainWindowContext window)
         ImGui.SetNextItemWidth(ImGuiWidgets.SetPropertyWidthGen(name + IconUtils.TRASH + IconUtils.TRASH + IconUtils.TRASH, 1, 2));
     }
 
-    private bool InputSwitch(string str, ref int rf, int step, ref IStageSceneObj sco)
+    private bool InputFogLight(string str, int rf, int step, ref IStageSceneObj sco, bool isFog)
+    {
+        int i = rf;
+
+        string tt = isFog ? "Edit Fog" : "Edit Light Area";
+        var f = window.CurrentScene!.GetFog(rf);
+        var l = window.CurrentScene!.GetLightArea(rf);
+
+        bool disable = rf < 0 || (isFog ? (f == null) : (l == null));
+        if (disable)
+            ImGui.BeginDisabled();
+        if (ImGui.Button(str + " id##flbtn", new(ImGui.GetWindowWidth() / 3 - ImGui.GetStyle().ItemSpacing.X, default)))
+        {
+            if (isFog)
+                window.SetFogSelected(window.CurrentScene.Stage.StageFogs.IndexOf(f!));
+            else
+                window.SetLightSelected(rf);
+        }
+        if (disable)
+            ImGui.EndDisabled();
+
+        if (!disable && tt != "")
+            ImGui.SetItemTooltip(tt);
+
+        ImGui.SameLine();
+        ImGuiWidgets.SetPropertyWidth(str);
+        if (ImGui.InputInt("##" + str, ref i, step, default, ImGuiInputTextFlags.EnterReturnsTrue))
+        {
+            i = Math.Clamp(i, -1, 9999);
+            ChangeHandler.ChangeDictionaryValue(window.CurrentScene!.History, sco.StageObj.Properties, "Arg0", rf, i);
+            
+        }
+        if (tt != "")
+            ImGui.SetItemTooltip(tt);
+
+        return false;
+    }    private bool InputSwitch(string str, ref int rf, int step, ref IStageSceneObj sco)
     {
         int i = rf;
 

--- a/Autumn/GUI/Editors/PropertiesWindow.cs
+++ b/Autumn/GUI/Editors/PropertiesWindow.cs
@@ -288,7 +288,7 @@ internal class PropertiesWindow(MainWindowContext window)
 
                         InputInt("ClippingGroupId", ref stageObj.ClippingGroupId, 1, ref stageObj);
                     }
-                    if (stageObj.Type == StageObjType.Area || stageObj.Type == StageObjType.CameraArea)
+                    if (stageObj.Type == StageObjType.Area || stageObj.Type == StageObjType.CameraArea || stageObj.Type == StageObjType.AreaChild)
                     {
                         if (!stageObj.Properties.ContainsKey("Priority"))
                         {
@@ -308,9 +308,10 @@ internal class PropertiesWindow(MainWindowContext window)
 
                         if (!stageObj.Properties.ContainsKey("ShapeModelNo"))
                         {
-                            ImGui.Text("ShapeModelNo:");
+                            ImGui.Text("Shape:");
+                            ImGui.SetItemTooltip("ShapeModelNo");
                             ImGui.SameLine();
-                            ImGuiWidgets.SetPropertyWidth("ShapeModelNo");
+                            ImGuiWidgets.SetPropertyWidth("Shape");
                             if (ImGui.Button("No shape property"))
                             {
                                 stageObj.Properties["ShapeModelNo"] = 0;
@@ -318,8 +319,25 @@ internal class PropertiesWindow(MainWindowContext window)
                         }
                         else
                         {
+                            ImGui.Text("Shape:");
+                            ImGui.SetItemTooltip("ShapeModelNo");
+                            ImGui.SameLine();
+                            ImGuiWidgets.SetPropertyWidth("Shape");
                             int shp = (int)stageObj.Properties["ShapeModelNo"]!;
-                            InputIntProperties("ShapeModelNo", ref shp, 1, ref stageObj);
+                            if (shp < 0 || shp > 3)
+                            {
+                                if (ImGui.InputInt("##ShapeModelNoInt", ref shp, 1, default, ImGuiInputTextFlags.EnterReturnsTrue))
+                                {
+                                    ChangeHandler.ChangeDictionaryValue(window.CurrentScene!.History, stageObj.Properties, "ShapeModelNo", stageObj.Properties["ShapeModelNo"], shp);
+                                }
+                            }
+                            else
+                            {
+                                if (ImGui.Combo("##ShapeModelNoCombo", ref shp, ["Cube (Base)", "Cube (Middle)", "Sphere", "Cylinder"], 4))
+                                {
+                                    ChangeHandler.ChangeDictionaryValue(window.CurrentScene!.History, stageObj.Properties, "ShapeModelNo", stageObj.Properties["ShapeModelNo"], shp);
+                                }
+                            }
                         }
                     }
                     ImGui.PopItemWidth();

--- a/Autumn/GUI/Editors/PropertiesWindow.cs
+++ b/Autumn/GUI/Editors/PropertiesWindow.cs
@@ -583,9 +583,6 @@ internal class PropertiesWindow(MainWindowContext window)
 
                                             ImGui.Text(ch.Type.ToString());
 
-                                            ImGui.PushStyleColor(ImGuiCol.Button, 0);
-                                            ImGui.PushStyleColor(ImGuiCol.ButtonHovered, 0);
-                                            ImGui.PushStyleColor(ImGuiCol.ButtonActive, 0);
                                             ImGui.TableSetColumnIndex(0);
                                             ImGui.PushID("SceneChildView" + cidx);
                                             if (ImGuiWidgets.HoverButton(IconUtils.MAG_GLASS, new(ImGui.GetColumnWidth(), 30)))
@@ -600,7 +597,6 @@ internal class PropertiesWindow(MainWindowContext window)
                                             {
                                                 remch = ch;
                                             }
-                                            ImGui.PopStyleColor(3);
 
                                             cidx++;
                                         }
@@ -952,16 +948,12 @@ internal class PropertiesWindow(MainWindowContext window)
                                             !window.Keyboard?.IsCtrlPressed() ?? true);
                                         window.CameraToObject(point);
                                     }
-                                    ImGui.PushStyleColor(ImGuiCol.Button, 0);
-                                    ImGui.PushStyleColor(ImGuiCol.ButtonHovered, 0);
-                                    ImGui.PushStyleColor(ImGuiCol.ButtonActive, 0);
                                     ImGui.TableSetColumnIndex(0);
                                     ImGui.PushID("ScenePointView" + cidx);
                                     if (ImGuiWidgets.HoverButton(IconUtils.MAG_GLASS, new(ImGui.GetColumnWidth(), 30)))
                                     {
                                         window.CameraToObject(railSceneObj.RailPoints[cidx]);
                                     }
-                                    ImGui.PopStyleColor(3);
 
                                     ImGui.TableSetColumnIndex(2);
                                     if (cidx == 0) ImGui.BeginDisabled();
@@ -1039,17 +1031,13 @@ internal class PropertiesWindow(MainWindowContext window)
                                 {
                                     ImGui.TableNextRow();
 
-                                    ImGui.PushStyleColor(ImGuiCol.Button, 0);
-                                    ImGui.PushStyleColor(ImGuiCol.ButtonHovered, 0);
-                                    ImGui.PushStyleColor(ImGuiCol.ButtonActive, 0);
                                     ImGui.TableSetColumnIndex(0);
                                     ImGui.PushID("SceneHandleView" + cc);
-                                    if (ImGui.Button(IconUtils.MAG_GLASS, new(-1, 25)))
+                                    if (ImGuiWidgets.HoverButton(IconUtils.MAG_GLASS, new(ImGui.GetColumnWidth(), 30)))
                                     {
                                         var hndl = cc == 0 ? (sceneObj as RailPointSceneObj)!.Handle1 : (sceneObj as RailPointSceneObj)!.Handle2;
                                         window.CameraToObject(hndl!);
                                     }
-                                    ImGui.PopStyleColor(3);
 
                                     ImGui.TableSetColumnIndex(1);
                                     ImGui.PushID("SceneHandleSelectable" + cc);

--- a/Autumn/GUI/Editors/PropertiesWindow.cs
+++ b/Autumn/GUI/Editors/PropertiesWindow.cs
@@ -1479,15 +1479,13 @@ internal class PropertiesWindow(MainWindowContext window)
         bool isActive = false;
         public bool Use(ref Vector3 rf, ref ISceneObj sto, float v_speed = 1, float? width = null, bool linked = false)
         {
-            if (!isActive)
+            if (!isActive && baseValue != rf)
             {
                 baseValue = new(rf.X, rf.Y, rf.Z);
-                Console.WriteLine("Not active");
             }
             if (refVec3 != rf)
             {
                 refVec3 = rf;
-                Console.WriteLine("RefUpdated");
             }
             bool validate = false;
             isActive = DragFloatX.IsActive || DragFloatY.IsActive || DragFloatZ.IsActive;

--- a/Autumn/GUI/Editors/PropertiesWindow.cs
+++ b/Autumn/GUI/Editors/PropertiesWindow.cs
@@ -146,7 +146,6 @@ internal class PropertiesWindow(MainWindowContext window)
             }
 
             string oldName = stageObj.Name;
-            ImGui.GetIO().ConfigDragClickToInputText = true; //TODO - MOVE TO EDITOR STARTUP SETUP
 
             // Fake dock
             string oldClassCCNT = GetClassFromCCNT(oldName);

--- a/Autumn/GUI/Editors/SceneWindow.cs
+++ b/Autumn/GUI/Editors/SceneWindow.cs
@@ -819,7 +819,7 @@ internal class SceneWindow(MainWindowContext window)
         {
             window.ExtrasFrameBuffer.Use(window.GL!);
             window.GL!.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
-            Canvas.CanvasRenderer.Render(window.GL!, window.ContextHandler.SystemSettings.EXPERIMENTAL_SelectionOutline, window.SceneFramebuffer);
+            Canvas.CanvasRenderer.Render(window.GL!, window);
         }
         GizmoButtons(upperRightCorner);
         ActionPanel(contentAvail);

--- a/Autumn/GUI/Editors/SceneWindow.cs
+++ b/Autumn/GUI/Editors/SceneWindow.cs
@@ -116,7 +116,7 @@ internal class SceneWindow(MainWindowContext window)
         else if (IsRotationActive)
             ActTransform.FullTransformString = "Rotating ";
 
-        if (window.CurrentScene!.SelectedObjects.Count() > 1)
+        if (window.CurrentScene!.SelectedObjCount > 1)
             ActTransform.FullTransformString += "multiple objects";
         else
         {
@@ -311,10 +311,10 @@ internal class SceneWindow(MainWindowContext window)
             }
         }
 
-            // if ((window.Keyboard?.IsKeyP ressed(Key.Space) ?? false) && window.CurrentScene.SelectedObjects.Count() > 0){
+            // if ((window.Keyboard?.IsKeyP ressed(Key.Space) ?? false) && window.CurrentScene.SelectedObjCount > 0){
             //     camera.LookAt(camera.Eye, window.CurrentScene.SelectedObjects.First().StageObj.Translation*0.01f);
             // }
-        if (window.CurrentScene.SelectedObjects.Any() || CamToObj)
+        if (window.CurrentScene.SelectedObjCount > 0 || CamToObj)
         {
             CamToObj = CamToObj ? CamToObj : (window.Keyboard?.IsKeyPressed(Key.Space) ?? false);
             if (!ImGui.GetIO().WantTextInput)
@@ -474,7 +474,7 @@ internal class SceneWindow(MainWindowContext window)
         bool ScaleGizmoHovered = false;
         HoveredAxis TransformGizmoAxis = HoveredAxis.NONE;
 
-        if (window.CurrentScene!.SelectedObjects.Any() && window.ContextHandler.SystemSettings.LastGizmo != 0)
+        if (window.CurrentScene!.SelectedObjCount > 0 && window.ContextHandler.SystemSettings.LastGizmo != 0)
         {
             // Method one: Gizmo is placed in the middle position of the selected objects
             if (window.ContextHandler.SystemSettings.GizmoPosition == GizmoPosition.Middle)
@@ -720,9 +720,9 @@ internal class SceneWindow(MainWindowContext window)
                 if (window.CurrentScene.TryGetPickableObj(pixel, out _pickObject) && _pickObject != null && (_pickObject is IStageSceneObj || _pickObject is RailSceneObj))
                 {
                     _objectOptionsPos = windowMousePos;
-                    bool select1 = window.CurrentScene.SelectedObjects.Count() == 1;
+                    bool select1 = window.CurrentScene.SelectedObjCount == 1;
 
-                    bool selectover1 = window.CurrentScene.SelectedObjects.Count() > 0;
+                    bool selectover1 = window.CurrentScene.SelectedObjCount > 0;
 
                     _selNotSame = selectover1 ? !window.CurrentScene.SelectedObjects.Contains(_pickObject) : true;
 
@@ -755,7 +755,7 @@ internal class SceneWindow(MainWindowContext window)
                 else
                     _isObjectOptionsEnabled = false;
             }
-            else if ((_isSceneHovered && window.CurrentScene.SelectedObjects.Any()) || IsTranslationActive || IsScaleActive || IsRotationActive)
+            else if ((_isSceneHovered && window.CurrentScene.SelectedObjCount > 0) || IsTranslationActive || IsScaleActive || IsRotationActive)
             {
                 Vector3 _ndcMousePos3D =
                     new(ndcMousePos.X * sceneImageSize.X / 2,
@@ -942,7 +942,7 @@ internal class SceneWindow(MainWindowContext window)
         //ImGui.PushFont(window.FontPointers[1]);
         ImGui.PushStyleVar(ImGuiStyleVar.FrameRounding, 0f);
         ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(1, default));
-        float buttons = ImGui.CalcTextSize(IconUtils.GRID).X*5 + 5*10;
+        float buttons = ImGui.CalcTextSize(IconUtils.GRID).X*5 + 5*11 +12;
         ImGui.SetCursorPos(new Vector2(contentAvail.X - buttons, opos.Y - 3f));
 
         if (ImGui.Button(IconUtils.GRID))
@@ -979,6 +979,11 @@ internal class SceneWindow(MainWindowContext window)
         ImGui.SetItemTooltip($"CameraArea visibility {(ModelRenderer.VisibleCameraAreas ? "ON" : "OFF")}");
         ImGui.SameLine();
 
+        if (ImGui.Button("A"))
+        {
+            ModelRenderer.UseFullAlphaPipeline = !ModelRenderer.UseFullAlphaPipeline;
+        }
+        ImGui.SetItemTooltip($"Pipeline {(ModelRenderer.UseFullAlphaPipeline ? "ON": "OFF")}");
 
         ImGui.PopStyleVar(2);
         //ImGui.PopFont();
@@ -1205,7 +1210,7 @@ internal class SceneWindow(MainWindowContext window)
             _axisLock = Vector3.One;
 
             // Add to Undo stack
-            if (window.CurrentScene!.SelectedObjects.Count() == 1)
+            if (window.CurrentScene!.SelectedObjCount == 1)
             {
                 var sobj = window.CurrentScene.SelectedObjects.First();
                 switch (sobj)
@@ -1511,7 +1516,7 @@ internal class SceneWindow(MainWindowContext window)
             FinishTransform = false;
             _axisLock = Vector3.One;
 
-            if (window.CurrentScene!.SelectedObjects.Count() == 1)
+            if (window.CurrentScene!.SelectedObjCount == 1)
             {
                 var sobj = window.CurrentScene.SelectedObjects.First();
                 switch (sobj)
@@ -1827,7 +1832,7 @@ internal class SceneWindow(MainWindowContext window)
             FinishTransform = false;
             _axisLock = Vector3.One;
 
-            if (window.CurrentScene!.SelectedObjects.Count() == 1)
+            if (window.CurrentScene!.SelectedObjCount == 1)
             {
                 var sobj = window.CurrentScene.SelectedObjects.First();
                 switch (sobj)

--- a/Autumn/GUI/Editors/SceneWindow.cs
+++ b/Autumn/GUI/Editors/SceneWindow.cs
@@ -218,8 +218,12 @@ internal class SceneWindow(MainWindowContext window)
         window.SceneFramebuffer.SetSize((uint)contentAvail.X, (uint)contentAvail.Y);
         window.SceneFramebuffer.Create(window.GL!);
 
+        window.ExtraFB.SetSize((uint)contentAvail.X, (uint)contentAvail.Y);
+        window.ExtraFB.Create(window.GL!);
+
+        Vector2 imPos = ImGui.GetCursorPos();
         ImGui.Image(
-            new IntPtr(window.SceneFramebuffer.GetColorTexture(0)),
+            new IntPtr(window.ExtraFB.GetColorTexture(0)),
             contentAvail,
             new Vector2(0, 1),
             new Vector2(1, 0)
@@ -810,6 +814,10 @@ internal class SceneWindow(MainWindowContext window)
                 
             }
         }
+
+        window.ExtraFB.Use(window.GL!);
+        window.GL!.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
+        Canvas.CanvasRenderer.Render(window.GL!, window.SceneFramebuffer);
         
         GizmoButtons(upperRightCorner);
         ActionPanel(contentAvail);

--- a/Autumn/GUI/Editors/SceneWindow.cs
+++ b/Autumn/GUI/Editors/SceneWindow.cs
@@ -364,8 +364,8 @@ internal class SceneWindow(MainWindowContext window)
                 switch (CamSceneObj)
                 {
                     case ISceneObj x when x is IStageSceneObj y:
-                        aabb *= y.StageObj.Scale;
                         camera.LookFrom(y.StageObj.Translation * 0.01f, aabb.GetDiagonal() * 0.01f);
+                        aabb *= y.StageObj.Scale * ((y is ActorSceneObj) ? (y as ActorSceneObj)!.DeltaScale: Vector3.One);
                         break;
                     case ISceneObj x when x is RailSceneObj y:
                         camera.LookFrom(y.Center * 0.01f, aabb.GetDiagonal() * 0.02f);

--- a/Autumn/GUI/Editors/SceneWindow.cs
+++ b/Autumn/GUI/Editors/SceneWindow.cs
@@ -217,13 +217,14 @@ internal class SceneWindow(MainWindowContext window)
 
         window.SceneFramebuffer.SetSize((uint)contentAvail.X, (uint)contentAvail.Y);
         window.SceneFramebuffer.Create(window.GL!);
-
-        window.ExtrasFrameBuffer.SetSize((uint)contentAvail.X, (uint)contentAvail.Y);
-        window.ExtrasFrameBuffer.Create(window.GL!);
-
+        if (ModelRenderer.UsePostProcessing)
+        {
+            window.ExtrasFrameBuffer.SetSize((uint)contentAvail.X, (uint)contentAvail.Y);
+            window.ExtrasFrameBuffer.Create(window.GL!);
+        }
         Vector2 imPos = ImGui.GetCursorPos();
         ImGui.Image(
-            new IntPtr(window.ExtrasFrameBuffer.GetColorTexture(0)),
+            new IntPtr(ModelRenderer.UsePostProcessing ? window.ExtrasFrameBuffer.GetColorTexture(0) : window.SceneFramebuffer.GetColorTexture(0)),
             contentAvail,
             new Vector2(0, 1),
             new Vector2(1, 0)
@@ -814,11 +815,12 @@ internal class SceneWindow(MainWindowContext window)
                 
             }
         }
-
-        window.ExtrasFrameBuffer.Use(window.GL!);
-        window.GL!.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
-        Canvas.CanvasRenderer.Render(window.GL!, window.SceneFramebuffer);
-        
+        if (ModelRenderer.UsePostProcessing)
+        {
+            window.ExtrasFrameBuffer.Use(window.GL!);
+            window.GL!.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
+            Canvas.CanvasRenderer.Render(window.GL!, window.SceneFramebuffer);
+        }
         GizmoButtons(upperRightCorner);
         ActionPanel(contentAvail);
         ActionMenu(deltaSeconds);
@@ -950,8 +952,16 @@ internal class SceneWindow(MainWindowContext window)
         //ImGui.PushFont(window.FontPointers[1]);
         ImGui.PushStyleVar(ImGuiStyleVar.FrameRounding, 0f);
         ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(1, default));
-        float buttons = ImGui.CalcTextSize(IconUtils.GRID).X*5 + 5*11 +12;
+        float buttons = ImGui.CalcTextSize(IconUtils.GRID).X*6 + 6*11 +12;
         ImGui.SetCursorPos(new Vector2(contentAvail.X - buttons, opos.Y - 3f));
+
+
+        if (ImGui.Button(IconUtils.USER))
+        {
+            ModelRenderer.UsePostProcessing = !ModelRenderer.UsePostProcessing;
+        }
+        ImGui.SetItemTooltip($"Post Processing {(ModelRenderer.UsePostProcessing ? "ON" : "OFF")}");
+        ImGui.SameLine();
 
         if (ImGui.Button(IconUtils.GRID))
         {

--- a/Autumn/GUI/Editors/SceneWindow.cs
+++ b/Autumn/GUI/Editors/SceneWindow.cs
@@ -217,14 +217,14 @@ internal class SceneWindow(MainWindowContext window)
 
         window.SceneFramebuffer.SetSize((uint)contentAvail.X, (uint)contentAvail.Y);
         window.SceneFramebuffer.Create(window.GL!);
-        if (ModelRenderer.UsePostProcessing)
+        if (window.ContextHandler.SystemSettings.EXPERIMENTAL_PostProcess)
         {
             window.ExtrasFrameBuffer.SetSize((uint)contentAvail.X, (uint)contentAvail.Y);
             window.ExtrasFrameBuffer.Create(window.GL!);
         }
         Vector2 imPos = ImGui.GetCursorPos();
         ImGui.Image(
-            new IntPtr(ModelRenderer.UsePostProcessing ? window.ExtrasFrameBuffer.GetColorTexture(0) : window.SceneFramebuffer.GetColorTexture(0)),
+            new IntPtr(window.ContextHandler.SystemSettings.EXPERIMENTAL_PostProcess ? window.ExtrasFrameBuffer.GetColorTexture(0) : window.SceneFramebuffer.GetColorTexture(0)),
             contentAvail,
             new Vector2(0, 1),
             new Vector2(1, 0)
@@ -815,11 +815,11 @@ internal class SceneWindow(MainWindowContext window)
                 
             }
         }
-        if (ModelRenderer.UsePostProcessing)
+        if (window.ContextHandler.SystemSettings.EXPERIMENTAL_PostProcess)
         {
             window.ExtrasFrameBuffer.Use(window.GL!);
             window.GL!.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
-            Canvas.CanvasRenderer.Render(window.GL!, window.SceneFramebuffer);
+            Canvas.CanvasRenderer.Render(window.GL!, window.ContextHandler.SystemSettings.EXPERIMENTAL_SelectionOutline, window.SceneFramebuffer);
         }
         GizmoButtons(upperRightCorner);
         ActionPanel(contentAvail);
@@ -958,9 +958,9 @@ internal class SceneWindow(MainWindowContext window)
 
         if (ImGui.Button(IconUtils.USER))
         {
-            ModelRenderer.UsePostProcessing = !ModelRenderer.UsePostProcessing;
+            window.ContextHandler.SystemSettings.EXPERIMENTAL_PostProcess = !window.ContextHandler.SystemSettings.EXPERIMENTAL_PostProcess;
         }
-        ImGui.SetItemTooltip($"Post Processing {(ModelRenderer.UsePostProcessing ? "ON" : "OFF")}");
+        ImGui.SetItemTooltip($"Post Processing {(window.ContextHandler.SystemSettings.EXPERIMENTAL_PostProcess ? "ON" : "OFF")}");
         ImGui.SameLine();
 
         if (ImGui.Button(IconUtils.GRID))

--- a/Autumn/GUI/Editors/SceneWindow.cs
+++ b/Autumn/GUI/Editors/SceneWindow.cs
@@ -218,12 +218,12 @@ internal class SceneWindow(MainWindowContext window)
         window.SceneFramebuffer.SetSize((uint)contentAvail.X, (uint)contentAvail.Y);
         window.SceneFramebuffer.Create(window.GL!);
 
-        window.ExtraFB.SetSize((uint)contentAvail.X, (uint)contentAvail.Y);
-        window.ExtraFB.Create(window.GL!);
+        window.ExtrasFrameBuffer.SetSize((uint)contentAvail.X, (uint)contentAvail.Y);
+        window.ExtrasFrameBuffer.Create(window.GL!);
 
         Vector2 imPos = ImGui.GetCursorPos();
         ImGui.Image(
-            new IntPtr(window.ExtraFB.GetColorTexture(0)),
+            new IntPtr(window.ExtrasFrameBuffer.GetColorTexture(0)),
             contentAvail,
             new Vector2(0, 1),
             new Vector2(1, 0)
@@ -815,7 +815,7 @@ internal class SceneWindow(MainWindowContext window)
             }
         }
 
-        window.ExtraFB.Use(window.GL!);
+        window.ExtrasFrameBuffer.Use(window.GL!);
         window.GL!.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
         Canvas.CanvasRenderer.Render(window.GL!, window.SceneFramebuffer);
         

--- a/Autumn/GUI/Editors/SceneWindow.cs
+++ b/Autumn/GUI/Editors/SceneWindow.cs
@@ -433,7 +433,7 @@ internal class SceneWindow(MainWindowContext window)
         window.GL!.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
 
         window.CurrentScene?.Render(
-            window.GL,
+            window,
             viewMatrix,
             projectionMatrix,
             window.CurrentScene.Camera.Rotation,

--- a/Autumn/GUI/Editors/SceneWindow.cs
+++ b/Autumn/GUI/Editors/SceneWindow.cs
@@ -364,8 +364,8 @@ internal class SceneWindow(MainWindowContext window)
                 switch (CamSceneObj)
                 {
                     case ISceneObj x when x is IStageSceneObj y:
-                        camera.LookFrom(y.StageObj.Translation * 0.01f, aabb.GetDiagonal() * 0.01f);
                         aabb *= y.StageObj.Scale * ((y is ActorSceneObj) ? (y as ActorSceneObj)!.DeltaScale: Vector3.One);
+                        camera.LookFrom(y.StageObj.Translation * 0.01f, aabb.GetDiagonal() * 0.01f);
                         break;
                     case ISceneObj x when x is RailSceneObj y:
                         camera.LookFrom(y.Center * 0.01f, aabb.GetDiagonal() * 0.02f);

--- a/Autumn/GUI/Editors/SceneWindow.cs
+++ b/Autumn/GUI/Editors/SceneWindow.cs
@@ -31,6 +31,7 @@ internal class SceneWindow(MainWindowContext window)
     public bool FinishTransform = false;
 
     private string _transformChangeString = "";
+    public bool FlyCam = false;
 
     internal static class ActTransform
     {
@@ -316,7 +317,7 @@ internal class SceneWindow(MainWindowContext window)
         camMoveSpeed *= window.Keyboard!.IsKeyPressed(Key.ShiftRight) || window.Keyboard.IsKeyPressed(Key.ShiftLeft) ? 6 : 1;
         if ((_isSceneHovered || _isSceneWindowFocused) && !ImGui.GetIO().WantTextInput)
         {
-            if (window.ContextHandler.SystemSettings.UseWASD)
+            if (window.ContextHandler.SystemSettings.UseWASD || FlyCam)
             {
                 if (!ImGui.IsKeyDown(ImGuiKey.ModCtrl) && !ImGui.IsKeyDown(ImGuiKey.ModSuper))
                 {
@@ -335,6 +336,8 @@ internal class SceneWindow(MainWindowContext window)
                     if (window.Keyboard?.IsKeyPressed(Key.E) ?? false)
                         camera.Eye += Vector3.UnitY * camMoveSpeed;
                 }
+                if (FlyCam && (window.Keyboard?.IsKeyPressed(Key.Escape) ?? false))
+                    FlyCam = false;
             }
         }
 
@@ -782,7 +785,7 @@ internal class SceneWindow(MainWindowContext window)
                 else
                     _isObjectOptionsEnabled = false;
             }
-            else if ((_isSceneHovered && window.CurrentScene.SelectedObjCount > 0) || IsTranslationActive || IsScaleActive || IsRotationActive)
+            else if (!FlyCam && ((_isSceneHovered && window.CurrentScene.SelectedObjCount > 0) || IsTranslationActive || IsScaleActive || IsRotationActive))
             {
                 Vector3 _ndcMousePos3D =
                     new(ndcMousePos.X * sceneImageSize.X / 2,
@@ -790,50 +793,50 @@ internal class SceneWindow(MainWindowContext window)
                         (normPickingDepth * 10 - 1) / 10f);
                 _ndcMousePos3D = Vector3.Transform(_ndcMousePos3D, window.CurrentScene.Camera.Rotation);
 
-            if (TranslateToPoint)
-            {
-                TranslateToPoint = false;
-                var sobj = window.CurrentScene.SelectedObjects.First();
-
-                switch (sobj)
+                if (TranslateToPoint)
                 {
-                    case ISceneObj x when x is IStageSceneObj y:
-                        ChangeHandler.ChangeStageObjTransform(
-                            window.CurrentScene.History,
-                            y,
-                            "Translation",
-                            y.StageObj.Translation,
-                            100 * new Vector3(worldMousePos.X, worldMousePos.Y, worldMousePos.Z)
-                        );
-                        break;
-                    case ISceneObj x when x is RailPointSceneObj y:
-                    ChangeHandler.ChangePointPosition(
-                            window.CurrentScene.History,
-                            y,
-                            y.RailPoint.Point0Trans,
-                            100 * new Vector3(worldMousePos.X, worldMousePos.Y, worldMousePos.Z),
-                            !ImGui.IsKeyDown(ImGuiKey.ModShift)
-                        );
-                        break;
-                    case ISceneObj x when x is RailHandleSceneObj y:
-                        ChangeHandler.ChangeHandleTransform(
-                            window.CurrentScene.History,
-                            y,
-                            y.Offset,
-                            -y.ParentPoint.RailPoint.Point0Trans + 100 * new Vector3(worldMousePos.X, worldMousePos.Y, worldMousePos.Z),
-                            false
-                        );
-                        break;
-                    case ISceneObj x when x is RailSceneObj y:
-                    break;
-                }
+                    TranslateToPoint = false;
+                    var sobj = window.CurrentScene.SelectedObjects.First();
 
-                if (!_isSceneWindowFocused)
-                    ImGui.SetWindowFocus();
-            }
-            TranslateAction(_ndcMousePos3D);
-            RotateAction(ndcMousePos);
-            ScaleAction(_ndcMousePos3D);
+                    switch (sobj)
+                    {
+                        case ISceneObj x when x is IStageSceneObj y:
+                            ChangeHandler.ChangeStageObjTransform(
+                                window.CurrentScene.History,
+                                y,
+                                "Translation",
+                                y.StageObj.Translation,
+                                100 * new Vector3(worldMousePos.X, worldMousePos.Y, worldMousePos.Z)
+                            );
+                            break;
+                        case ISceneObj x when x is RailPointSceneObj y:
+                        ChangeHandler.ChangePointPosition(
+                                window.CurrentScene.History,
+                                y,
+                                y.RailPoint.Point0Trans,
+                                100 * new Vector3(worldMousePos.X, worldMousePos.Y, worldMousePos.Z),
+                                !ImGui.IsKeyDown(ImGuiKey.ModShift)
+                            );
+                            break;
+                        case ISceneObj x when x is RailHandleSceneObj y:
+                            ChangeHandler.ChangeHandleTransform(
+                                window.CurrentScene.History,
+                                y,
+                                y.Offset,
+                                -y.ParentPoint.RailPoint.Point0Trans + 100 * new Vector3(worldMousePos.X, worldMousePos.Y, worldMousePos.Z),
+                                false
+                            );
+                            break;
+                        case ISceneObj x when x is RailSceneObj y:
+                        break;
+                    }
+
+                    if (!_isSceneWindowFocused)
+                        ImGui.SetWindowFocus();
+                }
+                TranslateAction(_ndcMousePos3D);
+                RotateAction(ndcMousePos);
+                ScaleAction(_ndcMousePos3D);
                 
             }
         }
@@ -967,6 +970,15 @@ internal class SceneWindow(MainWindowContext window)
 
             ImGui.SetCursorPos(opos + new Vector2(8, -2));
             ImGui.Text(ActTransform.FullTransformString);
+            ImGui.SetWindowFontScale(1.0f);
+            ImGui.SetCursorPos(opos);
+        }
+        else if (FlyCam)
+        {
+            ImGui.SetWindowFontScale(1.0f);
+
+            ImGui.SetCursorPos(opos + new Vector2(8, -2));
+            ImGui.Text("Fly Cam Mode enabled, press Esc to exit.");
             ImGui.SetWindowFontScale(1.0f);
             ImGui.SetCursorPos(opos);
         }

--- a/Autumn/GUI/Editors/SceneWindow.cs
+++ b/Autumn/GUI/Editors/SceneWindow.cs
@@ -127,7 +127,7 @@ internal class SceneWindow(MainWindowContext window)
             else if (fs is RailHandleSceneObj) ActTransform.FullTransformString += $"{(fs as RailHandleSceneObj)!.ParentPoint.ParentRail.RailObj.Name} Point {(fs as RailHandleSceneObj)!.ParentPoint.ParentRail.RailPoints.IndexOf((fs as RailHandleSceneObj)!.ParentPoint)} Handle";
         }
 
-        if (_axisLock == Vector3.UnitX || _axisLock == Vector3.UnitY || _axisLock == Vector3.UnitZ)
+        if (_axisLock == Vector3.UnitX || _axisLock == Vector3.UnitY || _axisLock == Vector3.UnitZ || _axisLock != Vector3.One)
         {
             ActTransform.FullTransformString += " on the ";
 
@@ -137,25 +137,47 @@ internal class SceneWindow(MainWindowContext window)
                 ActTransform.FullTransformString += "Y ";
             else if (_axisLock == Vector3.UnitZ)
                 ActTransform.FullTransformString += "Z ";
+            else
+            {
+                if (_axisLock == Vector3.UnitX + Vector3.UnitY)
+                    ActTransform.FullTransformString += "Z ";
+                else if (_axisLock == Vector3.UnitY + Vector3.UnitZ)
+                    ActTransform.FullTransformString += "X ";
+                else if (_axisLock == Vector3.UnitZ + Vector3.UnitX)
+                    ActTransform.FullTransformString += "Y ";
+            }
 
-
-            ActTransform.FullTransformString += "axis";
+            if (_axisLock == Vector3.UnitX || _axisLock == Vector3.UnitY || _axisLock == Vector3.UnitZ)
+                ActTransform.FullTransformString += "axis";
+            else
+                ActTransform.FullTransformString += "plane";
 
             if (_transformChangeString != "-" && _transformChangeString != "" && _axisLock != Vector3.One)
                 ActTransform.FullTransformString += ": " + (_transformChangeString != "-" ? _transformChangeString : "");
             else
-                ActTransform.FullTransformString += ": ";
+            {
+                if (_axisLock == Vector3.UnitX)
+                    ActTransform.FullTransformString += $": {STR.X:0.00}";
+
+                if (_axisLock == Vector3.UnitY)
+                    ActTransform.FullTransformString += $": {STR.Y:0.00}";
+
+                if (_axisLock == Vector3.UnitZ)
+                    ActTransform.FullTransformString += $": {STR.Z:0.00}";
+
+
+                if (_axisLock == Vector3.UnitX + Vector3.UnitY)
+                    ActTransform.FullTransformString += $": X: {STR.X:0.00}, Y: {STR.Y:0.00}";
+
+                if (_axisLock == Vector3.UnitY + Vector3.UnitZ)
+                    ActTransform.FullTransformString += $": Y: {STR.Y:0.00}, Z: {STR.Z:0.00}";
+
+                if (_axisLock == Vector3.UnitZ + Vector3.UnitX)
+                    ActTransform.FullTransformString += $": X: {STR.X:0.00}, Z: {STR.Z:0.00}";
+            }
 
 
 
-            if (_axisLock == Vector3.UnitX)
-                ActTransform.FullTransformString += $" {STR.X:0.00}";
-
-            if (_axisLock == Vector3.UnitY)
-                ActTransform.FullTransformString += $" {STR.Y:0.00}";
-
-            if (_axisLock == Vector3.UnitZ)
-                ActTransform.FullTransformString += $" {STR.Z:0.00}";
         }
         else
         {
@@ -1658,12 +1680,7 @@ internal class SceneWindow(MainWindowContext window)
             if (!IsTransformFromGizmo)
                 GetAxis();
 
-            if (_axisLock != Vector3.One)
-            {
-                TransformChange();
-            }
-            else
-                _transformChangeString = "";
+            TransformChange();
 
             var fst = window.CurrentScene!.SelectedObjects.First();
             switch (fst)
@@ -1706,9 +1723,7 @@ internal class SceneWindow(MainWindowContext window)
 
                     if (_transformChangeString != string.Empty && _transformChangeString != "-")
                     {
-                        (sobj as IStageSceneObj)!.StageObj.Scale =
-                            ActTransform.Originals[sobj]
-                            + Vector3.One * (distB - distA) / 500 * _axisLock * float.Parse(_transformChangeString); // original scale * (distance to selection from mouse )
+                        (sobj as IStageSceneObj)!.StageObj.Scale = Vector3.One - _axisLock + _axisLock * float.Parse(_transformChangeString);
                     }
                     else
                     {

--- a/Autumn/GUI/Editors/SceneWindow.cs
+++ b/Autumn/GUI/Editors/SceneWindow.cs
@@ -15,6 +15,7 @@ internal class SceneWindow(MainWindowContext window)
 {
     public bool IsWindowFocused => _isSceneWindowFocused;
     public bool IsSceneHovered => _isSceneHovered;
+    public bool ExternalSceneChange = true;
     public bool IsTransformActive => IsTranslationActive || IsRotationActive || IsScaleActive;
     public bool IsTransformFromGizmo = false;
     public bool IsTranslationActive = false;
@@ -177,8 +178,6 @@ internal class SceneWindow(MainWindowContext window)
                     ActTransform.FullTransformString += $": X: {STR.X:0.00}, Z: {STR.Z:0.00}";
             }
 
-
-
         }
         else
         {
@@ -189,9 +188,6 @@ internal class SceneWindow(MainWindowContext window)
     ImGuiWindowClass windowClass = new() { DockNodeFlagsOverrideSet = ImGuiDockNodeFlags.AutoHideTabBar | ImGuiWidgets.NO_WINDOW_MENU_BUTTON}; // | ImGuiDockNodeFlags.NoUndocking };
     public unsafe void Render(double deltaSeconds)
     {
-        if (window.CurrentScene is null)
-            return;
-
         float aspectRatio;
 
         Vector2 sceneImageRectMin;
@@ -220,14 +216,25 @@ internal class SceneWindow(MainWindowContext window)
         }
         ImGui.PopStyleColor(3);
 
-        if (!sceneReady)
+        if (!window.ContextHandler.IsProjectLoaded)
         {
-            ImGui.TextDisabled("The stage is being loaded, please wait...");
+            ImGui.TextDisabled("No project loaded.");
             ImGui.End();
             return;
         }
 
-        Vector2 contentAvail = ImGui.GetContentRegionAvail() - new Vector2(0, 24 * window.ScalingFactor);
+        Vector2 TPos = ImGui.GetCursorPos() + new Vector2(0, 1);
+        if (!sceneReady)
+        {
+            TabsPanel();
+            ImGui.SetCursorPosY(TPos.Y);
+            ImGui.TextDisabled("Please open a stage.");
+            ImGui.End();
+            return;
+        }
+        ImGui.SetCursorPosY(26 * window.ScalingFactor);
+
+        Vector2 contentAvail = ImGui.GetContentRegionAvail() - new Vector2(0, 26 * window.ScalingFactor);
         aspectRatio = contentAvail.X / contentAvail.Y;
         Vector2 sceneWindowRegionMin = ImGui.GetCursorScreenPos();
         Vector2 sceneWindowRegionMax = ImGui.GetCursorScreenPos() + contentAvail;
@@ -846,9 +853,26 @@ internal class SceneWindow(MainWindowContext window)
             window.GL!.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
             Canvas.CanvasRenderer.Render(window.GL!, window);
         }
+
         GizmoButtons(upperRightCorner);
         ActionPanel(contentAvail);
         ActionMenu(deltaSeconds);
+        ImGui.SetCursorPos(TPos);
+
+        ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, Vector2.UnitX * 2);
+        if (ImGui.BeginChild("TabsChild", new Vector2(-1, 25 * window.ScalingFactor), ImGuiChildFlags.AlwaysUseWindowPadding))
+        {
+            if (!TabsPanel())
+            {
+                ImGui.TextDisabled("No stage loaded.");
+                ImGui.PopStyleVar();
+                ImGui.EndChild();
+                ImGui.End();
+                return;
+            }
+            ImGui.EndChild();
+        }
+        ImGui.PopStyleVar();
 
         ImGui.End();
     }
@@ -1068,8 +1092,49 @@ internal class SceneWindow(MainWindowContext window)
         }
         ImGui.SetCursorPos(olpos);
     }
-    private void TabsPanel()
+    private bool TabsPanel()
     {
+        ImGui.PushStyleVar(ImGuiStyleVar.TabRounding, 0);
+        ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(default, 0));
+        ImGui.PushStyleVar(ImGuiStyleVar.ItemInnerSpacing, Vector2.UnitX );
+
+        if (ImGui.BeginTabBar("##SuperSceneTabs"))
+        {
+            for (int i = 0; i < window.Scenes.Count; i++)
+            {
+                ImGuiTabItemFlags flags = ImGuiTabItemFlags.NoPushId;
+
+                Scene scene = window.Scenes[i];
+
+                if (!scene.IsSaved) 
+                    flags |= ImGuiTabItemFlags.UnsavedDocument;
+                if (scene == window.CurrentScene && ExternalSceneChange) 
+                {
+                    flags |= ImGuiTabItemFlags.SetSelected;
+                }
+
+                bool opened = true;
+                string displayName = scene.Stage.Name + scene.Stage.Scenario;
+                if (ImGui.BeginTabItem($"{displayName}##SceneTab{i}", ref opened, flags | ImGuiTabItemFlags.NoAssumedClosure) && (ExternalSceneChange ? window.CurrentScene == scene : window.CurrentScene != scene))
+                {
+                    ExternalSceneChange = false;
+                    window.CurrentScene = scene;
+                    ImGui.EndTabItem();
+                }
+
+                ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(8));
+                ImGui.SetItemTooltip(scene.Stage.UserPath);
+                ImGui.PopStyleVar();
+                if (!opened)
+                {
+                    window.CloseStage(scene);
+                }
+            }
+
+            ImGui.EndTabBar();
+        }
+        ImGui.PopStyleVar(3);
+        return window.Scenes.Count > 0;
     }
 
     public void TranslateAction(Vector3 _ndcMousePos3D)

--- a/Autumn/GUI/Editors/StageWindow.cs
+++ b/Autumn/GUI/Editors/StageWindow.cs
@@ -91,51 +91,10 @@ internal class StageWindow
             {
                 foreach (var (name, scenario) in window.ContextHandler.ProjectStages)
                 {
-                    if (scenario == 0)
+                    if (scenario == 0) // Why?
                         continue;
-
-                    ImGui.TableNextRow();
-                    ImGui.TableSetColumnIndex(0);
-
-                    if (ImGui.Selectable(name +$"##{name}{scenario}", false, ImGuiSelectableFlags.SpanAllColumns))
-                    {
-                        Scene? scene = window.Scenes.Find(scene =>
-                            scene.Stage.Name == name && scene.Stage.Scenario == scenario
-                        );
-
-                        if (scene is not null) // Stage already opened
-                            window.CurrentScene = scene;
-                        else
-                        {
-                            window.BackgroundManager.Add(
-                                $"Loading stage \"{name + scenario}\"...",
-                                manager =>
-                                {
-                                    Stage stage = window.ContextHandler.FSHandler.ReadStage(name, scenario);
-
-                                    Scene newScene =
-                                        new(
-                                            stage,
-                                            window.ContextHandler.FSHandler,
-                                            window.GLTaskScheduler,
-                                            ref manager.StatusMessageSecondary
-                                        )
-                                        {
-                                            IsSaved = true
-                                        };
-
-                                    newScene.ResetCamera();
-                                    window.Scenes.Add(newScene);
-                                    ImGui.SetWindowFocus("Objects");
-                                }
-                            );
-                        }
-
-                    }
-
-                    ImGui.TableNextColumn();
-
-                    ImGui.Text(scenario.ToString());
+                    
+                    StageSelectable(name, scenario);
                 }
             }
             else
@@ -143,58 +102,13 @@ internal class StageWindow
                 foreach (
                     SystemDataTable.StageDefine _stage in window
                         .ContextHandler.FSHandler.ReadGameSystemDataTable()!
-                        .WorldList[currentItem - 1]
-                        .StageList
+                        .WorldList[currentItem - 1].StageList
                 )
                 {
                     if (!window.ContextHandler.ProjectStages.Contains((_stage.Stage, (byte)_stage.Scenario)))
                         continue;
 
-                    ImGui.TableNextRow();
-                    ImGui.TableSetColumnIndex(0);
-
-                    if (ImGui.Selectable(_stage.Stage + $"##{_stage.Stage}{_stage.Scenario}", false))
-                    {
-                        Scene? scene = window.Scenes.Find(scene =>
-                            scene.Stage.Name == _stage.Stage && scene.Stage.Scenario == _stage.Scenario
-                        );
-
-                        if (scene is not null) // Stage already opened
-                            window.CurrentScene = scene;
-                        else
-                        {
-                            window.BackgroundManager.Add(
-                                $"Loading stage \"{_stage.Stage + _stage.Scenario}\"...",
-                                manager =>
-                                {
-                                    Stage stage = window.ContextHandler.FSHandler.ReadStage(
-                                        _stage.Stage,
-                                        (byte)_stage.Scenario
-                                    );
-
-                                    Scene newScene =
-                                        new(
-                                            stage,
-                                            window.ContextHandler.FSHandler,
-                                            window.GLTaskScheduler,
-                                            ref manager.StatusMessageSecondary
-                                        )
-                                        {
-                                            IsSaved = true
-                                        };
-
-                                    newScene.ResetCamera();
-                                    window.Scenes.Add(newScene);
-                                    ImGui.SetWindowFocus("Objects");
-                                }
-                            );
-                        }
-
-                    }
-
-                    ImGui.TableNextColumn();
-
-                    ImGui.Text(_stage.Scenario.ToString());
+                    StageSelectable(_stage.Stage, (byte)_stage.Scenario);
                 }
             }
 
@@ -202,5 +116,56 @@ internal class StageWindow
         }
 
         ImGui.End();
+    }
+
+    private void StageSelectable(string stageName, byte scenario)
+    {
+        ImGui.TableNextRow();
+        ImGui.TableSetColumnIndex(0);
+
+        if (ImGui.Selectable(stageName +$"##{stageName}{scenario}", false, ImGuiSelectableFlags.SpanAllColumns))
+        {
+            Scene? scene = window.Scenes.Find(scene =>
+                scene.Stage.Name == stageName && scene.Stage.Scenario == scenario
+            );
+
+            if (scene is not null) // Stage already opened
+            {
+                window.CurrentScene = scene;
+                window.SetSceneChange();
+            }
+            else
+            {
+                window.BackgroundManager.Add(
+                    $"Loading stage \"{stageName + scenario}\"...",
+                    manager =>
+                    {
+                        Stage stage = window.ContextHandler.FSHandler.ReadStage(stageName, scenario);
+
+                        Scene newScene =
+                            new(
+                                stage,
+                                window.ContextHandler.FSHandler,
+                                window.GLTaskScheduler,
+                                ref manager.StatusMessageSecondary
+                            )
+                            {
+                                IsSaved = true
+                            };
+
+                        newScene.ResetCamera();
+                        window.Scenes.Add(newScene);
+                        window.CurrentScene = newScene;
+                        window.SetSceneChange();
+                        ImGui.SetWindowFocus("Objects");
+                    }
+                );
+            }
+
+        }
+
+        ImGui.TableNextColumn();
+
+        ImGui.Text(scenario.ToString());
     }
 }

--- a/Autumn/GUI/ImGuiController.cs
+++ b/Autumn/GUI/ImGuiController.cs
@@ -73,6 +73,7 @@ internal class ImGuiController : IDisposable
         onConfigureIO?.Invoke();
 
         io.BackendFlags |= ImGuiBackendFlags.RendererHasVtxOffset;
+        io.ConfigDragClickToInputText = true;
 
         unsafe
         {

--- a/Autumn/GUI/ImGuiController.cs
+++ b/Autumn/GUI/ImGuiController.cs
@@ -262,7 +262,7 @@ internal class ImGuiController : IDisposable
         io.DeltaTime = deltaSeconds; // DeltaTime is in seconds.
     }
 
-    private bool TryMapKey(Key key, out ImGuiKey result)
+    public bool TryMapKey(Key key, out ImGuiKey result)
     {
         ImGuiKey KeyToImGuiKeyShortcut(Key keyToConvert, Key startKey1, ImGuiKey startKey2)
         {

--- a/Autumn/GUI/Windows/MainWindowContext.cs
+++ b/Autumn/GUI/Windows/MainWindowContext.cs
@@ -112,11 +112,7 @@ internal class MainWindowContext : WindowContext
             depthAttachment: SceneGL.PixelFormat.D24_UNorm_S8_UInt,
             SceneGL.PixelFormat.R8_G8_B8_A8_UNorm, // Regular color.
             SceneGL.PixelFormat.R32_UInt, // Used for object selection.
-            SceneGL.PixelFormat.R8_UInt // Regular color. 
-            // 7 6 5 4 3 2 1 0
-            // 0 -> shadow base
-            // 1 -> shadow remove -> final shadow check
-            // 2 -> isSelected
+            SceneGL.PixelFormat.R8_G8_B8_A8_UNorm // Regular color.
         );
         CameraFramebuffer = new(
             initialSize: null,

--- a/Autumn/GUI/Windows/MainWindowContext.cs
+++ b/Autumn/GUI/Windows/MainWindowContext.cs
@@ -385,6 +385,21 @@ internal class MainWindowContext : WindowContext
         _camParams.SetSelectedChange();
         ImGui.SetWindowFocus("cameras");
     }
+    public StageFog? GetSelectedFog()
+    {
+        if (!_fogParams.IsOpen) return null;
+        if (_fogParams.SelectedFog > 0)
+        {
+            if ( CurrentScene!.Stage.StageFogs.Count > _fogParams.SelectedFog)
+                return CurrentScene!.Stage.StageFogs[_fogParams.SelectedFog];
+        }
+        return CurrentScene!.MainStageFog;
+    }
+    public uint GetFogType()
+    {
+        if (!_fogParams.IsOpen) return 0;
+        else return (uint)CurrentScene!.MainStageFog.FogType;
+    }
     public void UpdateCameraList()
     {
         _propertiesWindow.updateCameras = true;

--- a/Autumn/GUI/Windows/MainWindowContext.cs
+++ b/Autumn/GUI/Windows/MainWindowContext.cs
@@ -27,7 +27,7 @@ internal class MainWindowContext : WindowContext
 
     public SceneGL.GLWrappers.Framebuffer SceneFramebuffer { get; }
     public SceneGL.GLWrappers.Framebuffer CameraFramebuffer { get; }
-    public SceneGL.GLWrappers.Framebuffer ExtraFB { get; }
+    public SceneGL.GLWrappers.Framebuffer ExtrasFrameBuffer { get; }
 
     public BackgroundManager BackgroundManager { get; } = new();
     public GLTaskScheduler GLTaskScheduler { get; } = new();
@@ -112,17 +112,21 @@ internal class MainWindowContext : WindowContext
             depthAttachment: SceneGL.PixelFormat.D24_UNorm_S8_UInt,
             SceneGL.PixelFormat.R8_G8_B8_A8_UNorm, // Regular color.
             SceneGL.PixelFormat.R32_UInt, // Used for object selection.
-            SceneGL.PixelFormat.R8_G8_B8_A8_UNorm // Extra object information
+            SceneGL.PixelFormat.R8_UInt // Regular color. 
+            // 7 6 5 4 3 2 1 0
+            // 0 -> shadow base
+            // 1 -> shadow remove -> final shadow check
+            // 2 -> isSelected
         );
         CameraFramebuffer = new(
             initialSize: null,
             depthAttachment: SceneGL.PixelFormat.D24_UNorm_S8_UInt,
             SceneGL.PixelFormat.R8_G8_B8_A8_UNorm // Regular color.
         );
-        ExtraFB = new(
+        ExtrasFrameBuffer = new(
             initialSize: null,
             depthAttachment: null,
-            SceneGL.PixelFormat.R8_G8_B8_A8_UNorm // Regular color.
+            SceneGL.PixelFormat.R8_G8_B8_A8_UNorm  // final color
         );
 
         Window.Load += () =>

--- a/Autumn/GUI/Windows/MainWindowContext.cs
+++ b/Autumn/GUI/Windows/MainWindowContext.cs
@@ -27,6 +27,7 @@ internal class MainWindowContext : WindowContext
 
     public SceneGL.GLWrappers.Framebuffer SceneFramebuffer { get; }
     public SceneGL.GLWrappers.Framebuffer CameraFramebuffer { get; }
+    public SceneGL.GLWrappers.Framebuffer ExtraFB { get; }
 
     public BackgroundManager BackgroundManager { get; } = new();
     public GLTaskScheduler GLTaskScheduler { get; } = new();
@@ -110,11 +111,17 @@ internal class MainWindowContext : WindowContext
             initialSize: null,
             depthAttachment: SceneGL.PixelFormat.D24_UNorm_S8_UInt,
             SceneGL.PixelFormat.R8_G8_B8_A8_UNorm, // Regular color.
-            SceneGL.PixelFormat.R32_UInt // Used for object selection.
+            SceneGL.PixelFormat.R32_UInt, // Used for object selection.
+            SceneGL.PixelFormat.R8_G8_B8_A8_UNorm // Extra object information
         );
         CameraFramebuffer = new(
             initialSize: null,
             depthAttachment: SceneGL.PixelFormat.D24_UNorm_S8_UInt,
+            SceneGL.PixelFormat.R8_G8_B8_A8_UNorm // Regular color.
+        );
+        ExtraFB = new(
+            initialSize: null,
+            depthAttachment: null,
             SceneGL.PixelFormat.R8_G8_B8_A8_UNorm // Regular color.
         );
 
@@ -124,6 +131,7 @@ internal class MainWindowContext : WindowContext
             RailRenderer.Initialize(GL!);
             RelationLine.Initialize(GL!);
             ModelRenderer.Initialize(GL!, contextHandler.FSHandler);
+            Canvas.CanvasRenderer.Initialize(GL!);
             _propertiesWindow.Initialize(windowManager);
 
             var cubeTex = Image.Load<Rgba32>(Path.Join("Resources", "OrientationCubeTex.png"));

--- a/Autumn/GUI/Windows/MainWindowContext.cs
+++ b/Autumn/GUI/Windows/MainWindowContext.cs
@@ -325,6 +325,8 @@ internal class MainWindowContext : WindowContext
                             );
                         scene.ResetCamera();
                         Scenes.Add(scene);
+                        CurrentScene = scene;
+                        SetSceneChange();
                         ImGui.SetWindowFocus("Objects");
                     }
                 );
@@ -389,6 +391,18 @@ internal class MainWindowContext : WindowContext
         _switchParams.IsOpen = true;
         _switchParams.SelectedSwitch = i;
         ImGui.SetWindowFocus("Switches##SwitchWindow");
+    }
+    public void SetFogSelected(int i)
+    {
+        _fogParams.IsOpen = true;
+        _fogParams.SelectedFog = i;
+        ImGui.SetWindowFocus("Fog##FogParams");
+    }
+    public void SetLightSelected(int i)
+    {
+        _lightParams.IsOpen = true;
+        _lightParams.ExternalLightSelect = i;
+        ImGui.SetWindowFocus("Lights##LightParams");
     }
     public void SetCameraSelected(int i)
     {

--- a/Autumn/GUI/Windows/MainWindowContext.cs
+++ b/Autumn/GUI/Windows/MainWindowContext.cs
@@ -55,7 +55,9 @@ internal class MainWindowContext : WindowContext
     public readonly EditCreatorClassNameTable _editCCNT;
     #endregion
 
-    public bool IsDialogOpen = false;
+    public bool IsDialogOpen => _addStageDialog.IsOpen || _addObjectDialog.IsOpen || _DBEditorDialog.IsOpen
+                            || _editExtraPropsDialog.IsOpen || _settingsDialog.IsOpen || _editChildrenDialog.IsOpen
+                            || _shortcutsDialog.IsOpen || _editCCNT.IsOpen || _closingDialog.IsOpen || _welcomeDialog.IsOpen;
 
     #region Editor Windows 
     private readonly StageWindow _stageWindow;
@@ -243,7 +245,7 @@ internal class MainWindowContext : WindowContext
 
             if (!ContextHandler.IsProjectLoaded)
             {
-                if (!_welcomeDialog.IsOpened) RenderWelcomeScreen(barHeight);
+                if (!_welcomeDialog.IsOpen) RenderWelcomeScreen(barHeight);
             }
             else
             {

--- a/Autumn/GUI/Windows/MainWindowContext.cs
+++ b/Autumn/GUI/Windows/MainWindowContext.cs
@@ -47,6 +47,7 @@ internal class MainWindowContext : WindowContext
     private readonly SettingsDialog _settingsDialog;
     private readonly ShortcutsDialog _shortcutsDialog;
     private readonly DatabaseEditor _DBEditorDialog;
+    private readonly SaveReminderDialog _saveReminderDialog;
     #endregion
 
     #region Editor Dialogs
@@ -56,7 +57,7 @@ internal class MainWindowContext : WindowContext
     #endregion
 
     public bool IsDialogOpen => _addStageDialog.IsOpen || _addObjectDialog.IsOpen || _DBEditorDialog.IsOpen
-                            || _editExtraPropsDialog.IsOpen || _settingsDialog.IsOpen || _editChildrenDialog.IsOpen
+                            || _editExtraPropsDialog.IsOpen || _settingsDialog.IsOpen || _editChildrenDialog.IsOpen || _saveReminderDialog.IsOpen
                             || _shortcutsDialog.IsOpen || _editCCNT.IsOpen || _closingDialog.IsOpen || _welcomeDialog.IsOpen;
     public bool FlyCamOn => _sceneWindow.FlyCam;
 
@@ -96,6 +97,7 @@ internal class MainWindowContext : WindowContext
         _shortcutsDialog = new(this);
         _DBEditorDialog = new(this);
         _searchObjDialog = new(this);
+        _saveReminderDialog = new(this);
 
         // Initialize editors:
         _stageWindow = new(this);
@@ -272,6 +274,7 @@ internal class MainWindowContext : WindowContext
             _shortcutsDialog.Render();
             _welcomeDialog.Render();
             _settingsDialog.Render();
+            _saveReminderDialog.Render();
 
             _miscParams.Render();
             _camParams.Render();
@@ -415,19 +418,36 @@ internal class MainWindowContext : WindowContext
     internal void SetupChildrenDialog(StageObj stageObj) => _editChildrenDialog.Open(stageObj);
     internal void SetupExtraPropsDialog(StageObj stageObj, string propName) => _editExtraPropsDialog.Open(stageObj, propName);
     internal void SetupExtraPropsDialogNew(StageObj stageObj) => _editExtraPropsDialog.New(stageObj);
-    internal void CloseCurrentScene()
+    internal void SetSceneChange() => _sceneWindow.ExternalSceneChange = true;
+    internal void OpenSaveReminder(Scene s) => _saveReminderDialog.Open(s);
+    internal void CloseStage(Scene s)
     {
-        int i = Scenes.IndexOf(CurrentScene!) - 1;
-        Scenes.Remove(CurrentScene!);
-        if (i < 0)
-            CurrentScene = null;
-        else
-            CurrentScene = Scenes[i];
+        if (ContextHandler.SystemSettings.SaveReminder && !s.IsSaved)
+        {
+            OpenSaveReminder(s);
+            return;
+        }
+        if (s == CurrentScene)
+        {
+            if (Scenes.IndexOf(s) > 0)
+            {
+                CurrentScene = Scenes[Scenes.IndexOf(s)-1];
+            }
+            else if (Scenes.Count > 1)
+            {
+               CurrentScene = Scenes[1];
+            }
+            else
+            {
+                CurrentScene = null;
+            }
+        }
+        SetSceneChange();
+        Scenes.Remove(s);
         if (Scenes.Count == 0)
         {
             ImGui.SetWindowFocus("Stages");
         }
-
     }
 
     /// <summary>
@@ -598,66 +618,15 @@ internal class MainWindowContext : WindowContext
             ImGui.EndMenu();
         }
         ImGui.SetCursorPos(c);
-        #region SceneTabs
         // Opened stages are displayed in tabs in the main menu bar.
-
-        ImGuiTabBarFlags barFlags = ImGuiTabBarFlags.AutoSelectNewTabs;
 
         if (ContextHandler.ProjectChanged)
         {
             CurrentScene = null;
             Scenes.Clear();
             ContextHandler.ProjectChanged = false;
+            ImGui.SetWindowFocus("Stages");
         }
-
-        if (Scenes.Count > 0 && ImGui.BeginTabBar("sceneTabs", barFlags))
-        {
-            for (int i = 0; i < Scenes.Count; i++)
-            {
-                ImGuiTabItemFlags flags = ImGuiTabItemFlags.NoPushId;
-
-                Scene scene = Scenes[i];
-
-                if (!scene.IsSaved)
-                    flags |= ImGuiTabItemFlags.UnsavedDocument;
-
-                bool opened = true;
-                string displayName = scene.Stage!.Name + scene.Stage.Scenario;
-
-                ImGui.PushID(displayName);
-
-                if (ImGui.BeginTabItem(displayName, ref opened, flags) && CurrentScene != scene)
-                    CurrentScene = scene;
-
-                ImGui.EndTabItem();
-                ImGui.SetItemTooltip(scene.Stage.UserPath);
-
-                ImGui.PopID();
-
-                // Remove the tab when it is closed.
-                // This also closes the stage.
-                if (!opened && Scenes.Remove(scene))
-                {
-                    // TO-DO: Check whether the stage is not saved.
-
-                    i--;
-
-                    // Set the scene to the one before if possible.
-                    if (i < 0)
-                        CurrentScene = null;
-                    else
-                        CurrentScene = Scenes[i];
-                    if (Scenes.Count == 0)
-                    {
-                        ImGui.SetWindowFocus("Stages");
-                    }
-                }
-            }
-
-            ImGui.EndTabBar();
-        }
-
-        #endregion
 
         ImGui.EndMainMenuBar();
 

--- a/Autumn/GUI/Windows/MainWindowContext.cs
+++ b/Autumn/GUI/Windows/MainWindowContext.cs
@@ -560,8 +560,7 @@ internal class MainWindowContext : WindowContext
             if (ImGui.MenuItem("Edit Switches"))
                 _switchParams.IsOpen = true;
             ImGui.Separator();
-            if (ImGui.MenuItem("Search"))
-                _searchObjDialog.IsOpen = true;
+            ImGuiWidgets.CommandMenuItem(CommandID.Search, ContextHandler.ActionHandler, this);
             ImGui.EndMenu();
         }
 

--- a/Autumn/GUI/Windows/MainWindowContext.cs
+++ b/Autumn/GUI/Windows/MainWindowContext.cs
@@ -138,6 +138,7 @@ internal class MainWindowContext : WindowContext
             RailRenderer.Initialize(GL!);
             RelationLine.Initialize(GL!);
             ModelRenderer.Initialize(GL!, contextHandler.FSHandler);
+            TransparentWallRenderer.Initialize(GL!);
             Canvas.CanvasRenderer.Initialize(GL!);
             _propertiesWindow.Initialize(windowManager);
 

--- a/Autumn/GUI/Windows/MainWindowContext.cs
+++ b/Autumn/GUI/Windows/MainWindowContext.cs
@@ -58,12 +58,14 @@ internal class MainWindowContext : WindowContext
     public bool IsDialogOpen => _addStageDialog.IsOpen || _addObjectDialog.IsOpen || _DBEditorDialog.IsOpen
                             || _editExtraPropsDialog.IsOpen || _settingsDialog.IsOpen || _editChildrenDialog.IsOpen
                             || _shortcutsDialog.IsOpen || _editCCNT.IsOpen || _closingDialog.IsOpen || _welcomeDialog.IsOpen;
+    public bool FlyCamOn => _sceneWindow.FlyCam;
 
     #region Editor Windows 
     private readonly StageWindow _stageWindow;
     private readonly ObjectWindow _objectWindow;
     private readonly PropertiesWindow _propertiesWindow;
     private readonly SceneWindow _sceneWindow;
+    private readonly SearchWindow _searchObjDialog;
     private readonly WelcomeDialog _welcomeDialog;
     #endregion
 
@@ -93,6 +95,7 @@ internal class MainWindowContext : WindowContext
         _editCCNT = new(this);
         _shortcutsDialog = new(this);
         _DBEditorDialog = new(this);
+        _searchObjDialog = new(this);
 
         // Initialize editors:
         _stageWindow = new(this);
@@ -275,6 +278,7 @@ internal class MainWindowContext : WindowContext
             _fogParams.Render();
             _lightParams.Render();
             _switchParams.Render();
+            _searchObjDialog.Render();
 
             if (_isFirstFrame)
             {
@@ -343,6 +347,7 @@ internal class MainWindowContext : WindowContext
     public void OpenAddRailDialog() => _addObjectDialog.Open(2);
 
     public void OpenSettingsDialog() => _settingsDialog.Open();
+    public void OpenSearchDialog() => _searchObjDialog.IsOpen = true;
     public void OpenDbEntryDialog(ClassDatabaseWrapper.DatabaseEntry e) => _DBEditorDialog.Open(e);
 
     public void AddSceneMouseClickAction(Action<MainWindowContext, Vector4> action) =>
@@ -369,6 +374,7 @@ internal class MainWindowContext : WindowContext
     // public void CancelTransform() => _sceneWindow.CancelTransform = true;
     public void FinishTransform() => _sceneWindow.FinishTransform = true;
     public void MoveToPoint() => _sceneWindow.TranslateToPoint = true;
+    public void ToggleFlyCam() => _sceneWindow.FlyCam = !_sceneWindow.FlyCam;
     public void CameraToObject() => _sceneWindow.CamToObj = true;
     public void CameraToObject(ISceneObj obj) { _sceneWindow.CamToObj = true; _sceneWindow.CamSceneObj = obj; }
     public void AddRailPoint() => _sceneWindow.AddRailPoint = AddRailPointState.Add;
@@ -518,6 +524,9 @@ internal class MainWindowContext : WindowContext
                 _lightParams.IsOpen = true;
             if (ImGui.MenuItem("Edit Switches"))
                 _switchParams.IsOpen = true;
+            ImGui.Separator();
+            if (ImGui.MenuItem("Search"))
+                _searchObjDialog.IsOpen = true;
             ImGui.EndMenu();
         }
 

--- a/Autumn/Rendering/Area/AreaMaterial.cs
+++ b/Autumn/Rendering/Area/AreaMaterial.cs
@@ -56,8 +56,9 @@ internal static class AreaMaterial
 
             out vec4 oColor;
             out uint oPickingId;
+            out uint oPostProc;
 
-            void main() {                
+            void main() {
                 vec3 absolute = abs(vPos);
                 vec3 scale = vec3(  length(vec3(vTrans[0][0], vTrans[1][0], vTrans[2][0])),
                                     length(vec3(vTrans[0][1], vTrans[1][1], vTrans[2][1])), 
@@ -89,6 +90,7 @@ internal static class AreaMaterial
                 oColor.rgb += vec3(clamp(outline * 0.5 - 0.12,0,1));
                 oColor.a = 1.0;
                 oPickingId = uPickingId;
+                oPostProc = 0u + (uHighlightColor.a > 0.1 ? 1u : 0u) << 2u;
             }
             """
         );

--- a/Autumn/Rendering/Area/AreaMaterial.cs
+++ b/Autumn/Rendering/Area/AreaMaterial.cs
@@ -56,7 +56,7 @@ internal static class AreaMaterial
 
             out vec4 oColor;
             out uint oPickingId;
-            out uint oPostProc;
+            out vec4 oPostProc;
 
             void main() {
                 vec3 absolute = abs(vPos);
@@ -90,7 +90,7 @@ internal static class AreaMaterial
                 oColor.rgb += vec3(clamp(outline * 0.5 - 0.12,0,1));
                 oColor.a = 1.0;
                 oPickingId = uPickingId;
-                oPostProc = 0u + (uHighlightColor.a > 0.1 ? 1u : 0u) << 2u;
+                oPostProc = vec4((uHighlightColor.a > 0.1 ? 1 : 0), 0, 0, 0);
             }
             """
         );

--- a/Autumn/Rendering/Area/AreaMaterial.cs
+++ b/Autumn/Rendering/Area/AreaMaterial.cs
@@ -8,14 +8,16 @@ namespace Autumn.Rendering.Area;
 
 internal static class AreaMaterial
 {
-    private static readonly ShaderSource s_vertexShader =
+    private static readonly ShaderSource s_vertexCenterShader =
         new(
-            "Area.vert",
+            "AreaCentered.vert",
             ShaderType.VertexShader,
             """
             #version 330
 
             layout(location = 0) in vec3 aPos;
+            layout(location = 1) in vec2 aUV;
+            layout(location = 2) in float aFaceType;
 
             layout(std140) uniform ubScene {
                 mat4x4 uViewProjection;
@@ -23,19 +25,53 @@ internal static class AreaMaterial
             };
 
             out vec3 vPos;
+            out vec2 vUV;
+            out float vFaceType;
+            out mat4x4 vTrans;
+
+            void main() {
+                gl_Position = uViewProjection * uTransform * vec4(aPos.x, aPos.y, aPos.z, 2.0);
+                vPos = aPos;
+                vTrans = uTransform;
+                vUV = aUV;
+                vFaceType = aFaceType;
+            }
+            """
+        );
+    private static readonly ShaderSource s_vertexBaseShader =
+        new(
+            "AreaBase.vert",
+            ShaderType.VertexShader,
+            """
+            #version 330
+
+            layout(location = 0) in vec3 aPos;
+            layout(location = 1) in vec2 aUV;
+            layout(location = 2) in float aFaceType;
+
+            layout(std140) uniform ubScene {
+                mat4x4 uViewProjection;
+                mat4x4 uTransform;
+            };
+
+            out vec3 vPos;
+            out vec2 vUV;    
+            out float vFaceType;
             out mat4x4 vTrans;
 
             void main() {
                 gl_Position = uViewProjection * uTransform * vec4(aPos.x, aPos.y + 10.0, aPos.z, 2.0);
                 vPos = aPos;
                 vTrans = uTransform;
+                vUV = aUV;
+                vFaceType = aFaceType;
             }
             """
         );
 
-    private static readonly ShaderSource s_fragmentShader =
+    private static readonly ShaderSource s_CubeFragment =
         new(
-            "Area.frag",
+            "CubeArea.frag",
             ShaderType.FragmentShader,
             """
             #version 330
@@ -45,6 +81,8 @@ internal static class AreaMaterial
             }
 
             in vec3 vPos;
+            in vec2 vUV;
+            in float vFaceType;
             in mat4x4 vTrans;
 
             layout(std140) uniform ubMaterial {
@@ -58,51 +96,256 @@ internal static class AreaMaterial
             out uint oPickingId;
             out vec4 oPostProc;
 
+            const float PI = 3.14159;
+
+            vec2 rotate(vec2 samplePosition, float rotation){
+                float angle = rotation * PI / 180;
+                return vec2(cos(angle) * samplePosition.x + sin(angle) * samplePosition.y, 
+                            cos(angle) * samplePosition.y - sin(angle) * samplePosition.x);
+            }
+
             void main() {
-                vec3 absolute = abs(vPos);
                 vec3 scale = vec3(  length(vec3(vTrans[0][0], vTrans[1][0], vTrans[2][0])),
                                     length(vec3(vTrans[0][1], vTrans[1][1], vTrans[2][1])), 
                                     length(vec3(vTrans[0][2], vTrans[1][2], vTrans[2][2])));
-                float a = max3(
-                    min(absolute.x, absolute.y),
-                    min(absolute.x, absolute.z),
-                    min(absolute.y, absolute.z));
-
-                float wa = fwidth(a);
-
-                float outline = smoothstep(9 - wa , 10 + wa, a * 0.95);
-
-                vec3 col = vec3(0.05 * vPos.x + 0.5, 0.05 * vPos.y + 0.5, 0.05 * vPos.z + 0.5);
-                oColor.r = abs(vPos.x * scale.x) < (0.9 / scale.x) ? (0) : (1);
-                oColor.g = abs(vPos.y * scale.y) < (0.9 / scale.y) ? (0) : (1);
-                oColor.b = abs(vPos.z * scale.z) < (0.9) ? (0) : (1);
-
-                oColor.rgb = vec3(0);
-                vec3 limit = (0.05 / scale);
-                col.r = col.r < (1.0 - limit.x) && col.r > (limit.x) ? 0 : 1;
-                col.g = col.g < (1.0 - limit.y) && col.g > (limit.y) ? 0 : 1;
-                col.b = col.b < (1.0 - limit.z) && col.b > (limit.z) ? 0 : 1;
-                float final = (col.r * col.b + col.g * col.b + col.g * col.r);
-                if (final < 0.5) discard;
-
-                oColor.rgb = mix(uColor.rgb, uHighlightColor.rgb, uHighlightColor.a);
-                oColor.rgb = gl_FrontFacing ? oColor.rgb : oColor.rgb *0.80;
-                oColor.rgb += vec3(clamp(outline * 0.5 - 0.12,0,1));
                 oColor.a = 1.0;
                 oPickingId = uPickingId;
                 oPostProc = vec4((uHighlightColor.a > 0.1 ? 1 : 0), 0, 0, 0);
+                oColor.rgb = vec3(vUV,0);//uColor.rgb;
+                float xMin = 0.05;
+                float yMin = 0.05;
+                float dist = length(vUV - 0.5);
+                vec3 col = vec3(0);
+                float sz = 0.45;
+                if (vFaceType < 0.8)
+                {
+                    oColor.rgb = (vUV.x < xMin || vUV.x > 1.0 - xMin) ? vec3(1) : vec3(0);
+                    oColor.rgb += (vUV.y < yMin || vUV.y > 1.0 - yMin) ? vec3(1) : vec3(0);
+                    if (oColor.r < 0.1) discard;
+                    vec2 nUV = vUV.x < 0.5 ? vUV : 1.0 - vUV;
+                    col = vec3(nUV.xxx);
+                    nUV = vUV.y < 0.5 ? vUV : 1.0 - vUV;
+                    col += vec3(nUV.yyy);
+                    oColor.rgb = clamp(oColor.rgb, vec3(0), vec3(1)); //= col;
+                    //oColor.rgb *= col;
+                    //oColor.rgb = vec3(nUV.yy, 0);
+                }
+                if (vFaceType < 1.8)
+                {
+                    xMin = 0.05 / scale.x;
+                    yMin = 0.05 / scale.z;
+                    oColor.rgb = (vUV.x < xMin || vUV.x > 1.0 - xMin) ? vec3(1) : vec3(0);
+                    oColor.rgb += (vUV.y < yMin || vUV.y > 1.0 - yMin) ? vec3(1) : vec3(0);
+                    if (oColor.r < 0.1) discard;
+                    vec2 nUV = vUV.x < 0.5 ? vUV : 1.0 - vUV;
+                    col = vec3(nUV.xxx);
+                    nUV = vUV.y < 0.5 ? vUV : 1.0 - vUV;
+                    col += vec3(nUV.yyy);
+                    oColor.rgb = clamp(oColor.rgb, vec3(0), vec3(1)); //= col;
+                    //oColor.rgb *= col;
+                    //oColor.rgb = vec3(nUV.yy, 0);
+                }
+                else if (vFaceType < 2.8)
+                {
+                    xMin = 0.05 / scale.x;
+                    yMin = 0.05 / scale.z;
+                    oColor.rgb = (vUV.x < xMin || vUV.x > 1.0 - xMin) ? vec3(1) : vec3(0);
+                    oColor.rgb += (vUV.y < xMin || vUV.y > 1.0 - xMin) ? vec3(1) : vec3(0);
+                    
+                    float v = (scale.z + scale.x) / 2;
+                    vec2 rUV = rotate((vUV - 0.5) * v, 45) + 0.5;
+                    col = vec3(rUV.x > sz && rUV.x < 1-sz ? 1 : 0);
+                    col += vec3(rUV.y > sz && rUV.y < 1-sz ? 1 : 0);
+                    oColor.rgb += col;
+                    oColor.rgb = clamp(oColor.rgb, vec3(0), vec3(1));
+                    
+                    if ((oColor.r < 0.1)) discard;
+                    
+                }
+                oColor.rgb = mix(uColor.rgb, uColor.rgb, oColor.rgb);
+                //oColor.rgb *= uColor.rgb * 2;
+                oColor.rgb = mix(oColor.rgb, uHighlightColor.rgb, uHighlightColor.a);
+                oColor.rgb = gl_FrontFacing ? oColor.rgb : oColor.rgb *0.80;
+                // oColor.rgb = scale;
             }
             """
         );
 
-    public static readonly ShaderProgram Program = new(s_vertexShader, s_fragmentShader);
+    private static readonly ShaderSource s_SphereFragment =
+        new(
+            "SphereArea.frag",
+            ShaderType.FragmentShader,
+            """
+            #version 330
+
+            float max3(float a, float b, float c) {
+                return max(max(a, b), c);
+            }
+
+            in vec3 vPos;
+            in vec2 vUV;
+            in float vFaceType;
+            in mat4x4 vTrans;
+
+            layout(std140) uniform ubMaterial {
+                vec4 uColor;
+                vec4 uHighlightColor;
+            };
+
+            uniform uint uPickingId;
+
+            out vec4 oColor;
+            out uint oPickingId;
+            out vec4 oPostProc;
+
+            const float PI = 3.14159;
+
+            vec2 rotate(vec2 samplePosition, float rotation){
+                float angle = rotation * PI / 180;
+                return vec2(cos(angle) * samplePosition.x + sin(angle) * samplePosition.y, 
+                            cos(angle) * samplePosition.y - sin(angle) * samplePosition.x);
+            }
+
+            void main() {
+                oColor.a = 1.0;
+                oPickingId = uPickingId;
+                oPostProc = vec4((uHighlightColor.a > 0.1 ? 1 : 0), 0, 0, 0);
+                oColor.rgb = vec3(vUV,0);//uColor.rgb;
+                float xMin = 0.1;
+                float yMin = 0.1;
+                vec3 col = vec3(0);
+                oColor.rgb = (vUV.x < xMin || vUV.x > 1.0 - xMin) ? vec3(1) : vec3(0);
+                oColor.rgb += (vUV.y < yMin || vUV.y > 1.0 - yMin) ? vec3(1) : vec3(0);
+                if (oColor.r < 0.1) discard;
+                vec2 nUV = vUV.x < 0.5 ? vUV : 1.0 - vUV;
+                col = vec3(nUV.xxx);
+                nUV = vUV.y < 0.5 ? vUV : 1.0 - vUV;
+                col += vec3(nUV.yyy);
+
+                oColor.rgb = clamp(oColor.rgb, vec3(0), vec3(1));
+                oColor.rgb = mix(uColor.rgb, uColor.rgb, oColor.rgb);
+                
+                oColor.rgb = mix(oColor.rgb, uHighlightColor.rgb, uHighlightColor.a);
+                oColor.rgb = gl_FrontFacing ? oColor.rgb : oColor.rgb *0.80;
+
+            }
+            """
+        );
+    private static readonly ShaderSource s_CylinderFragment =
+        new(
+            "CylinderArea.frag",
+            ShaderType.FragmentShader,
+            """
+            #version 330
+
+            float max3(float a, float b, float c) {
+                return max(max(a, b), c);
+            }
+
+            in vec3 vPos;
+            in vec2 vUV;
+            in float vFaceType;
+            in mat4x4 vTrans;
+
+            layout(std140) uniform ubMaterial {
+                vec4 uColor;
+                vec4 uHighlightColor;
+            };
+
+            uniform uint uPickingId;
+
+            out vec4 oColor;
+            out uint oPickingId;
+            out vec4 oPostProc;
+
+            const float PI = 3.14159;
+
+            vec2 rotate(vec2 samplePosition, float rotation){
+                float angle = rotation * PI / 180;
+                return vec2(cos(angle) * samplePosition.x + sin(angle) * samplePosition.y, 
+                            cos(angle) * samplePosition.y - sin(angle) * samplePosition.x);
+            }
+
+            void main() {
+                vec3 scale = vec3(  length(vec3(vTrans[0][0], vTrans[1][0], vTrans[2][0])),
+                                    length(vec3(vTrans[0][1], vTrans[1][1], vTrans[2][1])), 
+                                    length(vec3(vTrans[0][2], vTrans[1][2], vTrans[2][2])));
+                oColor.a = 1.0;
+                oPickingId = uPickingId;
+                oPostProc = vec4((uHighlightColor.a > 0.1 ? 1 : 0), 0, 0, 0);
+                oColor.rgb = vec3(vUV,0);//uColor.rgb;
+                float xMin = 0.05;
+                float yMin = 0.1;
+                float dist = length(vUV - 0.5);
+                vec3 col = vec3(0);
+                float sz = 0.45;
+                if (vFaceType <0.8) // Sides
+                {
+                    oColor.rgb = (vUV.x < xMin || vUV.x > 1.0 - xMin) ? vec3(1) : vec3(0);
+                    oColor.rgb += (vUV.y < yMin || vUV.y > 1.0 - yMin) ? vec3(1) : vec3(0);
+                    if (oColor.r < 0.1) discard;
+                    vec2 nUV = vUV.x < 0.5 ? vUV : 1.0 - vUV;
+                    col = vec3(nUV.xxx);
+                    nUV = vUV.y < 0.5 ? vUV : 1.0 - vUV;
+                    col += vec3(nUV.yyy);
+                    oColor.rgb = clamp(oColor.rgb, vec3(0), vec3(1)); //= col;
+                    //oColor.rgb *= col;
+                    //oColor.rgb = vec3(nUV.yy, 0);
+                }
+                else if (vFaceType < 1.8) // Top Face
+                {
+                    
+                    oColor.rgb = vec3(dist > 0.43 && dist < 0.5 ? 1 : 0);
+                    if (!(dist > 0.43 && dist < 0.5)) discard;
+                    col = vec3(dist * 0.8);
+                    oColor.rgb = clamp(oColor.rgb, vec3(0), vec3(1));
+                    //oColor.rgb = col;
+                }
+                else if (vFaceType < 2.8) // Bottom Face
+                {
+                    oColor.rgb = vec3(dist > 0.43 && dist < 0.5 ? 1 : 0);
+                    col = vec3(dist * 0.8);
+                    oColor.rgb = clamp(oColor.rgb, vec3(0), vec3(1));
+                    
+                    float v = (scale.z + scale.x) / 2;
+                    vec2 rUV = rotate((vUV - 0.5) * v, 45) + 0.5;
+                    col = vec3(rUV.x > sz && rUV.x < 1-sz ? 1 : 0);
+                    col += vec3(rUV.y > sz && rUV.y < 1-sz ? 1 : 0);
+                    oColor.rgb += col;
+                    oColor.rgb = clamp(oColor.rgb, vec3(0), vec3(1));
+                    oColor.rgb = dist < 0.5 ? oColor.rgb : vec3(0);
+                    if ((oColor.r < 0.1)) discard;
+                }
+                oColor.rgb = mix(uColor.rgb, uColor.rgb, oColor.rgb);
+                //oColor.rgb *= uColor.rgb * 2;
+                oColor.rgb = mix(oColor.rgb, uHighlightColor.rgb, uHighlightColor.a);
+                oColor.rgb = gl_FrontFacing ? oColor.rgb : oColor.rgb *0.80;
+            }
+            """
+        );
+
+    public static readonly ShaderProgram CenterCubeProgram = new(s_vertexCenterShader, s_CubeFragment);
+    public static readonly ShaderProgram BaseCubeProgram = new(s_vertexBaseShader, s_CubeFragment);
+    public static readonly ShaderProgram SphereProgram = new(s_vertexCenterShader, s_SphereFragment);
+    public static readonly ShaderProgram CylinderProgram = new(s_vertexBaseShader, s_CylinderFragment);
 
     public static bool TryUse(
         GL gl,
+        int AreaType,
         CommonSceneParameters scene,
         CommonMaterialParameters material,
         out ProgramUniformScope scope
-    ) => Program.TryUse(gl, null, [scene.ShaderParameters, material.ShaderParameters], out scope, out _);
+    )
+    {
+        return AreaType switch
+        {
+            1 => CenterCubeProgram.TryUse(gl, null, [scene.ShaderParameters, material.ShaderParameters], out scope, out _),
+            2 => SphereProgram.TryUse(gl, null, [scene.ShaderParameters, material.ShaderParameters], out scope, out _),
+            3 => CylinderProgram.TryUse(gl, null, [scene.ShaderParameters, material.ShaderParameters], out scope, out _),
+            _ => BaseCubeProgram.TryUse(gl, null, [scene.ShaderParameters, material.ShaderParameters], out scope, out _),
+
+        }; 
+    }
 
     public static Vector4 GetAreaColor(string name)
     {

--- a/Autumn/Rendering/Area/AreaRenderer.cs
+++ b/Autumn/Rendering/Area/AreaRenderer.cs
@@ -102,7 +102,6 @@ internal static class AreaRenderer
     public static RenderableModel GenerateSphereModel(GL gl, float scale = 10)
     {
         ModelBuilder<ushort, Vertex> builder = new();
-        scale /= 1.5f;
         #region Transform Helpers
 
         #endregion

--- a/Autumn/Rendering/Area/AreaRenderer.cs
+++ b/Autumn/Rendering/Area/AreaRenderer.cs
@@ -1,5 +1,4 @@
 ﻿using System.Numerics;
-using Autumn.Rendering.DefaultCube;
 using Autumn.Rendering.Storage;
 using SceneGL;
 using SceneGL.Materials;
@@ -61,7 +60,7 @@ internal static class AreaRenderer
         #endregion
 
         float w = 1;
-        
+
         #region Cube part Helpers
         void Face(uint facetype)
         {

--- a/Autumn/Rendering/Area/AreaRenderer.cs
+++ b/Autumn/Rendering/Area/AreaRenderer.cs
@@ -1,33 +1,286 @@
-﻿using Autumn.Rendering.DefaultCube;
+﻿using System.Numerics;
+using Autumn.Rendering.DefaultCube;
 using Autumn.Rendering.Storage;
 using SceneGL;
+using SceneGL.Materials;
 using Silk.NET.OpenGL;
 
 namespace Autumn.Rendering.Area;
 
 internal static class AreaRenderer
 {
-    private static RenderableModel? s_model;
-
-    public static void Initialize(GL gl) => s_model = DefaultCubeRenderer.GenerateCubeModel(gl, 10.15f);
-
-    public static void Render(GL gl, CommonSceneParameters scene, CommonMaterialParameters material, uint pickingId)
+    private struct Vertex
     {
-        if (!AreaMaterial.TryUse(gl, scene, material, out ProgramUniformScope scope))
+        [VertexAttribute(CombinerMaterial.POSITION_LOC, 3, VertexAttribPointerType.Float, false)]
+        public Vector3 Position;
+        [VertexAttribute(AttributeShaderLoc.Loc1, 2, VertexAttribPointerType.Float, false)]
+        public Vector2 UV;
+        [VertexAttribute(AttributeShaderLoc.Loc2, 1, VertexAttribPointerType.Float, false)]
+        public float FaceType; // 0 -> Side, 1 -> Top, 2 -> Bottom
+    }
+    private static RenderableModel? s_CubeModel;
+    private static RenderableModel? s_SphereModel;
+    private static RenderableModel? s_CylinderModel;
+
+    public static void Initialize(GL gl)
+    {
+        s_CubeModel = GenerateCubeModel(gl);
+        s_SphereModel = GenerateSphereModel(gl);
+        s_CylinderModel = GenerateCylinderModel(gl);
+    }
+    public static RenderableModel GenerateCubeModel(GL gl, float scale = 10)
+    {
+        ModelBuilder<ushort, Vertex> builder = new();
+
+        Matrix4x4 mtx;
+
+        #region Transform Helpers
+        void Reset() => mtx = Matrix4x4.CreateScale(scale);
+
+        static void Rotate(ref float x, ref float y)
+        {
+            var _x = x;
+            x = y;
+            y = -_x;
+        }
+
+        void RotateOnX()
+        {
+            Rotate(ref mtx.M12, ref mtx.M13);
+            Rotate(ref mtx.M22, ref mtx.M23);
+            Rotate(ref mtx.M32, ref mtx.M33);
+        }
+
+        void RotateOnY()
+        {
+            Rotate(ref mtx.M11, ref mtx.M13);
+            Rotate(ref mtx.M21, ref mtx.M23);
+            Rotate(ref mtx.M31, ref mtx.M33);
+        }
+
+        #endregion
+
+        float w = 1;
+        
+        #region Cube part Helpers
+        void Face(uint facetype)
+        {
+            builder!.AddPlane(
+                new Vertex { Position = Vector3.Transform(new Vector3(-w, 1, -w), mtx), UV = Vector2.Zero, FaceType = facetype },
+                new Vertex { Position = Vector3.Transform(new Vector3(w, 1, -w), mtx), UV = Vector2.UnitX, FaceType = facetype },
+                new Vertex { Position = Vector3.Transform(new Vector3(-w, 1, w), mtx), UV = Vector2.UnitY, FaceType = facetype },
+                new Vertex { Position = Vector3.Transform(new Vector3(w, 1, w), mtx), UV = Vector2.One, FaceType = facetype }
+            );
+        }
+        #endregion
+
+
+        #region Construction
+
+        Reset();
+
+        #region Faces
+        Face(1);
+        RotateOnX();
+
+        for (int i = 0; i < 4; i++)
+        {
+            Face(0);
+            RotateOnY();
+        }
+        RotateOnX();
+        Face(2);
+        #endregion
+
+        Reset();
+
+
+        #endregion
+
+
+        return builder.GetModel(gl);
+    }
+    public static RenderableModel GenerateSphereModel(GL gl, float scale = 10)
+    {
+        ModelBuilder<ushort, Vertex> builder = new();
+        scale /= 1.5f;
+        #region Transform Helpers
+
+        #endregion
+
+        int vertical_slices = 8;
+        int horizontal_slices = 8;
+        float horizontal_steps = MathF.PI / horizontal_slices;
+        float vertical_steps = MathF.Tau / vertical_slices;
+
+        List<Vector3> vertexPositions = new();
+        vertexPositions.Add(new Vector3(0, scale, 0));
+        for (int i = 1; i < (horizontal_slices); i++)
+        {
+            float horizontal = i * horizontal_steps;
+            for (int j = 0; j < vertical_slices; ++j)
+            {
+                float vertical = j * vertical_steps;
+                vertexPositions.Add(
+                    new Vector3(scale * MathF.Sin(horizontal) * MathF.Cos(vertical),
+                                                        scale * MathF.Cos(horizontal),
+                                                        -scale * MathF.Sin(horizontal) * MathF.Sin(vertical)));
+
+            }
+        }
+        vertexPositions.Add(new Vector3(0, -scale, 0));
+
+        for (int i = 1; i <= vertical_slices; i++)
+        {
+            if (i < vertical_slices)
+                builder!.AddTriangle(new Vertex { Position = vertexPositions[0], FaceType = 0, UV = Vector2.Zero },
+                                       new Vertex { Position = vertexPositions[i], FaceType = 0, UV = Vector2.Zero },
+                                       new Vertex { Position = vertexPositions[i + 1], FaceType = 0, UV = Vector2.Zero });
+            else
+                builder!.AddTriangle(new Vertex { Position = vertexPositions[0], FaceType = 0, UV = Vector2.Zero },
+                                       new Vertex { Position = vertexPositions[i], FaceType = 0, UV = Vector2.Zero },
+                                       new Vertex { Position = vertexPositions[1], FaceType = 0, UV = Vector2.Zero });
+        }
+
+        for (int h_sl = 0; h_sl < horizontal_slices - 2; h_sl++)
+        {
+            for (int v_sl = 0; v_sl < vertical_slices - 1; v_sl++)
+            {
+                if (v_sl < vertical_slices - 1)
+                    builder.AddPlane(new Vertex { Position = vertexPositions[1 + v_sl + h_sl * vertical_slices], FaceType = 0, UV = Vector2.Zero },
+                                       new Vertex { Position = vertexPositions[1 + (v_sl + 1) + h_sl * vertical_slices], FaceType = 0, UV = Vector2.UnitX },
+                                       new Vertex { Position = vertexPositions[1 + v_sl + (h_sl + 1) * vertical_slices], FaceType = 0, UV = Vector2.UnitY },
+                                       new Vertex { Position = vertexPositions[1 + (v_sl + 1) + (h_sl + 1) * vertical_slices], FaceType = 0, UV = Vector2.One });
+            }
+
+            builder.AddPlane(new Vertex { Position = vertexPositions[vertical_slices + h_sl * vertical_slices], FaceType = 0, UV = Vector2.Zero },
+                                new Vertex { Position = vertexPositions[1 + h_sl * vertical_slices], FaceType = 0, UV = Vector2.UnitX },
+                                new Vertex { Position = vertexPositions[vertical_slices + (h_sl + 1) * vertical_slices], FaceType = 0, UV = Vector2.UnitY },
+                                new Vertex { Position = vertexPositions[1 + (h_sl + 1) * vertical_slices], FaceType = 0, UV = Vector2.One });
+        }
+
+        return builder.GetModel(gl);
+    }
+    public static RenderableModel GenerateCylinderModel(GL gl, float scale = 5)
+    {
+        ModelBuilder<ushort, Vertex> builder = new();
+        Matrix4x4 mtx;
+        #region Transform Helpers
+        void Reset() => mtx = Matrix4x4.CreateScale(scale);
+
+        float sides = 20;
+        float height = scale / 1.65f;
+        float radius = scale / 1.7f;
+        scale /= 1.5f;
+        float sideLength = 2 * radius * MathF.Sin(MathF.PI / sides);
+
+        static void Rotate(ref float x, ref float y)
+        {
+            var _x = x;
+            x = y;
+            y = -_x;
+        }
+
+        void RotateOnX()
+        {
+            Rotate(ref mtx.M12, ref mtx.M13);
+            Rotate(ref mtx.M22, ref mtx.M23);
+            Rotate(ref mtx.M32, ref mtx.M33);
+        }
+
+        #endregion
+
+        #region aaa
+        void Side(uint facetype)
+        {
+            builder!.AddPlane(
+                new Vertex { Position = Vector3.Transform(new Vector3(0, radius,  height), mtx), UV = Vector2.Zero, FaceType = facetype },
+                new Vertex { Position = Vector3.Transform(new Vector3(0, radius,  0), mtx), UV = Vector2.UnitX, FaceType = facetype },
+
+                new Vertex { Position = Vector3.Transform(new Vector3(0, radius,  height), mtx * Matrix4x4.CreateRotationY(MathF.PI / sides * 2)), UV = Vector2.UnitY, FaceType = facetype },
+                new Vertex { Position = Vector3.Transform(new Vector3(0, radius,  0), mtx * Matrix4x4.CreateRotationY(MathF.PI / sides * 2)), UV = Vector2.One, FaceType = facetype }
+            );
+        }
+        void Face(uint facetype)
+        {
+            builder!.AddPlane(
+                new Vertex { Position = Vector3.Transform(new Vector3(-radius, facetype == 2 ? height : 0, -radius), mtx), UV = Vector2.Zero, FaceType = facetype },
+                new Vertex { Position = Vector3.Transform(new Vector3( radius, facetype == 2 ? height : 0, -radius), mtx), UV = Vector2.UnitX, FaceType = facetype },
+                new Vertex { Position = Vector3.Transform(new Vector3(-radius, facetype == 2 ? height : 0,  radius), mtx), UV = Vector2.UnitY, FaceType = facetype },
+                new Vertex { Position = Vector3.Transform(new Vector3( radius, facetype == 2 ? height : 0,  radius), mtx), UV = Vector2.One, FaceType = facetype }
+            );
+        }
+        #endregion
+
+
+        #region Construction
+
+        Reset();
+
+        #region Faces
+        // Top
+        Face(1);
+        for (int i = 0; i < sides; i++)
+        {
+            Reset();
+            mtx *= Matrix4x4.CreateRotationX(0.5f * MathF.PI);
+            mtx *= Matrix4x4.CreateRotationY(MathF.PI / sides * i * 2);
+            Side(0);
+        }
+        Reset();
+        RotateOnX();
+        RotateOnX();
+        // // Bottom
+        Face(2);
+        #endregion
+
+        #endregion
+
+
+        return builder.GetModel(gl);
+    }
+
+    public static void Render(GL gl, CommonSceneParameters scene, CommonMaterialParameters material, int areaType, uint pickingId)
+    {
+        if (!AreaMaterial.TryUse(gl, areaType, scene, material, out ProgramUniformScope scope))
             return;
 
         using (scope)
         {
             gl.Disable(EnableCap.CullFace);
-
-            if (AreaMaterial.Program.TryGetUniformLoc("uPickingId", out int location))
-                gl.Uniform1(location, pickingId);
-
-            s_model!.Draw(gl);
+            int location = -1;
+            switch (areaType)
+            {
+                case 1:
+                    if (AreaMaterial.CenterCubeProgram.TryGetUniformLoc("uPickingId", out location))
+                        gl.Uniform1(location, pickingId);
+                    s_CubeModel!.Draw(gl);
+                    break;
+                case 2:
+                    if (AreaMaterial.SphereProgram.TryGetUniformLoc("uPickingId", out location))
+                        gl.Uniform1(location, pickingId);
+                    s_SphereModel!.Draw(gl);
+                    break;
+                case 3:
+                    if (AreaMaterial.CylinderProgram.TryGetUniformLoc("uPickingId", out location))
+                        gl.Uniform1(location, pickingId);
+                    s_CylinderModel!.Draw(gl);
+                    break;
+                default:
+                    if (AreaMaterial.BaseCubeProgram.TryGetUniformLoc("uPickingId", out location))
+                        gl.Uniform1(location, pickingId);
+                    s_CubeModel!.Draw(gl);
+                    break;
+            }
 
             gl.Enable(EnableCap.CullFace);
         }
     }
 
-    public static void CleanUp(GL gl) => s_model?.CleanUp(gl);
+    public static void CleanUp(GL gl) 
+    {
+        s_CubeModel?.CleanUp(gl);
+        s_SphereModel?.CleanUp(gl);
+        s_CylinderModel?.CleanUp(gl);
+    }
 }

--- a/Autumn/Rendering/CtrH3D/FragmentShaderGenerator.cs
+++ b/Autumn/Rendering/CtrH3D/FragmentShaderGenerator.cs
@@ -121,7 +121,7 @@ internal class FragmentShaderGenerator
         SB.AppendLine($"uniform int {DebugLUTModeUniform};");
         SB.AppendLine();
         SB.AppendLine("uniform uint uPickingId;");
-        SB.AppendLine("uniform vec4 uShadow;");
+        SB.AppendLine("uniform uint uShadow;");
 
         SB.AppendLine();
         SB.AppendLine($"in vec4 {ShaderOutputRegName.QuatNormal};");
@@ -133,7 +133,7 @@ internal class FragmentShaderGenerator
         SB.AppendLine();
         SB.AppendLine("out vec4 Output;");
         SB.AppendLine("out uint oPickingId;");
-        SB.AppendLine("out vec4 oShadow;");
+        SB.AppendLine("out uint oShadow;");
         SB.AppendLine();
         SB.AppendLine("//SPICA auto-generated Fragment Shader");
         SB.AppendLine();
@@ -141,7 +141,7 @@ internal class FragmentShaderGenerator
         SB.AppendLine();
         SB.AppendLine("    oPickingId = uPickingId;");
         SB.AppendLine("    oShadow = uShadow;");
-        SB.AppendLine($"    oShadow.b = {SelectionUniform}.a;");
+        SB.AppendLine($"    oShadow += ({SelectionUniform}.a > 0.1 ? 1 : 0) << 2;");
 
         SB.AppendLine("    vec4 Previous;");
         SB.AppendLine("    vec4 DebugDist0;");
@@ -410,9 +410,9 @@ internal class FragmentShaderGenerator
 
         if (Params.RenderLayer == (int)H3DMeshLayer.Opaque)
         {
-            SB.AppendLine("Output.a = uShadow.g > 0.1 ? 0 : 1;");
+            SB.AppendLine("Output.a = 1;");
         }
-        SB.AppendLine($"   oShadow.a = Output.a > 0.1 ? 1 : 0;");
+        // SB.AppendLine($"   oShadow.a = Output.a > 0.1 ? 1 : 0;");
 
         
         SB.AppendLine("}");

--- a/Autumn/Rendering/CtrH3D/FragmentShaderGenerator.cs
+++ b/Autumn/Rendering/CtrH3D/FragmentShaderGenerator.cs
@@ -645,7 +645,7 @@ internal class FragmentShaderGenerator
         SB.AppendLine($"\t\t\t{DiffuseUniform} * Lights[i].Diffuse * clamp(ln, 0, 1);");
         SB.AppendLine(
             $"\t\tvec4 Specular = "
-                + $"{Specular0Color} * Lights[i].Specular0 + " // Make specular 0 stronger to be closer to original
+                + $"{Specular0Color} * Lights[i].Specular0 * 2 + " // Make specular 0 stronger to be closer to original
                 + $"{Specular1Color} * Lights[i].Specular1;"
         );
         SB.AppendLine($"\t\tFragPriColor.rgb += Diffuse.rgb * SpotAtt * DistAtt;");

--- a/Autumn/Rendering/CtrH3D/FragmentShaderGenerator.cs
+++ b/Autumn/Rendering/CtrH3D/FragmentShaderGenerator.cs
@@ -121,6 +121,7 @@ internal class FragmentShaderGenerator
         SB.AppendLine($"uniform int {DebugLUTModeUniform};");
         SB.AppendLine();
         SB.AppendLine("uniform uint uPickingId;");
+        SB.AppendLine("uniform vec4 uShadow;");
 
         SB.AppendLine();
         SB.AppendLine($"in vec4 {ShaderOutputRegName.QuatNormal};");
@@ -132,12 +133,15 @@ internal class FragmentShaderGenerator
         SB.AppendLine();
         SB.AppendLine("out vec4 Output;");
         SB.AppendLine("out uint oPickingId;");
+        SB.AppendLine("out vec4 oShadow;");
         SB.AppendLine();
         SB.AppendLine("//SPICA auto-generated Fragment Shader");
         SB.AppendLine();
         SB.AppendLine("void main() {");
         SB.AppendLine();
         SB.AppendLine("    oPickingId = uPickingId;");
+        SB.AppendLine("    oShadow = uShadow;");
+        SB.AppendLine($"    oShadow.b = {SelectionUniform}.a;");
 
         SB.AppendLine("    vec4 Previous;");
         SB.AppendLine("    vec4 DebugDist0;");
@@ -406,8 +410,10 @@ internal class FragmentShaderGenerator
 
         if (Params.RenderLayer == (int)H3DMeshLayer.Opaque)
         {
-            SB.AppendLine("Output.a = 1;");
+            SB.AppendLine("Output.a = uShadow.g > 0.1 ? 0 : 1;");
         }
+        SB.AppendLine($"   oShadow.a = Output.a > 0.1 ? 1 : 0;");
+
         
         SB.AppendLine("}");
 

--- a/Autumn/Rendering/CtrH3D/FragmentShaderGenerator.cs
+++ b/Autumn/Rendering/CtrH3D/FragmentShaderGenerator.cs
@@ -29,6 +29,7 @@ internal class FragmentShaderGenerator
     public const string DebugModeUniform = "u_DebugMode";
     public const string DebugLUTModeUniform = "u_DebugLUTMode";
     public const string CombBufferUniform = "u_CombBufferColor";
+    public float ProjectionYOffset = 300;
 
     private StringBuilder SB;
 
@@ -36,9 +37,13 @@ internal class FragmentShaderGenerator
 
     private bool[] HasTexColor;
 
-    public FragmentShaderGenerator(H3DMaterialParams Params)
+    public FragmentShaderGenerator(H3DMaterialParams prms, float? projYOff)
     {
-        this.Params = Params;
+        Params = prms;
+        if (projYOff != null)
+        {
+            ProjectionYOffset = float.Max(float.Abs(projYOff.Value), 10);
+        }
     }
 
     public string GetFragShader()
@@ -367,7 +372,7 @@ internal class FragmentShaderGenerator
             $"\t    Output.rgb = vec3({ShaderOutputRegName.TexCoord0}.x, {ShaderOutputRegName.TexCoord0}.y, 1.0).rgb;"
         );
 
-        SB.AppendLine($"\telse if ({DebugModeUniform} == 6)"); //Show uv pattern
+        SB.AppendLine($"\telse if ({DebugModeUniform} == 6)"); //Show uv pattern  
         SB.AppendLine(
             $"\t    Output.rgb = texture(UVTestPattern, {ShaderOutputRegName.TexCoord0}.xy).rgb;"
         );
@@ -633,14 +638,14 @@ internal class FragmentShaderGenerator
             Specular1Color += " * g";
 
         if ((Params.FragmentFlags & H3DFragmentFlags.IsLUTGeoFactorEnabled) != 0)
-            SB.AppendLine("\t\tfloat g = 1;");// ln / abs(dot(Half, Half));");
+            SB.AppendLine("\t\tfloat g = ln / abs(dot(Half, Half));");
 
         SB.AppendLine("\t\tvec4 Diffuse =");
         SB.AppendLine($"\t\t\t{AmbientUniform} * Lights[i].Ambient +");
         SB.AppendLine($"\t\t\t{DiffuseUniform} * Lights[i].Diffuse * clamp(ln, 0, 1);");
         SB.AppendLine(
             $"\t\tvec4 Specular = "
-                + $"{Specular0Color} * Lights[i].Specular0 * 1.6 + " // Make specular 0 stronger to be closer to original
+                + $"{Specular0Color} * Lights[i].Specular0 + " // Make specular 0 stronger to be closer to original
                 + $"{Specular1Color} * Lights[i].Specular1;"
         );
         SB.AppendLine($"\t\tFragPriColor.rgb += Diffuse.rgb * SpotAtt * DistAtt;");
@@ -767,7 +772,11 @@ internal class FragmentShaderGenerator
             case H3DTextureMappingType.CameraCubeEnvMap:
                 return $"texture(TextureCube, {TexCoord}.xyz)";
             case H3DTextureMappingType.ProjectionMap:
-                return $"textureProj(Textures[{Index}], {TexCoord}.xyz)";
+            {
+                Console.WriteLine("Contains Projection material");
+                return $"textureProj(Textures[{Index}], vec3({TexCoord}.x, {TexCoord}.y, ({TexCoord}.z+ {ProjectionYOffset} * 100) * 0.01))";
+                //return $"textureProj(Textures[{Index}], {TexCoord}.xyz)";
+            }
             default:
                 return $"texture(Textures[{Index}], {TexCoord}.xy)";
         }

--- a/Autumn/Rendering/CtrH3D/FragmentShaderGenerator.cs
+++ b/Autumn/Rendering/CtrH3D/FragmentShaderGenerator.cs
@@ -133,16 +133,21 @@ internal class FragmentShaderGenerator
         SB.AppendLine();
         SB.AppendLine("out vec4 Output;");
         SB.AppendLine("out uint oPickingId;");
-        SB.AppendLine("out uint oPostProc;");
+        SB.AppendLine("out vec4 oPostProc;");
         SB.AppendLine();
         SB.AppendLine("//SPICA auto-generated Fragment Shader");
         SB.AppendLine();
         SB.AppendLine("void main() {");
         SB.AppendLine();
         SB.AppendLine("    oPickingId = uPickingId;");
-        SB.AppendLine("    oPostProc = uShadow;");
-        SB.AppendLine($"    oPostProc += ({SelectionUniform}.a > 0.1 ? 1 : 0) << 2;");
-
+        SB.AppendLine($"    oPostProc = vec4(({SelectionUniform}.a > 0.1 ? 1 : 0), (uShadow == 2u ? 0.2 : 0.0), uShadow == 1u ? 0.25 : 0.0, 1);");
+        SB.AppendLine("    if (uShadow != 0u)");
+        SB.AppendLine("    { ");
+        SB.AppendLine($"         Output = vec4({SelectionUniform}.a);");
+        // SB.AppendLine("         Output = vec3(0,0,0);");
+        SB.AppendLine("    }");
+        
+        SB.AppendLine("   else {");
         SB.AppendLine("    vec4 Previous;");
         SB.AppendLine("    vec4 DebugDist0;");
         SB.AppendLine("    vec4 DebugDist1;");
@@ -412,9 +417,9 @@ internal class FragmentShaderGenerator
         {
             SB.AppendLine("Output.a = 1;");
         }
-        // SB.AppendLine($"   oPostProc.a = Output.a > 0.1 ? 1 : 0;");
 
         
+        SB.AppendLine("}");
         SB.AppendLine("}");
 
         return SB.ToString();

--- a/Autumn/Rendering/CtrH3D/FragmentShaderGenerator.cs
+++ b/Autumn/Rendering/CtrH3D/FragmentShaderGenerator.cs
@@ -133,15 +133,15 @@ internal class FragmentShaderGenerator
         SB.AppendLine();
         SB.AppendLine("out vec4 Output;");
         SB.AppendLine("out uint oPickingId;");
-        SB.AppendLine("out uint oShadow;");
+        SB.AppendLine("out uint oPostProc;");
         SB.AppendLine();
         SB.AppendLine("//SPICA auto-generated Fragment Shader");
         SB.AppendLine();
         SB.AppendLine("void main() {");
         SB.AppendLine();
         SB.AppendLine("    oPickingId = uPickingId;");
-        SB.AppendLine("    oShadow = uShadow;");
-        SB.AppendLine($"    oShadow += ({SelectionUniform}.a > 0.1 ? 1 : 0) << 2;");
+        SB.AppendLine("    oPostProc = uShadow;");
+        SB.AppendLine($"    oPostProc += ({SelectionUniform}.a > 0.1 ? 1 : 0) << 2;");
 
         SB.AppendLine("    vec4 Previous;");
         SB.AppendLine("    vec4 DebugDist0;");
@@ -412,7 +412,7 @@ internal class FragmentShaderGenerator
         {
             SB.AppendLine("Output.a = 1;");
         }
-        // SB.AppendLine($"   oShadow.a = Output.a > 0.1 ? 1 : 0;");
+        // SB.AppendLine($"   oPostProc.a = Output.a > 0.1 ? 1 : 0;");
 
         
         SB.AppendLine("}");

--- a/Autumn/Rendering/CtrH3D/H3DRenderingMaterial.cs
+++ b/Autumn/Rendering/CtrH3D/H3DRenderingMaterial.cs
@@ -535,6 +535,7 @@ internal class H3DRenderingMaterial
             };
 
             uint sampler = SamplerHelper.CreateSampler2D(gl, wrapModeS, wrapModeT, magFilter, minFilter);
+            gl.SamplerParameter(sampler, SamplerParameterF.LodBias, -2.5f); // Editor option to improve rendering
 
             return new(sampler, texture);
 

--- a/Autumn/Rendering/CtrH3D/H3DRenderingMaterial.cs
+++ b/Autumn/Rendering/CtrH3D/H3DRenderingMaterial.cs
@@ -172,7 +172,8 @@ internal class H3DRenderingMaterial
         ShaderSource vertexShader = H3DShaders.VertexShader(FakeVtxCol);
         ShaderSource fragmentShader = H3DShaders.GetFragmentShader(
             material.Name,
-            material.MaterialParams
+            material.MaterialParams,
+            actor.Info?.ProjectionYOffset
         );
         Name = material.Name;
 

--- a/Autumn/Rendering/CtrH3D/H3DRenderingMaterial.cs
+++ b/Autumn/Rendering/CtrH3D/H3DRenderingMaterial.cs
@@ -412,7 +412,7 @@ internal class H3DRenderingMaterial
                 Constant4Color = matParams.Constant4Color.ToVector4(),
                 Constant5Color = matParams.Constant5Color.ToVector4(),
                 CombBufferColor = matParams.TexEnvBufferColor.ToVector4(),
-                AlphaReference = matParams.AlphaTest.Reference / 225f,
+                AlphaReference = matParams.AlphaTest.Reference / 255f,
                 Light0 = new()
                 {
                     Ambient = new(0.1f, 0.1f, 0.1f, 1),

--- a/Autumn/Rendering/CtrH3D/H3DRenderingMesh.cs
+++ b/Autumn/Rendering/CtrH3D/H3DRenderingMesh.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Numerics;
 using Silk.NET.OpenGL;
 using SPICA.Formats.CtrH3D.Model.Mesh;
 using SPICA.PICA.Commands;
@@ -18,6 +19,10 @@ internal class H3DRenderingMesh : IDisposable
 
     private bool _disposed = false;
 
+    public int Priority = 0;
+    public Vector3 Center = new();
+    public string Name;
+
     public unsafe H3DRenderingMesh(GL gl, H3DMesh mesh, H3DSubMeshCulling? subMeshCulling)
     {
         if (mesh.VertexStride <= 0)
@@ -27,7 +32,7 @@ internal class H3DRenderingMesh : IDisposable
 
         int vertexCount = mesh.RawBuffer.Length / mesh.VertexStride;
         int fixedAttributesOffset = mesh.RawBuffer.Length;
-
+        Name = mesh.Name;
         byte[] vertexBuffer;
 
         using (MemoryStream stream = new())
@@ -54,7 +59,7 @@ internal class H3DRenderingMesh : IDisposable
 
             vertexBuffer = stream.ToArray();
         }
-
+        Center = mesh.MeshCenter;
         //Debug.Assert(
         //    vertexBuffer.Length
         //        == fixedAttributesOffset + mesh.FixedAttributes.Count * 16 * vertexCount
@@ -74,6 +79,7 @@ internal class H3DRenderingMesh : IDisposable
 
         int offset = 0;
         uint stride = (uint)mesh.VertexStride;
+        Priority = mesh.Priority;
 
         foreach (PICAAttribute attribute in mesh.Attributes)
         {

--- a/Autumn/Rendering/CtrH3D/H3DShaders.cs
+++ b/Autumn/Rendering/CtrH3D/H3DShaders.cs
@@ -725,9 +725,9 @@ internal class H3DShaders
 			}
 			"""
 		);
-	public static ShaderSource GetFragmentShader(string name, H3DMaterialParams materialParams)
+	public static ShaderSource GetFragmentShader(string name, H3DMaterialParams materialParams, float? projYOff)
 	{
-		FragmentShaderGenerator generator = new(materialParams);
+		FragmentShaderGenerator generator = new(materialParams, projYOff);
 
 		return new(name + ".frag", ShaderType.FragmentShader, generator.GetFragShader());
 	}

--- a/Autumn/Rendering/DefaultCube/DefaultCubeMaterial.cs
+++ b/Autumn/Rendering/DefaultCube/DefaultCubeMaterial.cs
@@ -72,11 +72,11 @@ internal static class DefaultCubeMaterial
 
             out vec4 oColor;
             out uint oPickingId;
-            out uint oPostProc;            
+            out vec4 oPostProc;            
 
             void main() {
                 oPickingId = uPickingId;
-                oPostProc = 0u + (uHighlightColor.a > 0.1 ? 1u : 0u) << 2u;
+                oPostProc = vec4((uHighlightColor.a > 0.1 ? 1 : 0), 0, 0, 0);
 
                 vec3 absolute = abs(vPos);
 

--- a/Autumn/Rendering/DefaultCube/DefaultCubeMaterial.cs
+++ b/Autumn/Rendering/DefaultCube/DefaultCubeMaterial.cs
@@ -72,9 +72,11 @@ internal static class DefaultCubeMaterial
 
             out vec4 oColor;
             out uint oPickingId;
+            out uint oPostProc;            
 
             void main() {
                 oPickingId = uPickingId;
+                oPostProc = 0u + (uHighlightColor.a > 0.1 ? 1u : 0u) << 2u;
 
                 vec3 absolute = abs(vPos);
 

--- a/Autumn/Rendering/InfiniteGrid.cs
+++ b/Autumn/Rendering/InfiniteGrid.cs
@@ -60,13 +60,13 @@ namespace Autumn.Rendering
 
                 out vec4 oColor;
                 out uint oPick;
-                out uint oExtra;
+                out vec4 oPostProc;
 
                 void main() {
                     
                     oColor = vec4(0.5);
                     oPick = -1u; // Is this even valid?
-                    oExtra = 0u;
+                    oPostProc = vec4(0);
 
                     float fwx = fwidth(vTexCoord.x);
                     float fwy = fwidth(vTexCoord.y);

--- a/Autumn/Rendering/InfiniteGrid.cs
+++ b/Autumn/Rendering/InfiniteGrid.cs
@@ -59,11 +59,14 @@ namespace Autumn.Rendering
                 in vec2 vTexCoord;
 
                 out vec4 oColor;
+                out uint oPick;
+                out uint oExtra;
 
                 void main() {
                     
                     oColor = vec4(0.5);
-                    
+                    oPick = -1u; // Is this even valid?
+                    oExtra = 0u;
 
                     float fwx = fwidth(vTexCoord.x);
                     float fwy = fwidth(vTexCoord.y);

--- a/Autumn/Rendering/ModelRenderer.cs
+++ b/Autumn/Rendering/ModelRenderer.cs
@@ -199,16 +199,19 @@ internal static class ModelRenderer
                 int c = 0;
                 foreach (var (mesh, material) in actor.EnumerateMeshes(layer))
                 {
-                    if (l.Count > 0 && l.Exists(x => x.Priority <= mesh.Priority))// && mesh.Priority != 0)) 
-                    {
-                        int id = l.FindIndex(x => x.Priority <= mesh.Priority); 
-                        l.Insert(id, mesh); m.Insert(id, material); 
-                    }
-                    else { l.Add(mesh); m.Add(material); }
-                    c+= 1;
+                    // if (l.Count > 0 && l.Exists(x => x.Priority <= mesh.Priority))// && mesh.Priority != 0)) 
+                    // {
+                    //     int id = l.FindIndex(x => x.Priority <= mesh.Priority); 
+                    //     l.Insert(id, mesh); m.Insert(id, material); 
+                    // }
+                    // else { l.Add(mesh); m.Add(material); }
+                    // c+= 1;
+                    m.Add(material);
+                    l.Add(mesh);
                 }
-                l.Reverse();
-                m.Reverse();
+                // l.Reverse();
+                // m.Reverse();
+                
                 //
             for (int h = 0; h < m.Count; h++)
             {

--- a/Autumn/Rendering/ModelRenderer.cs
+++ b/Autumn/Rendering/ModelRenderer.cs
@@ -53,6 +53,7 @@ internal static class ModelRenderer
     public static bool VisibleRelationLines = true;
     
     public static bool UseFullAlphaPipeline = true;
+    public static bool UsePostProcessing = true;
 
     public static void Initialize(GL gl, LayeredFSHandler fsHandler)
     {

--- a/Autumn/Rendering/ModelRenderer.cs
+++ b/Autumn/Rendering/ModelRenderer.cs
@@ -1,6 +1,8 @@
+using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Numerics;
+using Autumn.Context;
 using Autumn.Enums;
 using Autumn.FileSystems;
 using Autumn.Rendering.Area;
@@ -9,6 +11,7 @@ using Autumn.Rendering.DefaultCube;
 using Autumn.Rendering.Rail;
 using Autumn.Rendering.Storage;
 using Autumn.Storage;
+using Autumn.Utils;
 using Autumn.Wrappers;
 using SceneGL;
 using SceneGL.GLHelpers;
@@ -111,7 +114,7 @@ internal static class ModelRenderer
         s_relationParams!.Camera = cameraEye;
     }
 
-    public static void Draw(GL gl, ISceneObj sceneObj, Scene scn)
+    public static void Draw(GL gl, ISceneObj sceneObj, ReadOnlyDictionary<string, string> CCNT, Scene scn)
     {
         if (s_commonSceneParams is null || s_defaultCubeMaterialParams is null)
             throw new InvalidOperationException(
@@ -447,8 +450,19 @@ internal static class ModelRenderer
             {
                 var material = m[h];
                 var mesh = l[h];
+                if (actorSceneObj.ChildModelTransforms.Count > 0 && actorSceneObj.ChildModelTransforms.ContainsKey(mesh.Name))
+                {
+                    actorSceneObj.DeltaTranslation += actorSceneObj.ChildModelTransforms[mesh.Name].Translate;
+                    actorSceneObj.UpdateTransform();
+                    material.SetMatrices(s_projectionMatrix, actorSceneObj.Transform, s_viewMatrix);
+                    actorSceneObj.DeltaTranslation -= actorSceneObj.ChildModelTransforms[mesh.Name].Translate;
+                    actorSceneObj.UpdateTransform();   
+                }
+                else
+                {
+                    material.SetMatrices(s_projectionMatrix, actorSceneObj.Transform, s_viewMatrix);
+                }
                 material.SetSelectionColor(new(s_highlightColor, actorSceneObj.Selected ? 0.4f : 0));
-                material.SetMatrices(s_projectionMatrix, actorSceneObj.Transform, s_viewMatrix);
                 if (scn.CanPreviewLights) material.SetLight0((scn.PreviewOneLight ? (scn.PreviewLight ?? scn.GetPreviewLight(actor.InitLight.Type)) : scn.GetPreviewLight(actor.InitLight.Type)) ?? _defaultLight);
                 else material.SetLight0(_defaultLight); 
                 material.SetViewRotation(s_cameraRotation);
@@ -516,8 +530,10 @@ internal static class ModelRenderer
                     gl.Disable(EnableCap.Blend);
                 }
             }
+            
         }
     }
+
 
     public static void AddLUTTexture(GL gl, string tableName, H3DLUTSampler sampler)
     {

--- a/Autumn/Rendering/ModelRenderer.cs
+++ b/Autumn/Rendering/ModelRenderer.cs
@@ -20,6 +20,7 @@ using Silk.NET.OpenGL;
 using SPICA.Formats.CtrGfx;
 using SPICA.Formats.CtrH3D;
 using SPICA.Formats.CtrH3D.LUT;
+using static Autumn.Wrappers.ClassModifiersWrapper;
 
 namespace Autumn.Rendering;
 
@@ -444,26 +445,22 @@ internal static class ModelRenderer
             }
             // Console.WriteLine(actorSceneObj.StageObj.Translation);
             // Console.WriteLine(scn.Camera.Eye);
-            
-            
+            # warning THIS WILL RENDER MULTIPLE TIMES IF AN OBJECT HAS MULTIPLE LAYERS
+            if (actorSceneObj.SubActors.Count > 0)
+            {
+                int cnt = 0;
+                foreach (Actor SubActor in actorSceneObj.SubActors)
+                {
+                    DrawSubActor(gl, actorSceneObj, SubActor, cnt, scn);
+                    cnt += 1;
+                } 
+            }
+
             for (int h = 0; h < m.Count; h++)
             {
                 var material = m[h];
                 var mesh = l[h];
-                if (actorSceneObj.ChildModelTransforms.Count > 0 && actorSceneObj.ChildModelTransforms.ContainsKey(mesh.Name))
-                {
-                    actorSceneObj.DeltaTranslation += actorSceneObj.ChildModelTransforms[mesh.Name].Translate;
-                    actorSceneObj.DeltaScale *= actorSceneObj.ChildModelTransforms[mesh.Name].Scale;
-                    actorSceneObj.UpdateTransform();
-                    material.SetMatrices(s_projectionMatrix, actorSceneObj.Transform, s_viewMatrix);
-                    actorSceneObj.DeltaTranslation -= actorSceneObj.ChildModelTransforms[mesh.Name].Translate;
-                    actorSceneObj.DeltaScale /= actorSceneObj.ChildModelTransforms[mesh.Name].Scale;
-                    actorSceneObj.UpdateTransform();   
-                }
-                else
-                {
-                    material.SetMatrices(s_projectionMatrix, actorSceneObj.Transform, s_viewMatrix);
-                }
+                material.SetMatrices(s_projectionMatrix, actorSceneObj.Transform, s_viewMatrix);
                 material.SetSelectionColor(new(s_highlightColor, actorSceneObj.Selected ? 0.4f : 0));
                 if (scn.CanPreviewLights) material.SetLight0((scn.PreviewOneLight ? (scn.PreviewLight ?? scn.GetPreviewLight(actor.InitLight.Type)) : scn.GetPreviewLight(actor.InitLight.Type)) ?? _defaultLight);
                 else material.SetLight0(_defaultLight); 
@@ -536,6 +533,90 @@ internal static class ModelRenderer
         }
     }
 
+    public static void DrawSubActor(GL gl, ActorSceneObj actorSceneObj, Actor act, int idx, Scene scn)
+    {
+        foreach (var (mesh, material) in act.EnumerateMeshes(H3DMeshLayer.Opaque))
+        {
+            string className = actorSceneObj.StageObj.Name;
+
+            actorSceneObj.DeltaTranslation += actorSceneObj.SubActorTransforms[idx].Translate * actorSceneObj.StageObj.Scale;
+            actorSceneObj.DeltaScale *= actorSceneObj.SubActorTransforms[idx].Scale;
+            actorSceneObj.UpdateTransform();
+            material.SetMatrices(s_projectionMatrix, actorSceneObj.Transform, s_viewMatrix);
+            actorSceneObj.DeltaTranslation -= actorSceneObj.SubActorTransforms[idx].Translate * actorSceneObj.StageObj.Scale;
+            actorSceneObj.DeltaScale /= actorSceneObj.SubActorTransforms[idx].Scale;
+            actorSceneObj.UpdateTransform();  
+
+            material.SetSelectionColor(new(s_highlightColor, actorSceneObj.Selected ? 0.4f : 0));
+            # warning maybe replace with parent Actor's light type and don't try to match the other one
+            if (scn.CanPreviewLights) material.SetLight0((scn.PreviewOneLight ? (scn.PreviewLight ?? scn.GetPreviewLight(act.InitLight.Type)) : scn.GetPreviewLight(act.InitLight.Type)) ?? _defaultLight);
+            else material.SetLight0(_defaultLight); 
+            material.SetViewRotation(s_cameraRotation);
+
+            if (!material.TryUse(gl, out ProgramUniformScope scope))
+                continue;
+
+            using (scope)
+            {
+                if (material.CullFaceMode == TriangleFace.FrontAndBack)
+                    gl.Disable(EnableCap.CullFace);
+                else
+                    gl.CullFace(material.CullFaceMode);
+
+                if (material.BlendingEnabled)
+                {
+                    gl.Enable(EnableCap.Blend | (EnableCap)0x0B60);// Attempt at Fog rendering
+
+                    gl.BlendColor(
+                        material.BlendingColor.X,
+                        material.BlendingColor.Y,
+                        material.BlendingColor.Z,
+                        material.BlendingColor.W
+                    );
+
+                    gl.BlendEquationSeparate(material.ColorBlendEquation, BlendEquationModeEXT.Max );//material.AlphaBlendEquation);
+
+                    gl.BlendFuncSeparate(
+                        material.ColorSrcFact,
+                        material.ColorDstFact,
+                        material.AlphaSrcFact,
+                        material.AlphaDstFact
+                    );
+                }
+
+                gl.StencilFunc(material.StencilFunction, material.StencilRef, material.StencilMask);
+
+                gl.StencilMask(material.StencilBufferMask);
+
+                gl.StencilOp(material.StencilOps[0], material.StencilOps[1], material.StencilOps[2]);
+
+                gl.DepthFunc(material.DepthFunction);
+                gl.DepthMask(material.DepthMaskEnabled); // /* Hacky fix to self overlapping alphas (within the same mesh),*/ if we wanted it && !material.Name.Contains("Edge"));
+
+                gl.ColorMask(
+                    material.ColorMask[0],
+                    material.ColorMask[1],
+                    material.ColorMask[2],
+                    material.ColorMask[3]
+                );
+
+                if (material.PolygonOffsetFillEnabled)
+                {
+                    gl.Enable(EnableCap.PolygonOffsetFill);
+                    gl.PolygonOffset(0, material.PolygonOffsetUnit);
+                }
+
+                material.Program.TryGetUniformLoc("uPickingId", out int location);
+                gl.Uniform1(location, actorSceneObj.PickingId);
+
+                mesh.Draw();
+
+                gl.Enable(EnableCap.CullFace);
+                gl.Disable(EnableCap.PolygonOffsetFill);
+                gl.Disable(EnableCap.Blend);
+            }
+        }
+    }
 
     public static void AddLUTTexture(GL gl, string tableName, H3DLUTSampler sampler)
     {

--- a/Autumn/Rendering/ModelRenderer.cs
+++ b/Autumn/Rendering/ModelRenderer.cs
@@ -441,6 +441,8 @@ internal static class ModelRenderer
             m.Reverse();
             if (actorSceneObj.StageObj.Name == "ShadowObj")
             {
+                l.Reverse();
+                m.Reverse();
                 for (int h = 0; h < m.Count; h++)
                 {
                     var material = m[h];
@@ -482,7 +484,7 @@ internal static class ModelRenderer
                         gl.StencilOp(material.StencilOps[0], material.StencilOps[1], material.StencilOps[2]);
 
                         gl.DepthFunc(material.DepthFunction);//h == 0 ? DepthFunction.Greater : DepthFunction.Less);
-                        gl.DepthMask(material.DepthMaskEnabled);
+                        gl.DepthMask(h == 1 ? material.DepthMaskEnabled : false);
 
                         gl.ColorMask(
                             material.ColorMask[0],
@@ -500,10 +502,8 @@ internal static class ModelRenderer
                         material.Program.TryGetUniformLoc("uPickingId", out int location);
                         gl.Uniform1(location, actorSceneObj.PickingId);
                         material.Program.TryGetUniformLoc("uShadow", out int location2);
-                        if (h == 0)
-                            gl.Uniform4(location2, new Vector4(1,1,0,0));
-                        else
-                            gl.Uniform4(location2, new Vector4(0,1,0,1));
+                        gl.Uniform1(location2, h == 0 ? 1u : 2u);
+
 
                         mesh.Draw();
 

--- a/Autumn/Rendering/ModelRenderer.cs
+++ b/Autumn/Rendering/ModelRenderer.cs
@@ -173,7 +173,7 @@ internal static class ModelRenderer
                 s_relationMaterialParams!.Selected = sceneObj.Selected;
 
                 gl.CullFace(TriangleFace.Back);
-                RelationLine.Render(gl, s_commonSceneParams, s_relationParams!, s_relationMaterialParams, actorSceneObj.PickingId, actorSceneObj.StageObj.Translation, actorSceneObj.StageObj.Parent.Translation);
+                RelationLine.Render(gl, s_commonSceneParams, s_relationParams!, s_relationMaterialParams, actorSceneObj.PickingId, actorSceneObj.StageObj.Translation + actorSceneObj.DeltaTranslation, actorSceneObj.StageObj.Parent.Translation);
             }
 
             if (actor.IsEmptyModel)
@@ -303,7 +303,7 @@ internal static class ModelRenderer
             s_relationMaterialParams!.Selected = actorSceneObj.Selected;
 
             gl.CullFace(TriangleFace.Back);
-            RelationLine.Render(gl, s_commonSceneParams, s_relationParams!, s_relationMaterialParams, actorSceneObj.PickingId, actorSceneObj.StageObj.Translation, actorSceneObj.StageObj.Parent.Translation);
+            RelationLine.Render(gl, s_commonSceneParams, s_relationParams!, s_relationMaterialParams, actorSceneObj.PickingId, actorSceneObj.StageObj.Translation + actorSceneObj.DeltaTranslation, actorSceneObj.StageObj.Parent.Translation);
         }
     }
 

--- a/Autumn/Rendering/ModelRenderer.cs
+++ b/Autumn/Rendering/ModelRenderer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Numerics;
 using Autumn.Enums;
@@ -8,6 +9,7 @@ using Autumn.Rendering.DefaultCube;
 using Autumn.Rendering.Rail;
 using Autumn.Rendering.Storage;
 using Autumn.Storage;
+using Autumn.Wrappers;
 using SceneGL;
 using SceneGL.GLHelpers;
 using SceneGL.Materials.Common;
@@ -20,7 +22,7 @@ namespace Autumn.Rendering;
 
 internal static class ModelRenderer
 {
-    private static readonly Vector3 s_highlightColor = new(1, 1, 0);
+    private static readonly Vector3 s_highlightColor = new(1, 1, 1);
 
     private static CommonSceneParameters? s_commonSceneParams;
     private static CommonMaterialParameters? s_defaultCubeMaterialParams;
@@ -45,6 +47,8 @@ internal static class ModelRenderer
     public static bool VisibleGrid = true;
     public static bool VisibleTransparentWall = true;
     public static bool VisibleRelationLines = true;
+    
+    public static bool UseFullAlphaPipeline = true;
 
     public static void Initialize(GL gl, LayeredFSHandler fsHandler)
     {
@@ -189,10 +193,29 @@ internal static class ModelRenderer
             }
 
             foreach (H3DMeshLayer layer in Enum.GetValues<H3DMeshLayer>())
-            foreach (var (mesh, material) in actor.EnumerateMeshes(layer))
             {
+                List<H3DRenderingMaterial> m = new();
+                List<H3DRenderingMesh> l = new();
+                int c = 0;
+                foreach (var (mesh, material) in actor.EnumerateMeshes(layer))
+                {
+                    if (l.Count > 0 && l.Exists(x => x.Priority <= mesh.Priority))// && mesh.Priority != 0)) 
+                    {
+                        int id = l.FindIndex(x => x.Priority <= mesh.Priority); 
+                        l.Insert(id, mesh); m.Insert(id, material); 
+                    }
+                    else { l.Add(mesh); m.Add(material); }
+                    c+= 1;
+                }
+                l.Reverse();
+                m.Reverse();
+                //
+            for (int h = 0; h < m.Count; h++)
+            {
+                var material = m[h];
+                var mesh = l[h];
+                    material.SetMatrices(s_projectionMatrix, actorSceneObj.Transform, s_viewMatrix);
                 material.SetSelectionColor(new(s_highlightColor, actorSceneObj.Selected ? 0.4f : 0));
-                material.SetMatrices(s_projectionMatrix, actorSceneObj.Transform, s_viewMatrix);
                 if (scn.CanPreviewLights) material.SetLight0((scn.PreviewOneLight ? (scn.PreviewLight ?? scn.GetPreviewLight(actor.InitLight.Type)) : scn.GetPreviewLight(actor.InitLight.Type)) ?? _defaultLight);
                 else material.SetLight0(_defaultLight); 
                 material.SetViewRotation(s_cameraRotation);
@@ -250,6 +273,7 @@ internal static class ModelRenderer
                         gl.PolygonOffset(0, material.PolygonOffsetUnit);
                     }
 
+            }
                     material.Program.TryGetUniformLoc("uPickingId", out int location);
                     gl.Uniform1(location, actorSceneObj.PickingId);
 

--- a/Autumn/Rendering/ModelRenderer.cs
+++ b/Autumn/Rendering/ModelRenderer.cs
@@ -191,7 +191,7 @@ internal static class ModelRenderer
                 return;
             }
 
-            if (actor.Name == "TransparentWall" && !VisibleTransparentWall)
+            if (actor.Name.Contains("TransparentWall") && !VisibleTransparentWall)
             {
                 return;
             }
@@ -380,7 +380,7 @@ internal static class ModelRenderer
                     return;
                 }
 
-                if (actor.Name == "TransparentWall" && !VisibleTransparentWall)
+                if (actor.Name.Contains("TransparentWall") && !VisibleTransparentWall)
                 {
                     return;
                 }
@@ -536,7 +536,7 @@ internal static class ModelRenderer
     public static void DrawSubActor(GL gl, ActorSceneObj actorSceneObj, Actor act, int idx, Scene scn)
     {
         #warning hardcoded to Opaque layers only for now
-        foreach (var (mesh, material) in act.EnumerateMeshes(H3DMeshLayer.Opaque))
+        foreach (var (mesh, material) in act.EnumerateMeshes())
         {
             string className = actorSceneObj.StageObj.Name;
 

--- a/Autumn/Rendering/ModelRenderer.cs
+++ b/Autumn/Rendering/ModelRenderer.cs
@@ -640,14 +640,16 @@ internal static class ModelRenderer
         foreach (var (mesh, material) in act.EnumerateMeshes())
         {
             string className = actorSceneObj.StageObj.Name;
-
-            actorSceneObj.DeltaTranslation += actorSceneObj.SubActorTransforms[idx].Translate * actorSceneObj.StageObj.Scale;
-            actorSceneObj.DeltaScale *= actorSceneObj.SubActorTransforms[idx].Scale;
-            actorSceneObj.UpdateTransform();
-            material.SetMatrices(s_projectionMatrix, actorSceneObj.Transform, s_viewMatrix);
-            actorSceneObj.DeltaTranslation -= actorSceneObj.SubActorTransforms[idx].Translate * actorSceneObj.StageObj.Scale;
-            actorSceneObj.DeltaScale /= actorSceneObj.SubActorTransforms[idx].Scale;
-            actorSceneObj.UpdateTransform();  
+            material.SetMatrices(
+                s_projectionMatrix, 
+                Matrix4x4.CreateRotationX(actorSceneObj.SubActorTransforms[idx].Rotate.X * MathF.PI / 180) *
+                Matrix4x4.CreateRotationY(actorSceneObj.SubActorTransforms[idx].Rotate.Y * MathF.PI / 180) *
+                Matrix4x4.CreateRotationZ(actorSceneObj.SubActorTransforms[idx].Rotate.Z * MathF.PI / 180) *
+                MathUtils.CreateTransformWithDelta((actorSceneObj.StageObj.Translation) * 0.01f, 
+                (actorSceneObj.DeltaTranslation + actorSceneObj.SubActorTransforms[idx].Translate * actorSceneObj.StageObj.Scale) * 0.01f,
+                actorSceneObj.StageObj.Scale * actorSceneObj.SubActorTransforms[idx].Scale * 0.01f, 
+                actorSceneObj.StageObj.Rotation+ actorSceneObj.DeltaRotation), 
+                s_viewMatrix);
 
             material.SetSelectionColor(new(s_highlightColor, actorSceneObj.Selected ? 0.4f : 0));
             # warning maybe replace with parent Actor's light type and don't try to match the other one

--- a/Autumn/Rendering/ModelRenderer.cs
+++ b/Autumn/Rendering/ModelRenderer.cs
@@ -535,6 +535,7 @@ internal static class ModelRenderer
 
     public static void DrawSubActor(GL gl, ActorSceneObj actorSceneObj, Actor act, int idx, Scene scn)
     {
+        #warning hardcoded to Opaque layers only for now
         foreach (var (mesh, material) in act.EnumerateMeshes(H3DMeshLayer.Opaque))
         {
             string className = actorSceneObj.StageObj.Name;

--- a/Autumn/Rendering/ModelRenderer.cs
+++ b/Autumn/Rendering/ModelRenderer.cs
@@ -439,9 +439,80 @@ internal static class ModelRenderer
             }
             l.Reverse();
             m.Reverse();
-            if (actorSceneObj.Actor.Name == "UsefulRuinMountain") 
+            if (actorSceneObj.StageObj.Name == "ShadowObj")
             {
-                //Debug.Assert(true);
+                for (int h = 0; h < m.Count; h++)
+                {
+                    var material = m[h];
+                    var mesh = l[h];
+                    material.SetMatrices(s_projectionMatrix, actorSceneObj.Transform, s_viewMatrix);
+                    material.SetSelectionColor(new(s_highlightColor, actorSceneObj.Selected ? 0.4f : -1f));
+
+                    if (!material.TryUse(gl, out ProgramUniformScope scope))
+                        continue;
+
+                    using (scope)
+                    {
+                        if (material.CullFaceMode == TriangleFace.FrontAndBack)
+                            gl.Disable(EnableCap.CullFace);
+                        else
+                            gl.CullFace(material.CullFaceMode);
+
+                        gl.Enable(EnableCap.Blend);// Attempt at Fog rendering
+
+                        gl.BlendColor(
+                            material.BlendingColor.X,
+                            material.BlendingColor.Y,
+                            material.BlendingColor.Z,
+                            material.BlendingColor.W
+                        );
+
+                        gl.BlendEquationSeparate(BlendEquationModeEXT.Max, BlendEquationModeEXT.Max);//material.AlphaBlendEquation);
+
+                        gl.BlendFuncSeparate(
+                            BlendingFactor.SrcColor,
+                            BlendingFactor.DstColor,
+                            BlendingFactor.One,
+                            BlendingFactor.One
+                        );
+                        gl.StencilFunc(material.StencilFunction, material.StencilRef, material.StencilMask);
+
+                        gl.StencilMask(material.StencilBufferMask);
+
+                        gl.StencilOp(material.StencilOps[0], material.StencilOps[1], material.StencilOps[2]);
+
+                        gl.DepthFunc(material.DepthFunction);//h == 0 ? DepthFunction.Greater : DepthFunction.Less);
+                        gl.DepthMask(material.DepthMaskEnabled);
+
+                        gl.ColorMask(
+                            material.ColorMask[0],
+                            material.ColorMask[1],
+                            material.ColorMask[2],
+                            material.ColorMask[3]
+                        );
+
+                        if (material.PolygonOffsetFillEnabled)
+                        {
+                            gl.Enable(EnableCap.PolygonOffsetFill);
+                            gl.PolygonOffset(0, material.PolygonOffsetUnit);
+                        }
+
+                        material.Program.TryGetUniformLoc("uPickingId", out int location);
+                        gl.Uniform1(location, actorSceneObj.PickingId);
+                        material.Program.TryGetUniformLoc("uShadow", out int location2);
+                        if (h == 0)
+                            gl.Uniform4(location2, new Vector4(1,1,0,0));
+                        else
+                            gl.Uniform4(location2, new Vector4(0,1,0,1));
+
+                        mesh.Draw();
+
+                        gl.Enable(EnableCap.CullFace);
+                        gl.Disable(EnableCap.PolygonOffsetFill);
+                        gl.Disable(EnableCap.Blend);
+                    }
+                }
+                return;
             }
             // Console.WriteLine(actorSceneObj.StageObj.Translation);
             // Console.WriteLine(scn.Camera.Eye);

--- a/Autumn/Rendering/ModelRenderer.cs
+++ b/Autumn/Rendering/ModelRenderer.cs
@@ -20,6 +20,7 @@ using Silk.NET.OpenGL;
 using SPICA.Formats.CtrGfx;
 using SPICA.Formats.CtrH3D;
 using SPICA.Formats.CtrH3D.LUT;
+using SPICA.Formats.CtrH3D.Model.Material;
 using static Autumn.Wrappers.ClassModifiersWrapper;
 
 namespace Autumn.Rendering;
@@ -53,7 +54,6 @@ internal static class ModelRenderer
     public static bool VisibleRelationLines = true;
     
     public static bool UseFullAlphaPipeline = true;
-    public static bool UsePostProcessing = true;
 
     public static void Initialize(GL gl, LayeredFSHandler fsHandler)
     {
@@ -311,6 +311,108 @@ internal static class ModelRenderer
             RelationLine.Render(gl, s_commonSceneParams, s_relationParams!, s_relationMaterialParams, actorSceneObj.PickingId, actorSceneObj.StageObj.Translation + actorSceneObj.DeltaTranslation, actorSceneObj.StageObj.Parent.Translation);
         }
     }
+    public static void DrawShadow(GL gl, Actor actor, Matrix4x4 Tr, bool Selected, uint PickId, bool fullActor = false)
+    {       
+            List<H3DRenderingMaterial> m = new();
+            List<H3DRenderingMesh> l = new();
+            List<(H3DRenderingMaterial, H3DRenderingMesh)> lm = new();
+            int c = 0;
+            foreach (var (mesh, material) in actor.EnumerateMeshes())
+            {
+                l.Add(mesh); 
+                m.Add(material);
+                lm.Add((material, mesh));
+                c+= 1;
+            }
+            // lm.OrderBy(x => x.Item1.Name);
+            {
+                if (actor.Name.Contains("ShadowVolumeDokan"))
+                {
+                    lm.Reverse();
+                }
+                for (int h = 0; h < lm.Count; h++)
+                {
+                    var material = lm[h].Item1;
+                    var mesh = lm[h].Item2;
+                    material.SetMatrices(s_projectionMatrix, Tr, s_viewMatrix);
+                    material.SetSelectionColor(new(s_highlightColor, Selected ? 0.4f : -1f));
+
+                    if (!material.TryUse(gl, out ProgramUniformScope scope))
+                        continue;
+
+                    using (scope)
+                    {
+                        if (material.CullFaceMode == TriangleFace.FrontAndBack)
+                            gl.Disable(EnableCap.CullFace);
+                        else
+                            gl.CullFace(material.CullFaceMode);
+
+                        gl.Enable(EnableCap.Blend);// Attempt at Fog rendering
+
+                        gl.BlendColor(
+                            material.BlendingColor.X,
+                            material.BlendingColor.Y,
+                            material.BlendingColor.Z,
+                            material.BlendingColor.W
+                        );
+
+                        gl.BlendEquationSeparate(BlendEquationModeEXT.FuncAdd, BlendEquationModeEXT.FuncAdd);//material.AlphaBlendEquation);
+
+                        gl.BlendFuncSeparate(
+                            BlendingFactor.SrcColor,
+                            BlendingFactor.DstAlpha,
+                            BlendingFactor.One,
+                            BlendingFactor.One
+                        );
+                        gl.StencilFunc(material.StencilFunction, material.StencilRef, material.StencilMask);
+
+                        gl.StencilMask(material.StencilBufferMask);
+
+                        gl.StencilOp(material.StencilOps[0], material.StencilOps[1], material.StencilOps[2]);
+
+                        gl.DepthFunc(material.DepthFunction);//h == 0 ? DepthFunction.Greater : DepthFunction.Less);
+                        gl.DepthMask(h == 1 ? material.DepthMaskEnabled : false);
+
+                        // gl.ColorMask(
+                        //     material.ColorMask[0],
+                        //     material.ColorMask[1],
+                        //     material.ColorMask[2],
+                        //     material.ColorMask[3]
+                        // );
+                        gl.ColorMask(
+                            fullActor,
+                            true,
+                            true,
+                            true
+                        );
+
+                        if (material.PolygonOffsetFillEnabled)
+                        {
+                            gl.Enable(EnableCap.PolygonOffsetFill);
+                            gl.PolygonOffset(0, material.PolygonOffsetUnit);
+                        }
+                        
+                        material.Program.TryGetUniformLoc("uPickingId", out int location);
+                        gl.Uniform1(location, PickId);
+                        material.Program.TryGetUniformLoc("uShadow", out int location2);
+                        gl.Uniform1(location2, h == 0 ? 1u : 2u);
+
+
+                        mesh.Draw();
+
+                        gl.Enable(EnableCap.CullFace);
+                        gl.Disable(EnableCap.PolygonOffsetFill);
+                        gl.Disable(EnableCap.Blend);
+                        gl.ColorMask(
+                            true,
+                            true,
+                            true,
+                            true
+                        );
+                    }
+                }
+            }
+    }
 
     public static void DrawLayer(GL gl, ISceneObj sceneObj, Scene scn, H3DMeshLayer layer)
     {
@@ -440,81 +542,6 @@ internal static class ModelRenderer
             }
             l.Reverse();
             m.Reverse();
-            if (actorSceneObj.StageObj.Name == "ShadowObj")
-            {
-                l.Reverse();
-                m.Reverse();
-                for (int h = 0; h < m.Count; h++)
-                {
-                    var material = m[h];
-                    var mesh = l[h];
-                    material.SetMatrices(s_projectionMatrix, actorSceneObj.Transform, s_viewMatrix);
-                    material.SetSelectionColor(new(s_highlightColor, actorSceneObj.Selected ? 0.4f : -1f));
-
-                    if (!material.TryUse(gl, out ProgramUniformScope scope))
-                        continue;
-
-                    using (scope)
-                    {
-                        if (material.CullFaceMode == TriangleFace.FrontAndBack)
-                            gl.Disable(EnableCap.CullFace);
-                        else
-                            gl.CullFace(material.CullFaceMode);
-
-                        gl.Enable(EnableCap.Blend);// Attempt at Fog rendering
-
-                        gl.BlendColor(
-                            material.BlendingColor.X,
-                            material.BlendingColor.Y,
-                            material.BlendingColor.Z,
-                            material.BlendingColor.W
-                        );
-
-                        gl.BlendEquationSeparate(BlendEquationModeEXT.Max, BlendEquationModeEXT.Max);//material.AlphaBlendEquation);
-
-                        gl.BlendFuncSeparate(
-                            BlendingFactor.SrcColor,
-                            BlendingFactor.DstColor,
-                            BlendingFactor.One,
-                            BlendingFactor.One
-                        );
-                        gl.StencilFunc(material.StencilFunction, material.StencilRef, material.StencilMask);
-
-                        gl.StencilMask(material.StencilBufferMask);
-
-                        gl.StencilOp(material.StencilOps[0], material.StencilOps[1], material.StencilOps[2]);
-
-                        gl.DepthFunc(material.DepthFunction);//h == 0 ? DepthFunction.Greater : DepthFunction.Less);
-                        gl.DepthMask(h == 1 ? material.DepthMaskEnabled : false);
-
-                        gl.ColorMask(
-                            material.ColorMask[0],
-                            material.ColorMask[1],
-                            material.ColorMask[2],
-                            material.ColorMask[3]
-                        );
-
-                        if (material.PolygonOffsetFillEnabled)
-                        {
-                            gl.Enable(EnableCap.PolygonOffsetFill);
-                            gl.PolygonOffset(0, material.PolygonOffsetUnit);
-                        }
-
-                        material.Program.TryGetUniformLoc("uPickingId", out int location);
-                        gl.Uniform1(location, actorSceneObj.PickingId);
-                        material.Program.TryGetUniformLoc("uShadow", out int location2);
-                        gl.Uniform1(location2, h == 0 ? 1u : 2u);
-
-
-                        mesh.Draw();
-
-                        gl.Enable(EnableCap.CullFace);
-                        gl.Disable(EnableCap.PolygonOffsetFill);
-                        gl.Disable(EnableCap.Blend);
-                    }
-                }
-                return;
-            }
             // Console.WriteLine(actorSceneObj.StageObj.Translation);
             // Console.WriteLine(scn.Camera.Eye);
             # warning THIS WILL RENDER MULTIPLE TIMES IF AN OBJECT HAS MULTIPLE LAYERS
@@ -527,6 +554,8 @@ internal static class ModelRenderer
                     cnt += 1;
                 } 
             }
+
+            
 
             for (int h = 0; h < m.Count; h++)
             {
@@ -559,7 +588,7 @@ internal static class ModelRenderer
                             material.BlendingColor.W
                         );
 
-                        gl.BlendEquationSeparate(material.ColorBlendEquation, BlendEquationModeEXT.Max );//material.AlphaBlendEquation);
+                        gl.BlendEquationSeparate(material.ColorBlendEquation, BlendEquationModeEXT.Max);//material.AlphaBlendEquation);
 
                         gl.BlendFuncSeparate(
                             material.ColorSrcFact,

--- a/Autumn/Rendering/ModelRenderer.cs
+++ b/Autumn/Rendering/ModelRenderer.cs
@@ -291,7 +291,21 @@ internal static class ModelRenderer
         }
     }
 
+    /// <summary>
+    /// Separated from the draw function so it's only drawn once
+    /// </summary>
+    /// <param name="gl"></param>
+    /// <param name="actorSceneObj"></param>
+    public static void DrawRelLines(GL gl, ActorSceneObj actorSceneObj)
+    {
+        if (VisibleRelationLines)
+        {
+            s_relationMaterialParams!.Selected = actorSceneObj.Selected;
 
+            gl.CullFace(TriangleFace.Back);
+            RelationLine.Render(gl, s_commonSceneParams, s_relationParams!, s_relationMaterialParams, actorSceneObj.PickingId, actorSceneObj.StageObj.Translation, actorSceneObj.StageObj.Parent.Translation);
+        }
+    }
 
     public static void DrawLayer(GL gl, ISceneObj sceneObj, Scene scn, H3DMeshLayer layer)
     {

--- a/Autumn/Rendering/ModelRenderer.cs
+++ b/Autumn/Rendering/ModelRenderer.cs
@@ -273,7 +273,222 @@ internal static class ModelRenderer
                         gl.PolygonOffset(0, material.PolygonOffsetUnit);
                     }
 
+                    material.Program.TryGetUniformLoc("uPickingId", out int location);
+                    gl.Uniform1(location, actorSceneObj.PickingId);
+//                     if (actor.Name == "Pole") // if the actor modifies the bones
+//                         material.ChangeUnivReg(0, 2, 3, actorSceneObj.StageObj.Scale.Y, gl);
+                    mesh.Draw();
+
+                    gl.Enable(EnableCap.CullFace);
+                    gl.Disable(EnableCap.PolygonOffsetFill);
+                    gl.Disable(EnableCap.Blend);
+                }
             }
+            }
+        }
+    }
+
+
+
+    public static void DrawLayer(GL gl, ISceneObj sceneObj, Scene scn, H3DMeshLayer layer)
+    {
+        if (s_commonSceneParams is null || s_defaultCubeMaterialParams is null)
+            throw new InvalidOperationException(
+                $@"{nameof(ModelRenderer)} must be initialized before any calls to {nameof(Draw)}"
+            );
+            
+        if (!sceneObj.IsVisible)
+            return;
+
+        if (layer == H3DMeshLayer.Opaque)
+        {
+            StageObj? stageObj = null;
+
+            if (sceneObj is IStageSceneObj stageSceneObj) stageObj = stageSceneObj.StageObj;
+
+
+            if (sceneObj is BasicSceneObj basicSceneObj && stageObj!.IsArea())
+            {
+                if (!VisibleAreas && !sceneObj.Selected && stageObj.Type != StageObjType.CameraArea)
+                    return;
+
+                if (!VisibleCameraAreas && !sceneObj.Selected && stageObj.Type == StageObjType.CameraArea)
+                    return;
+
+                s_commonSceneParams.Transform = sceneObj.Transform;
+
+                if (basicSceneObj.Selected)
+                {
+                    basicSceneObj.MaterialParams.HighlightColor = s_highlightColor;
+                    basicSceneObj.MaterialParams.Selected = true;
+                }
+                else if (basicSceneObj.MaterialParams.Selected)
+                {
+                    // We only set it to false if needed, otherwise the buffer will be rewritten always.
+                    basicSceneObj.MaterialParams.Selected = false;
+                }
+
+                gl.CullFace(TriangleFace.Back);
+
+                AreaRenderer.Render(gl, s_commonSceneParams, basicSceneObj.MaterialParams, sceneObj.PickingId);
+                return;
+            }
+
+            if (sceneObj is RailSceneObj railSceneObj)
+            {
+                if(!railSceneObj.RailModel.Initialized)
+                    return;
+                s_railMaterialParams!.Selected = railSceneObj.Selected;
+
+                gl.Disable(EnableCap.CullFace);
+                RailRenderer.Render(gl, railSceneObj, railSceneObj.Selected,
+                    s_commonSceneParams, s_railGeometryParams!, s_railHandleGeoParams!, s_railMaterialParams, s_railPointMaterialParams!);
+                return;
+            }
+            if (sceneObj is ActorSceneObj actorSceneObj1)
+            {
+                Actor actor = actorSceneObj1.Actor;
+                if (actor.IsEmptyModel)
+                {
+                    s_commonSceneParams.Transform = sceneObj.Transform;
+                    s_defaultCubeMaterialParams.Selected = sceneObj.Selected;
+
+                    gl.CullFace(TriangleFace.Back);
+
+                    DefaultCubeRenderer.Render(gl, s_commonSceneParams, s_defaultCubeMaterialParams, sceneObj.PickingId);
+                    return;
+                }
+
+                if (actor.Name == "TransparentWall" && !VisibleTransparentWall)
+                {
+                    return;
+                }
+            }
+        }
+
+        if (sceneObj is ActorSceneObj actorSceneObj)
+        {
+            Actor actor = actorSceneObj.Actor;
+            
+            List<H3DRenderingMaterial> m = new();
+            List<H3DRenderingMesh> l = new();
+            // var d = actor.EnumerateMeshes(layer).ToDictionary();
+            // foreach (var (mesh, material) in actor.EnumerateMeshes(layer))
+            // {
+            //     if (l.Count > 0 && mesh.Priority < l[0].Priority) { l.Insert(0, mesh); m.Insert(0, material); }
+            //     else { l.Add(mesh); m.Add(material); }
+            // }
+            // Console.WriteLine("////////////");
+            int c = 0;
+            List<(H3DRenderingMesh, H3DRenderingMaterial)> dd;
+            if (layer == H3DMeshLayer.Opaque)
+                dd = actor.EnumerateMeshes(layer).ToList();
+            else
+            {
+                dd = actor.EnumerateMeshes(layer).ToList();
+                //dd = actor.MeshesUnlayered.ToList();
+                dd.Reverse();
+            }
+            foreach (var (mesh, material) in dd)
+            {
+                if (l.Count > 0 && l.Exists(x => x.Priority <= mesh.Priority))// && mesh.Priority != 0)) 
+                {
+                    int id = -1;
+                    if (l.Exists(x => x.Priority < mesh.Priority))
+                        id = l.FindIndex(x => x.Priority < mesh.Priority);
+                    else if (l.Exists(x => x.Priority == mesh.Priority))
+                        id = l.FindLastIndex(x => x.Priority == mesh.Priority) + 1;
+                    l.Insert(id, mesh); m.Insert(id, material);
+                }
+                // else if (l.Count > 0  && l.Exists(x => x.Priority == 0 && mesh.Priority == 0))
+                // {
+                //     int id = l.FindLastIndex(x => x.Priority == 0); 
+                //     l.Insert(id, mesh); m.Insert(id, material); 
+                // }
+                // else if (l.Count > 0)
+                // {
+                //     if (Vector3.Distance(mesh.Center + actorSceneObj.StageObj.Translation, scn.Camera.Eye * 100) < Vector3.Distance(l[c].Center + actorSceneObj.StageObj.Translation, scn.Camera.Eye * 100))
+                //     {
+                //         l.Insert(l.Count-1, mesh); m.Insert(m.Count-1, material);
+                //     }
+                // }
+                else { l.Add(mesh); m.Add(material); }
+                // Console.WriteLine(l[c].Center);
+                c+= 1;
+            }
+            l.Reverse();
+            m.Reverse();
+            if (actorSceneObj.Actor.Name == "UsefulRuinMountain") 
+            {
+                //Debug.Assert(true);
+            }
+            // Console.WriteLine(actorSceneObj.StageObj.Translation);
+            // Console.WriteLine(scn.Camera.Eye);
+            
+            
+            for (int h = 0; h < m.Count; h++)
+            {
+                var material = m[h];
+                var mesh = l[h];
+                material.SetSelectionColor(new(s_highlightColor, actorSceneObj.Selected ? 0.4f : 0));
+                material.SetMatrices(s_projectionMatrix, actorSceneObj.Transform, s_viewMatrix);
+                if (scn.CanPreviewLights) material.SetLight0((scn.PreviewOneLight ? (scn.PreviewLight ?? scn.GetPreviewLight(actor.InitLight.Type)) : scn.GetPreviewLight(actor.InitLight.Type)) ?? _defaultLight);
+                else material.SetLight0(_defaultLight); 
+                material.SetViewRotation(s_cameraRotation);
+
+                if (!material.TryUse(gl, out ProgramUniformScope scope))
+                    continue;
+
+                using (scope)
+                {
+                    if (material.CullFaceMode == TriangleFace.FrontAndBack)
+                        gl.Disable(EnableCap.CullFace);
+                    else
+                        gl.CullFace(material.CullFaceMode);
+
+                    if (material.BlendingEnabled)
+                    {
+                        gl.Enable(EnableCap.Blend | (EnableCap)0x0B60);// Attempt at Fog rendering
+
+                        gl.BlendColor(
+                            material.BlendingColor.X,
+                            material.BlendingColor.Y,
+                            material.BlendingColor.Z,
+                            material.BlendingColor.W
+                        );
+
+                        gl.BlendEquationSeparate(material.ColorBlendEquation, BlendEquationModeEXT.Max );//material.AlphaBlendEquation);
+
+                        gl.BlendFuncSeparate(
+                            material.ColorSrcFact,
+                            material.ColorDstFact,
+                            material.AlphaSrcFact,
+                            material.AlphaDstFact
+                        );
+                    }
+
+                    gl.StencilFunc(material.StencilFunction, material.StencilRef, material.StencilMask);
+
+                    gl.StencilMask(material.StencilBufferMask);
+
+                    gl.StencilOp(material.StencilOps[0], material.StencilOps[1], material.StencilOps[2]);
+
+                    gl.DepthFunc(material.DepthFunction);
+                    gl.DepthMask(material.DepthMaskEnabled); // /* Hacky fix to self overlapping alphas (within the same mesh),*/ if we wanted it && !material.Name.Contains("Edge"));
+
+                    gl.ColorMask(
+                        material.ColorMask[0],
+                        material.ColorMask[1],
+                        material.ColorMask[2],
+                        material.ColorMask[3]
+                    );
+
+                    if (material.PolygonOffsetFillEnabled)
+                    {
+                        gl.Enable(EnableCap.PolygonOffsetFill);
+                        gl.PolygonOffset(0, material.PolygonOffsetUnit);
+                    }
+
                     material.Program.TryGetUniformLoc("uPickingId", out int location);
                     gl.Uniform1(location, actorSceneObj.PickingId);
 

--- a/Autumn/Rendering/ModelRenderer.cs
+++ b/Autumn/Rendering/ModelRenderer.cs
@@ -453,9 +453,11 @@ internal static class ModelRenderer
                 if (actorSceneObj.ChildModelTransforms.Count > 0 && actorSceneObj.ChildModelTransforms.ContainsKey(mesh.Name))
                 {
                     actorSceneObj.DeltaTranslation += actorSceneObj.ChildModelTransforms[mesh.Name].Translate;
+                    actorSceneObj.DeltaScale *= actorSceneObj.ChildModelTransforms[mesh.Name].Scale;
                     actorSceneObj.UpdateTransform();
                     material.SetMatrices(s_projectionMatrix, actorSceneObj.Transform, s_viewMatrix);
                     actorSceneObj.DeltaTranslation -= actorSceneObj.ChildModelTransforms[mesh.Name].Translate;
+                    actorSceneObj.DeltaScale /= actorSceneObj.ChildModelTransforms[mesh.Name].Scale;
                     actorSceneObj.UpdateTransform();   
                 }
                 else

--- a/Autumn/Rendering/ModelRenderer.cs
+++ b/Autumn/Rendering/ModelRenderer.cs
@@ -563,8 +563,6 @@ internal static class ModelRenderer
                 } 
             }
 
-            
-
             for (int h = 0; h < m.Count; h++)
             {
                 var material = m[h];
@@ -644,7 +642,6 @@ internal static class ModelRenderer
 
     public static void DrawSubActor(GL gl, ActorSceneObj actorSceneObj, Actor act, int idx, Scene scn)
     {
-        #warning hardcoded to Opaque layers only for now
         foreach (var (mesh, material) in act.EnumerateMeshes())
         {
             string className = actorSceneObj.StageObj.Name;
@@ -660,7 +657,6 @@ internal static class ModelRenderer
                 s_viewMatrix);
 
             material.SetSelectionColor(new(s_highlightColor, actorSceneObj.Selected ? 0.4f : 0));
-            # warning maybe replace with parent Actor's light type and don't try to match the other one
             if (scn.CanPreviewLights) material.SetLight0((scn.PreviewOneLight ? (scn.PreviewLight ?? scn.GetPreviewLight(act.InitLight.Type)) : scn.GetPreviewLight(act.InitLight.Type)) ?? _defaultLight);
             else material.SetLight0(_defaultLight); 
             material.SetViewRotation(s_cameraRotation);

--- a/Autumn/Rendering/ModelRenderer.cs
+++ b/Autumn/Rendering/ModelRenderer.cs
@@ -31,6 +31,7 @@ internal static class ModelRenderer
 
     private static CommonSceneParameters? s_commonSceneParams;
     private static CommonMaterialParameters? s_defaultCubeMaterialParams;
+    private static CommonMaterialParameters? s_transparentWallMaterialParams;
 
     private static RailGeometryParameters? s_railGeometryParams;
     private static RailGeometryParameters? s_railHandleGeoParams;
@@ -63,6 +64,7 @@ internal static class ModelRenderer
         s_commonSceneParams = new();
 
         s_defaultCubeMaterialParams = new(new(1, 0.5f, 0, 1), s_highlightColor);
+        s_transparentWallMaterialParams = new(new(0.3f, 0.3f, 0.3f, 1), s_highlightColor);
         s_railGeometryParams = new(lineWidth: 0.08f, camera: new(1));
         s_railHandleGeoParams = new(0.04f, new(1));
         s_railMaterialParams = new(new(0.25f, 0.25f, 0.31f, 1), s_highlightColor);
@@ -483,8 +485,14 @@ internal static class ModelRenderer
                     return;
                 }
 
-                if (actor.Name.Contains("TransparentWall") && !VisibleTransparentWall)
+                if (actor.Name.Contains("TransparentWall"))
                 {
+                    if (!VisibleTransparentWall && !sceneObj.Selected)
+                        return;
+                    s_commonSceneParams.Transform = sceneObj.Transform;
+                    s_transparentWallMaterialParams!.Selected = sceneObj.Selected;
+
+                    TransparentWallRenderer.Render(gl, s_commonSceneParams, s_transparentWallMaterialParams, sceneObj.PickingId);
                     return;
                 }
             }

--- a/Autumn/Rendering/ModelRenderer.cs
+++ b/Autumn/Rendering/ModelRenderer.cs
@@ -153,7 +153,7 @@ internal static class ModelRenderer
 
             gl.CullFace(TriangleFace.Back);
 
-            AreaRenderer.Render(gl, s_commonSceneParams, basicSceneObj.MaterialParams, sceneObj.PickingId);
+            AreaRenderer.Render(gl, s_commonSceneParams, basicSceneObj.MaterialParams, basicSceneObj.StageObj.Properties.TryGetValue("ShapeModelNo", out object? val) ? (int)val! : 0, sceneObj.PickingId);
             return;
         }
 
@@ -454,7 +454,7 @@ internal static class ModelRenderer
 
                 gl.CullFace(TriangleFace.Back);
 
-                AreaRenderer.Render(gl, s_commonSceneParams, basicSceneObj.MaterialParams, sceneObj.PickingId);
+                AreaRenderer.Render(gl, s_commonSceneParams, basicSceneObj.MaterialParams, basicSceneObj.StageObj.Properties.TryGetValue("ShapeModelNo", out object? val) ? (int)val! : 0, sceneObj.PickingId);
                 return;
             }
 

--- a/Autumn/Rendering/ModelRenderer.cs
+++ b/Autumn/Rendering/ModelRenderer.cs
@@ -240,7 +240,7 @@ internal static class ModelRenderer
 
                     if (material.BlendingEnabled)
                     {
-                        gl.Enable(EnableCap.Blend | (EnableCap)0x0B60);// Attempt at Fog rendering
+                        gl.Enable(EnableCap.Blend);
 
                         gl.BlendColor(
                             material.BlendingColor.X,
@@ -347,7 +347,7 @@ internal static class ModelRenderer
                         else
                             gl.CullFace(material.CullFaceMode);
 
-                        gl.Enable(EnableCap.Blend);// Attempt at Fog rendering
+                        gl.Enable(EnableCap.Blend);
 
                         gl.BlendColor(
                             material.BlendingColor.X,
@@ -579,7 +579,7 @@ internal static class ModelRenderer
 
                     if (material.BlendingEnabled)
                     {
-                        gl.Enable(EnableCap.Blend | (EnableCap)0x0B60);// Attempt at Fog rendering
+                        gl.Enable(EnableCap.Blend);
 
                         gl.BlendColor(
                             material.BlendingColor.X,
@@ -669,7 +669,7 @@ internal static class ModelRenderer
 
                 if (material.BlendingEnabled)
                 {
-                    gl.Enable(EnableCap.Blend | (EnableCap)0x0B60);// Attempt at Fog rendering
+                    gl.Enable(EnableCap.Blend);
 
                     gl.BlendColor(
                         material.BlendingColor.X,

--- a/Autumn/Rendering/MultitextureCanvas.cs
+++ b/Autumn/Rendering/MultitextureCanvas.cs
@@ -130,18 +130,18 @@ internal static class Canvas
                 // Exponential fog
                 else if (((uBools >> 1u) & 3u) == 2u)
                 {
-                   FragColor.rgb = mix(FragColor.rgb, uFogColor, clamp(ToExp(log(texture(Depth, vec3(TexCoords.x, TexCoords.y, 0.01))) * log(1/ 1000000f)), 0.0, 1.0)); 
+                   FragColor.rgb = mix(FragColor.rgb, uFogColor, clamp(ToExp(log(texture(Depth, vec3(TexCoords.x, TexCoords.y, 0.01))) * log(1/ 1000000.0)), 0.0, 1.0)); 
                 }
                 // Exponential Squared fog
                 else if (((uBools >> 1u) & 3u) == 3u)
                 {
-                   FragColor.rgb = mix(FragColor.rgb, uFogColor, clamp(ToExpSqr(log(texture(Depth, vec3(TexCoords.x, TexCoords.y, 0.01))) * log(1/ 1/ 1000000f)), 0.0, 1.0)); 
+                   FragColor.rgb = mix(FragColor.rgb, uFogColor, clamp(ToExpSqr(log(texture(Depth, vec3(TexCoords.x, TexCoords.y, 0.01))) * log(1/ 1/ 1000000.0)), 0.0, 1.0)); 
                 }
 
                 vec4 tx2 = texture(FgTexture, TexCoords);
                 if (tx2.g * 2 < tx2.b)
                     FragColor *= 0.6;
-                // FragColor.rgb = vec3(ToExpSqr(log(texture(Depth, vec3(TexCoords.x, TexCoords.y, 0.01))) * log(1 / 1000000f)));
+                // FragColor.rgb = vec3(ToExpSqr(log(texture(Depth, vec3(TexCoords.x, TexCoords.y, 0.01))) * log(1 / 1000000.0)));
                 // FragColor.rgb = vec3(1 - log(texture(Depth, vec3(TexCoords.x, TexCoords.y, 0.01))) * log(1/ uNearFarDensity.x / 1000));
             }
             """

--- a/Autumn/Rendering/MultitextureCanvas.cs
+++ b/Autumn/Rendering/MultitextureCanvas.cs
@@ -40,18 +40,18 @@ internal static class Canvas
 
             in vec2 TexCoords;
 
-            uniform sampler2D FgTexture;
+            uniform usampler2D FgTexture;
             uniform sampler2D BgTexture;
 
             out vec4 FragColor;
 
             const float offset = 1.0 / 350.0; 
             void main()
-            { 
+            {
                 FragColor = texture(BgTexture, TexCoords);
-                vec4 tx = texture(FgTexture, TexCoords);
-                if (tx.g > 0.1 && tx.r < 0.1)
-                    FragColor *= tx.g * 0.6;
+                uint tx = texture(FgTexture, TexCoords).r;
+                if ((tx & 3u) == 1u)
+                    FragColor *= 0.6;
                 vec2 offsets[9] = vec2[](
                     vec2(-offset,  offset), // top-left
                     vec2( 0.0f,    offset), // top-center
@@ -69,14 +69,15 @@ internal static class Canvas
                     2, -22, 2,
                     2, 2, 2
                 );
-                float hasSelection = 0;
+                uint hasSelection = 0u;
                 vec3 sampleTex[9];
                 for(int i = 0; i < 9; i++)
                 {
-                    sampleTex[i] = vec3(texture(FgTexture, TexCoords.st + offsets[i]).b);
-                    hasSelection += (texture(FgTexture, TexCoords.st + offsets[i]).b > 0.3 ? 1 : 0);
+                    uint t = texture(FgTexture, TexCoords.st + offsets[i]).r;
+                    sampleTex[i] = vec3(t);
+                    hasSelection += (((t & 4u) == 4u && (t != 255u)) ? 1u : 0u);
                 }
-                if (hasSelection > 0.5)
+                if (hasSelection > 1u)
                 {
                     vec3 col = vec3(0.0);
                     for(int i = 0; i < 9; i++)
@@ -91,7 +92,7 @@ internal static class Canvas
     public static bool TryUse(
         GL gl,
         out ProgramUniformScope scope
-    ) => Program.TryUse(gl, null, [_something], out scope, out _);
+    ) => Program.TryUse(gl, null, [_samplers], out scope, out _);
 
 
     private static uint _smpl = 0; 
@@ -108,7 +109,7 @@ internal static class Canvas
         return _smpl;
     }
     static List<SamplerBinding> samplerBindings = new();        
-    public static ShaderParams _something;
+    private static ShaderParams _samplers;
 
 
     internal static class CanvasRenderer
@@ -130,7 +131,7 @@ internal static class Canvas
             samplerBindings.Add(new ("STexture", 0, 0));
             samplerBindings.Add(new ("STexture2", 0, 0));
         }
-        public static RenderableModel GenerateCanvas(GL gl, float scale = 0.5f)
+        public static RenderableModel GenerateCanvas(GL gl)
         {
             ModelBuilder<ushort, Vertex> builder = new();
             builder!.AddPlane(
@@ -143,7 +144,7 @@ internal static class Canvas
             return builder.GetModel(gl);
         }
         public static bool HasToReset = true;
-        public static void Reset(uint tx1, uint tx2, uint tx3)
+        public static void Reset(uint tx1, uint tx2)
         {
             samplerBindings[0] = new ("BgTexture", _smpl, tx1);
             samplerBindings[1] = new ("FgTexture", _smpl, tx2);
@@ -153,10 +154,10 @@ internal static class Canvas
 
         public static void Render(GL gl, SceneGL.GLWrappers.Framebuffer basis)
         {
-            if (true) 
+            if (HasToReset) 
             {
-                Reset(basis.GetColorTexture(0), basis.GetColorTexture(2), basis.GetColorTexture(1));
-                _something = ShaderParams.FromSamplers(samplerBindings.ToArray());
+                Reset(basis.GetColorTexture(0), basis.GetColorTexture(2));
+                _samplers = ShaderParams.FromSamplers(samplerBindings.ToArray());
             }
             if (!Canvas.TryUse(gl, out ProgramUniformScope scope))
                 return;

--- a/Autumn/Rendering/MultitextureCanvas.cs
+++ b/Autumn/Rendering/MultitextureCanvas.cs
@@ -40,8 +40,11 @@ internal static class Canvas
 
             in vec2 TexCoords;
 
-            uniform usampler2D FgTexture;
+            uniform sampler2D FgTexture;
             uniform sampler2D BgTexture;
+
+            uniform uint uBools;
+            // first bit -> outline enabled
 
             out vec4 FragColor;
 
@@ -49,41 +52,43 @@ internal static class Canvas
             void main()
             {
                 FragColor = texture(BgTexture, TexCoords);
-                uint tx = texture(FgTexture, TexCoords).r;
-                if ((tx & 3u) == 1u)
+                vec4 tx2 = texture(FgTexture, TexCoords);
+                if (tx2.g * 2 < tx2.b)
                     FragColor *= 0.6;
-                vec2 offsets[9] = vec2[](
-                    vec2(-offset,  offset), // top-left
-                    vec2( 0.0f,    offset), // top-center
-                    vec2( offset,  offset), // top-right
-                    vec2(-offset,  0.0f),   // center-left
-                    vec2( 0.0f,    0.0f),   // center-center
-                    vec2( offset,  0.0f),   // center-right
-                    vec2(-offset, -offset), // bottom-left
-                    vec2( 0.0f,   -offset), // bottom-center
-                    vec2( offset, -offset)  // bottom-right    
-                );
+                if ((uBools & 1u) == 1u)
+                {
+                    vec2 offsets[9] = vec2[](
+                        vec2(-offset,  offset), // top-left
+                        vec2( 0.0f,    offset), // top-center
+                        vec2( offset,  offset), // top-right
+                        vec2(-offset,  0.0f),   // center-left
+                        vec2( 0.0f,    0.0f),   // center-center
+                        vec2( offset,  0.0f),   // center-right
+                        vec2(-offset, -offset), // bottom-left
+                        vec2( 0.0f,   -offset), // bottom-center
+                        vec2( offset, -offset)  // bottom-right    
+                    );
 
-                float kernel[9] = float[](
-                    2, 2, 2,
-                    2, -22, 2,
-                    2, 2, 2
-                );
-                uint hasSelection = 0u;
-                vec3 sampleTex[9];
-                for(int i = 0; i < 9; i++)
-                {
-                    uint t = texture(FgTexture, TexCoords.st + offsets[i]).r;
-                    sampleTex[i] = vec3(t);
-                    hasSelection += (((t & 4u) == 4u && (t != 255u)) ? 1u : 0u);
-                }
-                if (hasSelection > 1u)
-                {
-                    vec3 col = vec3(0.0);
+                    float kernel[9] = float[](
+                        2, 2, 2,
+                        2, -22, 2,
+                        2, 2, 2
+                    );
+                    float hasSelection = 0;
+                    vec3 sampleTex[9];
                     for(int i = 0; i < 9; i++)
-                        col += sampleTex[i] * kernel[i];
-                    
-                    FragColor.rgb += clamp(col, vec3(0), vec3(1));
+                    {
+                        sampleTex[i] = vec3(texture(FgTexture, TexCoords.st + offsets[i]).r);
+                        hasSelection += (texture(FgTexture, TexCoords.st + offsets[i]).r > 0.3 ? 1 : 0);
+                    }
+                    if (hasSelection > 0.5)
+                    {
+                        vec3 col = vec3(0.0);
+                        for(int i = 0; i < 9; i++)
+                            col += sampleTex[i] * kernel[i];
+                        
+                        FragColor.rgb += clamp(col, vec3(0), vec3(1));
+                    }
                 }
             }
             """
@@ -130,6 +135,7 @@ internal static class Canvas
             CreateTextureSamplerA(gl);
             samplerBindings.Add(new ("STexture", 0, 0));
             samplerBindings.Add(new ("STexture2", 0, 0));
+            samplerBindings.Add(new ("STexture3", 0, 0));
         }
         public static RenderableModel GenerateCanvas(GL gl)
         {
@@ -152,7 +158,7 @@ internal static class Canvas
         }
 
 
-        public static void Render(GL gl, SceneGL.GLWrappers.Framebuffer basis)
+        public static void Render(GL gl, bool enableOutline, SceneGL.GLWrappers.Framebuffer basis)
         {
             if (HasToReset) 
             {
@@ -165,6 +171,9 @@ internal static class Canvas
             using (scope)
             {
                 gl.Disable(EnableCap.CullFace);
+                if (Program.TryGetUniformLoc("uBools", out int location))
+                    gl.Uniform1(location, enableOutline ? 1u : 0u);
+                
                 s_model!.Draw(gl);
                 gl.Enable(EnableCap.CullFace);
             }

--- a/Autumn/Rendering/MultitextureCanvas.cs
+++ b/Autumn/Rendering/MultitextureCanvas.cs
@@ -1,4 +1,6 @@
 using System.Numerics;
+using Autumn.GUI.Windows;
+using Autumn.Storage;
 using SceneGL;
 using SceneGL.GLHelpers;
 using SceneGL.GLWrappers;
@@ -42,19 +44,48 @@ internal static class Canvas
 
             uniform sampler2D FgTexture;
             uniform sampler2D BgTexture;
+            uniform sampler2DShadow Depth;
+
+            uniform vec3 uFogColor;
+            uniform vec3 uNearFarDensity;
+
 
             uniform uint uBools;
             // first bit -> outline enabled
+            // second-third bit -> fog type
+            //  0 -> disabled, 1 -> linear, 2 -> exponential, 3 -> exp_sqr
 
             out vec4 FragColor;
 
             const float offset = 1.0 / 350.0; 
+
+            float ToLinear(float depth)
+            {
+                float z = depth * 10 - 9.5; // Back to NDC 
+                z = clamp(z, -1, 10);
+                return (2.0 * uNearFarDensity.x * uNearFarDensity.y) / (uNearFarDensity.y + uNearFarDensity.x - z * (uNearFarDensity.y - uNearFarDensity.x));
+            }
+
+            // float ToExp(float depth)
+            // {
+            //     float z = depth * 10.0 - 10.0; // Back to NDC 
+            //     return exp(-uNearFarDensity.z*z);
+            // }
+
+            float ToExp(float depth)
+            {
+                float z = depth * 10 - 1;
+                return exp(-(z/ uNearFarDensity.z));
+            }
+            float ToExpSqr(float depth)
+            {
+                float z = depth * 10 - 1;
+                return exp(-(pow(z, 2)/ uNearFarDensity.z));
+            }
+
             void main()
             {
                 FragColor = texture(BgTexture, TexCoords);
-                vec4 tx2 = texture(FgTexture, TexCoords);
-                if (tx2.g * 2 < tx2.b)
-                    FragColor *= 0.6;
                 if ((uBools & 1u) == 1u)
                 {
                     vec2 offsets[9] = vec2[](
@@ -90,6 +121,28 @@ internal static class Canvas
                         FragColor.rgb += clamp(col, vec3(0), vec3(1));
                     }
                 }
+                // Linear fog
+                if (((uBools >> 1u) & 3u) == 1u)
+                {
+                    FragColor.rgb = mix(FragColor.rgb, uFogColor, clamp(1 - log(texture(Depth, vec3(TexCoords.x, TexCoords.y, 0.01))) * log(1/ uNearFarDensity.y) * log(uNearFarDensity.x), 0, 1));
+                    // FragColor.rgb += uFogColor * vec3(ToLinear(texture(Depth, vec3(TexCoords.x, TexCoords.y, 0.01))));
+                }
+                // Exponential fog
+                else if (((uBools >> 1u) & 3u) == 2u)
+                {
+                   FragColor.rgb = mix(FragColor.rgb, uFogColor, clamp(ToExp(log(texture(Depth, vec3(TexCoords.x, TexCoords.y, 0.01))) * log(1/ 1000000f)), 0.0, 1.0)); 
+                }
+                // Exponential Squared fog
+                else if (((uBools >> 1u) & 3u) == 3u)
+                {
+                   FragColor.rgb = mix(FragColor.rgb, uFogColor, clamp(ToExpSqr(log(texture(Depth, vec3(TexCoords.x, TexCoords.y, 0.01))) * log(1/ 1/ 1000000f)), 0.0, 1.0)); 
+                }
+
+                vec4 tx2 = texture(FgTexture, TexCoords);
+                if (tx2.g * 2 < tx2.b)
+                    FragColor *= 0.6;
+                // FragColor.rgb = vec3(ToExpSqr(log(texture(Depth, vec3(TexCoords.x, TexCoords.y, 0.01))) * log(1 / 1000000f)));
+                // FragColor.rgb = vec3(1 - log(texture(Depth, vec3(TexCoords.x, TexCoords.y, 0.01))) * log(1/ uNearFarDensity.x / 1000));
             }
             """
 		);
@@ -150,19 +203,20 @@ internal static class Canvas
             return builder.GetModel(gl);
         }
         public static bool HasToReset = true;
-        public static void Reset(uint tx1, uint tx2)
+        public static void Reset(uint tx1, uint tx2, uint tx3)
         {
             samplerBindings[0] = new ("BgTexture", _smpl, tx1);
             samplerBindings[1] = new ("FgTexture", _smpl, tx2);
+            samplerBindings[2] = new ("Depth", _smpl, tx3);
             HasToReset = false;
         }
 
 
-        public static void Render(GL gl, bool enableOutline, SceneGL.GLWrappers.Framebuffer basis)
+        public static void Render(GL gl, MainWindowContext window)
         {
             if (HasToReset) 
             {
-                Reset(basis.GetColorTexture(0), basis.GetColorTexture(2));
+                Reset(window.SceneFramebuffer.GetColorTexture(0), window.SceneFramebuffer.GetColorTexture(2), window.SceneFramebuffer.DepthStencilTexture);
                 _samplers = ShaderParams.FromSamplers(samplerBindings.ToArray());
             }
             if (!Canvas.TryUse(gl, out ProgramUniformScope scope))
@@ -171,9 +225,21 @@ internal static class Canvas
             using (scope)
             {
                 gl.Disable(EnableCap.CullFace);
-                if (Program.TryGetUniformLoc("uBools", out int location))
-                    gl.Uniform1(location, enableOutline ? 1u : 0u);
+
+                uint uBools = window.ContextHandler.SystemSettings.EXPERIMENTAL_SelectionOutline ? 1u : 0u;
+                uBools += (uint)window.GetFogType() << 1;
                 
+                if (Program.TryGetUniformLoc("uBools", out int location))
+                    gl.Uniform1(location, uBools);
+
+                var fog = window.GetSelectedFog();
+                if (fog != null)
+                {    
+                    if (Program.TryGetUniformLoc("uFogColor", out location))
+                        gl.Uniform3(location, fog!.Color);
+                    if (Program.TryGetUniformLoc("uNearFarDensity", out location))
+                        gl.Uniform3(location, new Vector3(fog.MinDepth, fog.MaxDepth, fog.Density));
+                }
                 s_model!.Draw(gl);
                 gl.Enable(EnableCap.CullFace);
             }

--- a/Autumn/Rendering/MultitextureCanvas.cs
+++ b/Autumn/Rendering/MultitextureCanvas.cs
@@ -1,0 +1,173 @@
+using System.Numerics;
+using SceneGL;
+using SceneGL.GLHelpers;
+using SceneGL.GLWrappers;
+using SceneGL.Materials;
+using SceneGL.Materials.Common;
+using Silk.NET.OpenGL;
+
+namespace Autumn.Rendering;
+
+/// <summary>
+/// Canvas to render onto from other passes, mainly color and extras
+/// </summary>
+internal static class Canvas
+{
+	public static ShaderSource s_vertexShader =>
+		new(
+			"Canvas.vert",
+			ShaderType.VertexShader,
+            """
+            #version 330 core
+            layout (location = 0) in vec2 aPos;
+            layout (location = 1) in vec2 aTexCoords;
+
+            out vec2 TexCoords;
+
+            void main()
+            {
+                gl_Position = vec4(aPos.x, aPos.y, 0.0, 1.0);
+                TexCoords = aTexCoords;
+            }  
+            """
+		);
+	public static ShaderSource s_fragmentShader =>
+		new(
+			"Canvas.frag",
+			ShaderType.FragmentShader,
+            """
+            #version 330 core
+
+            in vec2 TexCoords;
+
+            uniform sampler2D FgTexture;
+            uniform sampler2D BgTexture;
+
+            out vec4 FragColor;
+
+            const float offset = 1.0 / 350.0; 
+            void main()
+            { 
+                FragColor = texture(BgTexture, TexCoords);
+                vec4 tx = texture(FgTexture, TexCoords);
+                if (tx.g > 0.1 && tx.r < 0.1)
+                    FragColor *= tx.g * 0.6;
+                vec2 offsets[9] = vec2[](
+                    vec2(-offset,  offset), // top-left
+                    vec2( 0.0f,    offset), // top-center
+                    vec2( offset,  offset), // top-right
+                    vec2(-offset,  0.0f),   // center-left
+                    vec2( 0.0f,    0.0f),   // center-center
+                    vec2( offset,  0.0f),   // center-right
+                    vec2(-offset, -offset), // bottom-left
+                    vec2( 0.0f,   -offset), // bottom-center
+                    vec2( offset, -offset)  // bottom-right    
+                );
+
+                float kernel[9] = float[](
+                    2, 2, 2,
+                    2, -22, 2,
+                    2, 2, 2
+                );
+                float hasSelection = 0;
+                vec3 sampleTex[9];
+                for(int i = 0; i < 9; i++)
+                {
+                    sampleTex[i] = vec3(texture(FgTexture, TexCoords.st + offsets[i]).b);
+                    hasSelection += (texture(FgTexture, TexCoords.st + offsets[i]).b > 0.3 ? 1 : 0);
+                }
+                if (hasSelection > 0.5)
+                {
+                    vec3 col = vec3(0.0);
+                    for(int i = 0; i < 9; i++)
+                        col += sampleTex[i] * kernel[i];
+                    
+                    FragColor.rgb += clamp(col, vec3(0), vec3(1));
+                }
+            }
+            """
+		);
+    public static ShaderProgram Program { get; } = new(s_vertexShader, s_fragmentShader);
+    public static bool TryUse(
+        GL gl,
+        out ProgramUniformScope scope
+    ) => Program.TryUse(gl, null, [_something], out scope, out _);
+
+
+    private static uint _smpl = 0; 
+    public static uint CreateTextureSamplerA(GL gl)
+    {
+        if (_smpl == 0)
+        { 
+        TextureMagFilter magFilter = TextureMagFilter.Nearest;
+
+        TextureMinFilter minFilter = TextureMinFilter.Nearest;
+
+        _smpl = SamplerHelper.CreateSampler2D(gl, TextureWrapMode.ClampToEdge, TextureWrapMode.ClampToEdge, magFilter, minFilter);
+        }
+        return _smpl;
+    }
+    static List<SamplerBinding> samplerBindings = new();        
+    public static ShaderParams _something;
+
+
+    internal static class CanvasRenderer
+    {
+        private struct Vertex
+        {
+            [VertexAttribute(CombinerMaterial.POSITION_LOC, 2, VertexAttribPointerType.Float, false)]
+            public Vector2 Position;
+            [VertexAttribute(CombinerMaterial.COLOR_LOC, 2, VertexAttribPointerType.Float, false)]
+            public Vector2 UV;
+        }
+
+        private static RenderableModel? s_model;
+
+        public static void Initialize(GL gl)
+        {
+            s_model = GenerateCanvas(gl);
+            CreateTextureSamplerA(gl);
+            samplerBindings.Add(new ("STexture", 0, 0));
+            samplerBindings.Add(new ("STexture2", 0, 0));
+        }
+        public static RenderableModel GenerateCanvas(GL gl, float scale = 0.5f)
+        {
+            ModelBuilder<ushort, Vertex> builder = new();
+            builder!.AddPlane(
+                new Vertex { Position = new Vector2(1,   1)  , UV = new Vector2(1, 1) },
+                new Vertex { Position = new Vector2(1,  -1)  , UV = new Vector2(1, 0) },
+                new Vertex { Position = new Vector2(-1,  1)  , UV = new Vector2(0, 1) },
+                new Vertex { Position = new Vector2(-1, -1)  , UV = new Vector2(0, 0) }
+            );
+
+            return builder.GetModel(gl);
+        }
+        public static bool HasToReset = true;
+        public static void Reset(uint tx1, uint tx2, uint tx3)
+        {
+            samplerBindings[0] = new ("BgTexture", _smpl, tx1);
+            samplerBindings[1] = new ("FgTexture", _smpl, tx2);
+            HasToReset = false;
+        }
+
+
+        public static void Render(GL gl, SceneGL.GLWrappers.Framebuffer basis)
+        {
+            if (true) 
+            {
+                Reset(basis.GetColorTexture(0), basis.GetColorTexture(2), basis.GetColorTexture(1));
+                _something = ShaderParams.FromSamplers(samplerBindings.ToArray());
+            }
+            if (!Canvas.TryUse(gl, out ProgramUniformScope scope))
+                return;
+
+            using (scope)
+            {
+                gl.Disable(EnableCap.CullFace);
+                s_model!.Draw(gl);
+                gl.Enable(EnableCap.CullFace);
+            }
+        }
+
+    }
+}

--- a/Autumn/Rendering/MultitextureCanvas.cs
+++ b/Autumn/Rendering/MultitextureCanvas.cs
@@ -238,7 +238,13 @@ internal static class Canvas
                     if (Program.TryGetUniformLoc("uFogColor", out location))
                         gl.Uniform3(location, fog!.Color);
                     if (Program.TryGetUniformLoc("uNearFarDensity", out location))
-                        gl.Uniform3(location, new Vector3(fog.MinDepth, fog.MaxDepth, fog.Density));
+                    {
+                        if (fog.MinDepth < fog.MaxDepth)
+                            gl.Uniform3(location, new Vector3(fog.MinDepth, fog.MaxDepth, fog.Density));
+                        else
+                            gl.Uniform3(location, new Vector3(0, 0, fog.Density));
+
+                    }
                 }
                 s_model!.Draw(gl);
                 gl.Enable(EnableCap.CullFace);

--- a/Autumn/Rendering/Rail/RailMaterial.cs
+++ b/Autumn/Rendering/Rail/RailMaterial.cs
@@ -93,9 +93,11 @@ internal static class RailMaterial
 
             out vec4 oColor;
             out uint oPickingId;
+            out uint oPostProc;
 
             void main() {
                 oPickingId = uPickingId;
+                oPostProc = 0u + (uHighlightColor.a > 0.1 ? 1u : 0u) << 2u;
 
                 oColor = uColor;
                 oColor.rgb = mix(oColor.rgb, uHighlightColor.rgb, uHighlightColor.a);

--- a/Autumn/Rendering/Rail/RailMaterial.cs
+++ b/Autumn/Rendering/Rail/RailMaterial.cs
@@ -93,11 +93,11 @@ internal static class RailMaterial
 
             out vec4 oColor;
             out uint oPickingId;
-            out uint oPostProc;
+            out vec4 oPostProc;
 
             void main() {
                 oPickingId = uPickingId;
-                oPostProc = 0u + (uHighlightColor.a > 0.1 ? 1u : 0u) << 2u;
+                oPostProc = vec4((uHighlightColor.a > 0.1 ? 1 : 0), 0, 0, 0);
 
                 oColor = uColor;
                 oColor.rgb = mix(oColor.rgb, uHighlightColor.rgb, uHighlightColor.a);

--- a/Autumn/Rendering/Rail/RailPointMaterial.cs
+++ b/Autumn/Rendering/Rail/RailPointMaterial.cs
@@ -53,11 +53,11 @@ internal static class RailPointMaterial
 
             out vec4 oColor;
             out uint oPickingId;
-            out uint oPostProc;
+            out vec4 oPostProc;
 
             void main() {
                 oPickingId = uPickingId;
-                oPostProc = 0u + (uHighlightColor.a > 0.1 ? 1u : 0u) << 2u;
+                oPostProc = vec4((uHighlightColor.a > 0.1 ? 1 : 0), 0, 0, 0);
                 
                 vec3 absolute = abs(vPos);
 

--- a/Autumn/Rendering/Rail/RailPointMaterial.cs
+++ b/Autumn/Rendering/Rail/RailPointMaterial.cs
@@ -53,9 +53,11 @@ internal static class RailPointMaterial
 
             out vec4 oColor;
             out uint oPickingId;
+            out uint oPostProc;
 
             void main() {
                 oPickingId = uPickingId;
+                oPostProc = 0u + (uHighlightColor.a > 0.1 ? 1u : 0u) << 2u;
                 
                 vec3 absolute = abs(vPos);
 

--- a/Autumn/Rendering/Rail/RailRenderer.cs
+++ b/Autumn/Rendering/Rail/RailRenderer.cs
@@ -230,11 +230,6 @@ internal static class RailRenderer
         Matrix4x4 transform
     )
     {
-        RenderableModel model = s_pointModel!;
-
-        if (isHandle)
-            model = s_pointHandleModel!;
-
         scene.Transform = transform;
         material.Selected = selected;
 
@@ -249,7 +244,10 @@ internal static class RailRenderer
             if (RailPointMaterial.Program.TryGetUniformLoc("uIsHandle", out int location2))
                 gl.Uniform1(location2, (float)(isHandle ? 1 : 0));
 
-            model.Draw(gl);
+            if (isHandle)
+                s_pointHandleModel!.Draw(gl);
+            else
+                s_pointModel!.Draw(gl);
         }
     }
 }

--- a/Autumn/Rendering/RelationLine/RelationLineMaterial.cs
+++ b/Autumn/Rendering/RelationLine/RelationLineMaterial.cs
@@ -100,9 +100,11 @@ internal static class RelationLineMaterial
 
             out vec4 oColor;
             out uint oPickingId;
+            out uint oPostProc;
 
             void main() {
                 oPickingId = uPickingId;
+                oPostProc = 0u;
 
                 oColor = uColor;
                 oColor.rgb = mix(oColor.rgb, uHighlightColor.rgb, uHighlightColor.a);

--- a/Autumn/Rendering/RelationLine/RelationLineMaterial.cs
+++ b/Autumn/Rendering/RelationLine/RelationLineMaterial.cs
@@ -100,11 +100,11 @@ internal static class RelationLineMaterial
 
             out vec4 oColor;
             out uint oPickingId;
-            out uint oPostProc;
+            out vec4 oPostProc;
 
             void main() {
                 oPickingId = uPickingId;
-                oPostProc = 0u;
+                oPostProc = vec4(0);
 
                 oColor = uColor;
                 oColor.rgb = mix(oColor.rgb, uHighlightColor.rgb, uHighlightColor.a);

--- a/Autumn/Rendering/Scene.cs
+++ b/Autumn/Rendering/Scene.cs
@@ -80,8 +80,11 @@ internal class Scene
 
         if (ModelRenderer.UseFullAlphaPipeline)
         {
+            List<ActorSceneObj> Shadows = new();
             foreach (ISceneObj o in Opaque)
             {
+                if (o is ActorSceneObj obj && obj.StageObj.Name == "ShadowObj") { Shadows.Add(obj); continue; }
+
                 ModelRenderer.DrawLayer(window.GL!, o, this, H3DMeshLayer.Opaque);
             }
 
@@ -101,6 +104,11 @@ internal class Scene
             {
                 ModelRenderer.DrawLayer(window.GL!, o, this, H3DMeshLayer.Additive);
             }
+            foreach (ActorSceneObj sh in Shadows)
+            {
+                ModelRenderer.DrawLayer(window.GL!, sh, this, H3DMeshLayer.Opaque);
+            }
+
             foreach (ISceneObj o in EnumerateSceneObjs())
             {
                 if (o is not ActorSceneObj) continue;

--- a/Autumn/Rendering/Scene.cs
+++ b/Autumn/Rendering/Scene.cs
@@ -116,6 +116,12 @@ internal class Scene
             {
                 ModelRenderer.DrawLayer(gl, o, this, H3DMeshLayer.Additive);
             }
+            foreach (ISceneObj o in EnumerateSceneObjs())
+            {
+                if (o is not ActorSceneObj) continue;
+                if ((o as ActorSceneObj)!.StageObj.Parent != null) 
+                    ModelRenderer.DrawRelLines(gl, (o as ActorSceneObj)!);
+            }
         }
         else
         {

--- a/Autumn/Rendering/Scene.cs
+++ b/Autumn/Rendering/Scene.cs
@@ -63,6 +63,7 @@ internal class Scene
     public List<ActorSceneObj> Translucent = new();
     public List<ActorSceneObj> Subtractive = new();
     public List<ActorSceneObj> Additive = new();
+    public List<ActorSceneObj> Shadows = new();
 
     public Scene(Stage stage, LayeredFSHandler fsHandler, GLTaskScheduler scheduler, ref string status)
     {
@@ -80,13 +81,15 @@ internal class Scene
 
         if (ModelRenderer.UseFullAlphaPipeline)
         {
-            List<ActorSceneObj> Shadows = new();
             foreach (ISceneObj o in Opaque)
             {
-                if (o is ActorSceneObj obj && obj.StageObj.Name == "ShadowObj") { Shadows.Add(obj); continue; }
-
                 ModelRenderer.DrawLayer(window.GL!, o, this, H3DMeshLayer.Opaque);
             }
+            if (!window.ContextHandler.SystemSettings.EXPERIMENTAL_PostProcess)
+                foreach (ActorSceneObj sh in Shadows)
+                {
+                    ModelRenderer.DrawLayer(window.GL!, sh, this, H3DMeshLayer.Opaque);
+                }
 
             // Preemptively sort by distance
             var ey = cameraEye * 100;
@@ -104,16 +107,38 @@ internal class Scene
             {
                 ModelRenderer.DrawLayer(window.GL!, o, this, H3DMeshLayer.Additive);
             }
+            if (window.ContextHandler.SystemSettings.EXPERIMENTAL_PostProcess)
             foreach (ActorSceneObj sh in Shadows)
             {
-                ModelRenderer.DrawLayer(window.GL!, sh, this, H3DMeshLayer.Opaque);
+                ModelRenderer.DrawShadow(window.GL!, sh.Actor, sh.Transform, sh.Selected, sh.PickingId, true);
             }
 
+            List<ActorSceneObj> shsss = new();
             foreach (ISceneObj o in EnumerateSceneObjs())
             {
-                if (o is not ActorSceneObj) continue;
+                if (o is not ActorSceneObj || !o.IsVisible) continue;
                 if ((o as ActorSceneObj)!.StageObj.Parent != null) 
                     ModelRenderer.DrawRelLines(window.GL!, (o as ActorSceneObj)!);
+                if (window.ContextHandler.SystemSettings.EXPERIMENTAL_ActorShadows && window.ContextHandler.SystemSettings.EXPERIMENTAL_PostProcess)
+                    if ((o as ActorSceneObj)!.Shadows.Count > 0)
+                    {
+                        shsss.Add((o as ActorSceneObj)!);
+                    }
+            }
+            if (window.ContextHandler.SystemSettings.EXPERIMENTAL_ActorShadows && window.ContextHandler.SystemSettings.EXPERIMENTAL_PostProcess)
+            {
+                shsss = shsss.OrderBy(x => Vector3.Distance(x.StageObj.Translation, ey)).ToList();
+                shsss.Reverse();
+                foreach (ActorSceneObj o in shsss)
+                {
+                    for (int s = 0; s < o.Shadows.Count; s++)
+                    {
+                        ModelRenderer.DrawShadow(window.GL!, 
+                        o.Shadows[s], 
+                        o.GetTransform(o.Actor.InitShadow[s].Size, o.Actor.InitShadow[s].RotateOffset, o.Actor.InitShadow[s].Offset), 
+                        o.Selected, o.PickingId);
+                    }
+                }
             }
         }
         else
@@ -693,10 +718,19 @@ internal class Scene
                 }
             }
         }
+        if (stageObj.Name == "ShadowObj")
+        {
+            actor.IsShadowModel = true;
+        }
+        foreach (ActorShadow shadow in actor.InitShadow)
+        {
+            actorSceneObj.Shadows.Add( fsHandler.ReadActor( shadow.GetShadowVolumeString(), scheduler));
+        }
 
         scheduler.EnqueueGLTask( gl => 
             {
                 if (actor.IsEmptyModel) Opaque.Add(actorSceneObj);
+                else if (actor.IsShadowModel) Shadows.Add(actorSceneObj);
                 else
                 {
                     if (actor.CountMeshesLayer(H3DMeshLayer.Opaque) > 0) Opaque.Add(actorSceneObj);
@@ -859,6 +893,7 @@ internal class Scene
         if (Opaque.Contains(sceneObj)) Opaque.Remove(sceneObj);
         if (sceneObj is ActorSceneObj)
         {
+            if (Shadows.Contains(sceneObj)) Shadows.Remove((sceneObj as ActorSceneObj)!);
             if (Translucent.Contains(sceneObj)) Translucent.Remove((sceneObj as ActorSceneObj)!);
             if (Additive.Contains(sceneObj)) Additive.Remove((sceneObj as ActorSceneObj)!);
             if (Subtractive.Contains(sceneObj)) Subtractive.Remove((sceneObj as ActorSceneObj)!);

--- a/Autumn/Rendering/Scene.cs
+++ b/Autumn/Rendering/Scene.cs
@@ -646,17 +646,9 @@ internal class Scene
 
         if (actorClass != null && ClassModifiersWrapper.ModifierEntries.ContainsKey(actorClass)) 
         {
-            fsHandler.ReadActorExtras(actorName, actorClass, actor, scheduler);
+            fsHandler.ReadActorExtras(actorName, actorClass, actorSceneObj, scheduler);
         
-            ClassModifiersWrapper.ModifierEntry? act = null;
-            if (ClassModifiersWrapper.ModifierEntries[actorClass].Variants != null && ClassModifiersWrapper.ModifierEntries[actorClass].Variants.ContainsKey(actorName))
-            {
-                act = ClassModifiersWrapper.ModifierEntries[actorClass].Variants![actorName]!.Value;
-            }
-            else if (ClassModifiersWrapper.ModifierEntries[actorClass].Default != null)
-            {
-                act = ClassModifiersWrapper.ModifierEntries[actorClass].Default!.Value;
-            }
+            ClassModifiersWrapper.ModifierEntry? act = ClassModifiersWrapper.GetEntry(actorName, actorClass);
             if (act is not null)
             {
                 if (act.Value.Translation != null) 
@@ -667,18 +659,19 @@ internal class Scene
                     actorSceneObj.DeltaRotation = act.Value.Rotation.Value;
                 if (act.Value.ExtraModels != null)
                 {
-                    foreach(string m in act.Value.ExtraModels.Keys)
+                    foreach(Actor ac in actorSceneObj.SubActors)
                     {
-                        actorSceneObj.ChildModelTransforms.Add(m, new());
-                        if (act.Value.ExtraModels[m] != null)
+                        actorSceneObj.SubActorTransforms.Add(new());
+                        if (act.Value.ExtraModels[ac.Name] != null)
                         {
-                            if (act.Value.ExtraModels[m]!.Value.Translation != null) 
-                                actorSceneObj.ChildModelTransforms[m].Translate = act.Value.ExtraModels[m]!.Value.Translation!.Value;
-                            if (act.Value.ExtraModels[m]!.Value.Scale != null) 
-                                actorSceneObj.ChildModelTransforms[m].Scale = act.Value.ExtraModels[m]!.Value.Scale!.Value;
-                            if (act.Value.ExtraModels[m]!.Value.Rotation != null) 
-                                actorSceneObj.ChildModelTransforms[m].Rotate = act.Value.ExtraModels[m]!.Value.Rotation!.Value;
+                            if (act.Value.ExtraModels[ac.Name]!.Value.Translation != null) 
+                                actorSceneObj.SubActorTransforms[actorSceneObj.BaseSubActorCount].Translate = act.Value.ExtraModels[ac.Name]!.Value.Translation!.Value;
+                            if (act.Value.ExtraModels[ac.Name]!.Value.Scale != null) 
+                                actorSceneObj.SubActorTransforms[actorSceneObj.BaseSubActorCount].Scale = act.Value.ExtraModels[ac.Name]!.Value.Scale!.Value;
+                            if (act.Value.ExtraModels[ac.Name]!.Value.Rotation != null) 
+                                actorSceneObj.SubActorTransforms[actorSceneObj.BaseSubActorCount].Rotate = act.Value.ExtraModels[ac.Name]!.Value.Rotation!.Value;
                         }
+                        actorSceneObj.BaseSubActorCount += 1;
                     }
                 }
             }

--- a/Autumn/Rendering/Scene.cs
+++ b/Autumn/Rendering/Scene.cs
@@ -674,6 +674,15 @@ internal class Scene
                         actorSceneObj.BaseSubActorCount += 1;
                     }
                 }
+
+                if (act.Value.Args != null)
+                foreach (string arg in act.Value.Args.Keys)
+                {
+                    if (stageObj.Properties.ContainsKey(arg))
+                    {
+                        actorSceneObj.UpdateActorFromArg(fsHandler, (ClassModifiersWrapper.ModifierEntry)act, arg, scheduler);
+                    }
+                }
             }
         }
 

--- a/Autumn/Rendering/Scene.cs
+++ b/Autumn/Rendering/Scene.cs
@@ -104,7 +104,7 @@ internal class Scene
             var ey = cameraEye * 100;
             l2 = Translucent.OrderBy(x => Vector3.Distance(x.StageObj.Translation, ey)).ToList();
             l2.Reverse();
-            foreach (ISceneObj o in l2)
+            foreach (ISceneObj o in Translucent)
             {
                 ModelRenderer.DrawLayer(gl, o, this, H3DMeshLayer.Translucent);
             }

--- a/Autumn/Rendering/Scene.cs
+++ b/Autumn/Rendering/Scene.cs
@@ -57,11 +57,10 @@ internal class Scene
     private Dictionary<StageFog, List<ISceneObj>> _stageFogList = new();
     private Dictionary<StageFog, int> _stageFogCount = new();
 
-
-    List<ISceneObj> Opaque = new();
-    List<ActorSceneObj> Translucent = new();
-    List<ActorSceneObj> Subtractive = new();
-    List<ActorSceneObj> Additive = new();
+    public List<ISceneObj> Opaque = new();
+    public List<ActorSceneObj> Translucent = new();
+    public List<ActorSceneObj> Subtractive = new();
+    public List<ActorSceneObj> Additive = new();
 
     public Scene(Stage stage, LayeredFSHandler fsHandler, GLTaskScheduler scheduler, ref string status)
     {
@@ -652,19 +651,51 @@ internal class Scene
         )
             actorName = modelNameString;
 
-        fsHandler.ReadCreatorClassNameTable().TryGetValue(actorName, out string? fallback);
+        fsHandler.ReadCreatorClassNameTable().TryGetValue(actorName, out string? actorClass);
 
         Actor actor;
-        if (fallback != null && ClassDatabaseWrapper.DatabaseEntries.ContainsKey(fallback) && ClassDatabaseWrapper.DatabaseEntries[fallback].ArchiveName != null)
-        {
-            actor = fsHandler.ReadActor(actorName, ClassDatabaseWrapper.DatabaseEntries[fallback].ArchiveName, fallback, scheduler);
-        }
-        else if (ClassDatabaseWrapper.DatabaseEntries.ContainsKey(actorName) && ClassDatabaseWrapper.DatabaseEntries[actorName].ArchiveName != null)
-            actor = fsHandler.ReadActor(actorName, ClassDatabaseWrapper.DatabaseEntries[actorName].ArchiveName, scheduler);
-        else
-            actor = fsHandler.ReadActor(actorName, fallback, scheduler);
-
+        actor = fsHandler.ReadActorNew(actorName, actorClass, scheduler);
+        // if (actorClass != null && ClassModifiersWrapper.ModifierEntries.ContainsKey(actorClass) && ClassModifiersWrapper.ModifierEntries[actorClass].Variants.ContainsKey(actorName) && ClassModifiersWrapper.ModifierEntries[actorClass].Variants[actorName]!.Value.ModelReplace != null)
+        // {
+        //     actor = fsHandler.ReadActor(ClassModifiersWrapper.ModifierEntries[actorClass].Variants[actorName]!.Value.ModelReplace!, ClassDatabaseWrapper.DatabaseEntries[actorClass].ArchiveName, actorClass, scheduler);
+        // }
+        // else if (actorClass != null && ClassDatabaseWrapper.DatabaseEntries.ContainsKey(actorClass) && ClassDatabaseWrapper.DatabaseEntries[actorClass].ArchiveName != null)
+        // {
+        //     actor = fsHandler.ReadActor(actorName, ClassDatabaseWrapper.DatabaseEntries[actorClass].ArchiveName, actorClass, scheduler);
+        // }
+        // else if (ClassDatabaseWrapper.DatabaseEntries.ContainsKey(actorName) && ClassDatabaseWrapper.DatabaseEntries[actorName].ArchiveName != null)
+        //     actor = fsHandler.ReadActor(actorName, ClassDatabaseWrapper.DatabaseEntries[actorName].ArchiveName, scheduler);
+        // else
+        //     actor = fsHandler.ReadActor(actorName, actorClass, scheduler);
+        
         ActorSceneObj actorSceneObj = new(stageObj, actor, _lastPickingId);
+
+
+
+        if (actorClass != null && ClassModifiersWrapper.ModifierEntries.ContainsKey(actorClass)) 
+        {
+            fsHandler.ReadActorExtras(actorName, actorClass, actor, scheduler);
+        
+            ClassModifiersWrapper.ModifierEntry? act = null;
+            if (ClassModifiersWrapper.ModifierEntries[actorClass].Variants != null && ClassModifiersWrapper.ModifierEntries[actorClass].Variants.ContainsKey(actorName))
+            {
+                act = ClassModifiersWrapper.ModifierEntries[actorClass].Variants![actorName]!.Value;
+            }
+            else if (ClassModifiersWrapper.ModifierEntries[actorClass].Default != null)
+            {
+                act = ClassModifiersWrapper.ModifierEntries[actorClass].Default!.Value;
+            }
+            if (act is not null)
+            {
+                if (act.Value.Translation != null) 
+                    actorSceneObj.DeltaTranslation = act.Value.Translation.Value;
+                if (act.Value.Scale != null) 
+                    actorSceneObj.DeltaScale = act.Value.Scale.Value;
+                if (act.Value.Rotation != null) 
+                    actorSceneObj.DeltaRotation = act.Value.Rotation.Value;
+            }
+        }
+
         scheduler.EnqueueGLTask( gl => 
             {
                 if (actor.IsEmptyModel) Opaque.Add(actorSceneObj);

--- a/Autumn/Rendering/Scene.cs
+++ b/Autumn/Rendering/Scene.cs
@@ -2,8 +2,10 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using Autumn.Background;
+using Autumn.Context;
 using Autumn.Enums;
 using Autumn.FileSystems;
+using Autumn.GUI.Windows;
 using Autumn.History;
 using Autumn.Rendering.Area;
 using Autumn.Rendering.Rail;
@@ -70,15 +72,17 @@ internal class Scene
         GenerateFog();
     }
 
-    public void Render(GL gl, in Matrix4x4 view, in Matrix4x4 projection, in Quaternion cameraRot, in Vector3 cameraEye)
+    public void Render(MainWindowContext window, in Matrix4x4 view, in Matrix4x4 projection, in Quaternion cameraRot, in Vector3 cameraEye)
     {
         ModelRenderer.UpdateSceneParams(view, projection, cameraRot, cameraEye);
+
+        var CCNT = window.ContextHandler.FSHandler!.ReadCreatorClassNameTable();
 
         if (ModelRenderer.UseFullAlphaPipeline)
         {
             foreach (ISceneObj o in Opaque)
             {
-                ModelRenderer.DrawLayer(gl, o, this, H3DMeshLayer.Opaque);
+                ModelRenderer.DrawLayer(window.GL!, o, this, H3DMeshLayer.Opaque);
             }
 
             // Preemptively sort by distance
@@ -87,27 +91,27 @@ internal class Scene
             l2.Reverse();
             foreach (ISceneObj o in Translucent)
             {
-                ModelRenderer.DrawLayer(gl, o, this, H3DMeshLayer.Translucent);
+                ModelRenderer.DrawLayer(window.GL!, o, this, H3DMeshLayer.Translucent);
             }
             foreach (ISceneObj o in Subtractive)
             {
-                ModelRenderer.DrawLayer(gl, o, this, H3DMeshLayer.Subtractive);
+                ModelRenderer.DrawLayer(window.GL!, o, this, H3DMeshLayer.Subtractive);
             }
             foreach (ISceneObj o in Additive)
             {
-                ModelRenderer.DrawLayer(gl, o, this, H3DMeshLayer.Additive);
+                ModelRenderer.DrawLayer(window.GL!, o, this, H3DMeshLayer.Additive);
             }
             foreach (ISceneObj o in EnumerateSceneObjs())
             {
                 if (o is not ActorSceneObj) continue;
                 if ((o as ActorSceneObj)!.StageObj.Parent != null) 
-                    ModelRenderer.DrawRelLines(gl, (o as ActorSceneObj)!);
+                    ModelRenderer.DrawRelLines(window.GL!, (o as ActorSceneObj)!);
             }
         }
         else
         {
             foreach (ISceneObj obj in EnumerateSceneObjs())
-                ModelRenderer.Draw(gl, obj, this);
+                ModelRenderer.Draw(window.GL!, obj, CCNT, this);
         }
     }
 
@@ -661,6 +665,22 @@ internal class Scene
                     actorSceneObj.DeltaScale = act.Value.Scale.Value;
                 if (act.Value.Rotation != null) 
                     actorSceneObj.DeltaRotation = act.Value.Rotation.Value;
+                if (act.Value.ExtraModels != null)
+                {
+                    foreach(string m in act.Value.ExtraModels.Keys)
+                    {
+                        actorSceneObj.ChildModelTransforms.Add(m, new());
+                        if (act.Value.ExtraModels[m] != null)
+                        {
+                            if (act.Value.ExtraModels[m]!.Value.Translation != null) 
+                                actorSceneObj.ChildModelTransforms[m].Translate = act.Value.ExtraModels[m]!.Value.Translation!.Value;
+                            if (act.Value.ExtraModels[m]!.Value.Scale != null) 
+                                actorSceneObj.ChildModelTransforms[m].Scale = act.Value.ExtraModels[m]!.Value.Scale!.Value;
+                            if (act.Value.ExtraModels[m]!.Value.Rotation != null) 
+                                actorSceneObj.ChildModelTransforms[m].Rotate = act.Value.ExtraModels[m]!.Value.Rotation!.Value;
+                        }
+                    }
+                }
             }
         }
 

--- a/Autumn/Rendering/Scene.cs
+++ b/Autumn/Rendering/Scene.cs
@@ -25,6 +25,7 @@ internal class Scene
 
     private readonly List<ISceneObj> _selectedObjects = new();
     public IEnumerable<ISceneObj> SelectedObjects => _selectedObjects;
+    public int SelectedObjCount => _selectedObjects.Count;
 
     public ISceneObj? HoveringObject { get; private set; }
 
@@ -56,6 +57,12 @@ internal class Scene
     private Dictionary<StageFog, List<ISceneObj>> _stageFogList = new();
     private Dictionary<StageFog, int> _stageFogCount = new();
 
+
+    List<ISceneObj> Opaque = new();
+    List<ActorSceneObj> Translucent = new();
+    List<ActorSceneObj> Subtractive = new();
+    List<ActorSceneObj> Additive = new();
+
     public Scene(Stage stage, LayeredFSHandler fsHandler, GLTaskScheduler scheduler, ref string status)
     {
         Stage = stage;
@@ -68,8 +75,53 @@ internal class Scene
     {
         ModelRenderer.UpdateSceneParams(view, projection, cameraRot, cameraEye);
 
-        foreach (ISceneObj obj in EnumerateSceneObjs())
-            ModelRenderer.Draw(gl, obj, this);
+        if (ModelRenderer.UseFullAlphaPipeline)
+        {
+            // foreach (ISceneObj obj in EnumerateSceneObjs())
+            // {
+            //     // Skip object to opaque pass
+            //     if (obj is BasicSceneObj || obj is RailSceneObj || (obj is ActorSceneObj && (obj as ActorSceneObj)!.Actor.IsEmptyModel))
+            //     {
+            //         Opaque.Add(obj);
+            //     }
+            //     else if (obj is ActorSceneObj actorS)
+            //     {
+            //         Actor actor = actorS.Actor;
+            //         if (actor.CountMeshesLayer(H3DMeshLayer.Opaque) > 0) Opaque.Add(obj);
+            //         if (actor.CountMeshesLayer(H3DMeshLayer.Translucent) > 0) Translucent.Add((obj as ActorSceneObj)!);
+            //         if (actor.CountMeshesLayer(H3DMeshLayer.Subtractive) > 0) { Subtractive.Add((obj as ActorSceneObj)!); Translucent.Add((obj as ActorSceneObj)!); }
+            //         if (actor.CountMeshesLayer(H3DMeshLayer.Additive) > 0) { Additive.Add((obj as ActorSceneObj)!); Translucent.Add((obj as ActorSceneObj)!); }
+            //     }
+            // }
+            foreach (ISceneObj o in Opaque)
+            {
+                ModelRenderer.DrawLayer(gl, o, this, H3DMeshLayer.Opaque);
+            }
+
+            // Preemptively sort by distance
+            List<ActorSceneObj> l2 = new();
+            float dist = 0;
+            var ey = cameraEye * 100;
+            l2 = Translucent.OrderBy(x => Vector3.Distance(x.StageObj.Translation, ey)).ToList();
+            l2.Reverse();
+            foreach (ISceneObj o in l2)
+            {
+                ModelRenderer.DrawLayer(gl, o, this, H3DMeshLayer.Translucent);
+            }
+            foreach (ISceneObj o in Subtractive)
+            {
+                ModelRenderer.DrawLayer(gl, o, this, H3DMeshLayer.Subtractive);
+            }
+            foreach (ISceneObj o in Additive)
+            {
+                ModelRenderer.DrawLayer(gl, o, this, H3DMeshLayer.Additive);
+            }
+        }
+        else
+        {
+            foreach (ISceneObj obj in EnumerateSceneObjs())
+                ModelRenderer.Draw(gl, obj, this);
+        }
     }
 
     #region Object selection
@@ -563,6 +615,7 @@ internal class Scene
             CommonMaterialParameters matParams = new(color, new());
 
             BasicSceneObj areaSceneObj = new(stageObj, matParams, 20f, _lastPickingId);
+            Opaque.Add(areaSceneObj);
             AddSwitchFromStageObj(stageObj, areaSceneObj);
             _stageSceneObjs.Add(areaSceneObj);
             _pickableObjs.Add(_lastPickingId++, areaSceneObj);
@@ -574,6 +627,7 @@ internal class Scene
         {
             RailModel model = new(rail);
             RailSceneObj railSceneObj = new(rail, model, ref _lastPickingId);
+            Opaque.Add(railSceneObj);
 
             scheduler.EnqueueGLTask(model.Initialize);
 
@@ -605,10 +659,24 @@ internal class Scene
             actor = fsHandler.ReadActor(actorName, fallback, scheduler);
 
         ActorSceneObj actorSceneObj = new(stageObj, actor, _lastPickingId);
+        scheduler.EnqueueGLTask( gl => 
+            {
+                if (actor.IsEmptyModel) Opaque.Add(actorSceneObj);
+                else
+                {
+                    if (actor.CountMeshesLayer(H3DMeshLayer.Opaque) > 0) Opaque.Add(actorSceneObj);
+                    if (actor.CountMeshesLayer(H3DMeshLayer.Translucent) > 0) Translucent.Add(actorSceneObj);
+                    if (actor.CountMeshesLayer(H3DMeshLayer.Subtractive) > 0) { Subtractive.Add(actorSceneObj);}    // Translucent.Add(actorSceneObj); }
+                    if (actor.CountMeshesLayer(H3DMeshLayer.Additive) > 0) { Additive.Add(actorSceneObj);}          // Translucent.Add(actorSceneObj); }
+                }
+            }
+        );
+
         AddSwitchFromStageObj(stageObj, actorSceneObj);
 
         _stageSceneObjs.Add(actorSceneObj);
         _pickableObjs.Add(_lastPickingId++, actorSceneObj);
+        actorSceneObj.UpdateTransform();
     }
 
     #region Point Editing
@@ -752,6 +820,14 @@ internal class Scene
                 _railObjs.Remove(y);
                 break;
         }
+
+        if (Opaque.Contains(sceneObj)) Opaque.Remove(sceneObj);
+        if (sceneObj is ActorSceneObj)
+        {
+            if (Translucent.Contains(sceneObj)) Translucent.Remove((sceneObj as ActorSceneObj)!);
+            if (Additive.Contains(sceneObj)) Additive.Remove((sceneObj as ActorSceneObj)!);
+            if (Subtractive.Contains(sceneObj)) Subtractive.Remove((sceneObj as ActorSceneObj)!);
+        }  
 
         _pickableObjs.Remove(sceneObj.PickingId);
     }

--- a/Autumn/Rendering/Scene.cs
+++ b/Autumn/Rendering/Scene.cs
@@ -76,32 +76,14 @@ internal class Scene
 
         if (ModelRenderer.UseFullAlphaPipeline)
         {
-            // foreach (ISceneObj obj in EnumerateSceneObjs())
-            // {
-            //     // Skip object to opaque pass
-            //     if (obj is BasicSceneObj || obj is RailSceneObj || (obj is ActorSceneObj && (obj as ActorSceneObj)!.Actor.IsEmptyModel))
-            //     {
-            //         Opaque.Add(obj);
-            //     }
-            //     else if (obj is ActorSceneObj actorS)
-            //     {
-            //         Actor actor = actorS.Actor;
-            //         if (actor.CountMeshesLayer(H3DMeshLayer.Opaque) > 0) Opaque.Add(obj);
-            //         if (actor.CountMeshesLayer(H3DMeshLayer.Translucent) > 0) Translucent.Add((obj as ActorSceneObj)!);
-            //         if (actor.CountMeshesLayer(H3DMeshLayer.Subtractive) > 0) { Subtractive.Add((obj as ActorSceneObj)!); Translucent.Add((obj as ActorSceneObj)!); }
-            //         if (actor.CountMeshesLayer(H3DMeshLayer.Additive) > 0) { Additive.Add((obj as ActorSceneObj)!); Translucent.Add((obj as ActorSceneObj)!); }
-            //     }
-            // }
             foreach (ISceneObj o in Opaque)
             {
                 ModelRenderer.DrawLayer(gl, o, this, H3DMeshLayer.Opaque);
             }
 
             // Preemptively sort by distance
-            List<ActorSceneObj> l2 = new();
-            float dist = 0;
             var ey = cameraEye * 100;
-            l2 = Translucent.OrderBy(x => Vector3.Distance(x.StageObj.Translation, ey)).ToList();
+            List<ActorSceneObj> l2 = Translucent.OrderBy(x => Vector3.Distance(x.StageObj.Translation, ey)).ToList();
             l2.Reverse();
             foreach (ISceneObj o in Translucent)
             {
@@ -655,22 +637,8 @@ internal class Scene
 
         Actor actor;
         actor = fsHandler.ReadActorNew(actorName, actorClass, scheduler);
-        // if (actorClass != null && ClassModifiersWrapper.ModifierEntries.ContainsKey(actorClass) && ClassModifiersWrapper.ModifierEntries[actorClass].Variants.ContainsKey(actorName) && ClassModifiersWrapper.ModifierEntries[actorClass].Variants[actorName]!.Value.ModelReplace != null)
-        // {
-        //     actor = fsHandler.ReadActor(ClassModifiersWrapper.ModifierEntries[actorClass].Variants[actorName]!.Value.ModelReplace!, ClassDatabaseWrapper.DatabaseEntries[actorClass].ArchiveName, actorClass, scheduler);
-        // }
-        // else if (actorClass != null && ClassDatabaseWrapper.DatabaseEntries.ContainsKey(actorClass) && ClassDatabaseWrapper.DatabaseEntries[actorClass].ArchiveName != null)
-        // {
-        //     actor = fsHandler.ReadActor(actorName, ClassDatabaseWrapper.DatabaseEntries[actorClass].ArchiveName, actorClass, scheduler);
-        // }
-        // else if (ClassDatabaseWrapper.DatabaseEntries.ContainsKey(actorName) && ClassDatabaseWrapper.DatabaseEntries[actorName].ArchiveName != null)
-        //     actor = fsHandler.ReadActor(actorName, ClassDatabaseWrapper.DatabaseEntries[actorName].ArchiveName, scheduler);
-        // else
-        //     actor = fsHandler.ReadActor(actorName, actorClass, scheduler);
-        
+
         ActorSceneObj actorSceneObj = new(stageObj, actor, _lastPickingId);
-
-
 
         if (actorClass != null && ClassModifiersWrapper.ModifierEntries.ContainsKey(actorClass)) 
         {

--- a/Autumn/Rendering/Scene.cs
+++ b/Autumn/Rendering/Scene.cs
@@ -319,6 +319,15 @@ internal class Scene
         }
         Stage.LightAreaNames.Add(_i, "[汎用]デフォルトライト");
     }
+    public string? GetLightArea(int id)
+    {
+        Stage.LightAreaNames.TryGetValue(id, out string? ret);
+        return ret;
+    }
+    public StageFog? GetFog(int id)
+    {
+        return Stage.StageFogs.FirstOrDefault(x => x.AreaId == id);
+    }
     public void AddFog(StageFog fog)
     {
         for (int i = 0; i < 9999; i++)

--- a/Autumn/Rendering/Scene.cs
+++ b/Autumn/Rendering/Scene.cs
@@ -695,7 +695,7 @@ internal class Scene
         fsHandler.ReadCreatorClassNameTable().TryGetValue(actorName, out string? actorClass);
 
         Actor actor;
-        actor = fsHandler.ReadActorNew(actorName, actorClass, scheduler);
+        actor = fsHandler.ReadActor(actorName, actorClass, scheduler);
 
         ActorSceneObj actorSceneObj = new(stageObj, actor, _lastPickingId);
 
@@ -746,7 +746,7 @@ internal class Scene
         }
         foreach (ActorShadow shadow in actor.InitShadow)
         {
-            actorSceneObj.Shadows.Add( fsHandler.ReadActor( shadow.GetShadowVolumeString(), scheduler));
+            actorSceneObj.Shadows.Add( fsHandler.ReadActorBasic( shadow.GetShadowVolumeString(), scheduler));
         }
 
         scheduler.EnqueueGLTask( gl => 

--- a/Autumn/Rendering/Scene.cs
+++ b/Autumn/Rendering/Scene.cs
@@ -194,6 +194,19 @@ internal class Scene
         }
     }
 
+    public void SelectAllObjects()
+    {
+        foreach (ISceneObj sceneObj in _stageSceneObjs)
+        {
+            sceneObj.Selected = true;
+            _selectedObjects.Add(sceneObj);
+        }
+        foreach (ISceneObj sceneObj in _railObjs)
+        {
+            sceneObj.Selected = true;
+            _selectedObjects.Add(sceneObj);
+        }
+    }
     public void SetSelectedObjects(IEnumerable<ISceneObj> objs)
     {
         UnselectAllObjects();

--- a/Autumn/Rendering/Storage/ActorSceneObj.cs
+++ b/Autumn/Rendering/Storage/ActorSceneObj.cs
@@ -15,6 +15,7 @@ internal class ActorSceneObj : IStageSceneObj
     public Actor Actor { get; set; }
     public List<Actor> SubActors = new(); // Flagpole top, Arg additions, etc
     public List<Transform> SubActorTransforms = new(); //Transform
+    public List<Actor> Shadows = new();
     /// <summary>
     /// Number of subactors this actor has by default, without args
     /// </summary>
@@ -48,6 +49,10 @@ internal class ActorSceneObj : IStageSceneObj
         Vector3 scale = Actor.IsEmptyModel ? StageObj.Scale : (StageObj.Scale * DeltaScale) * 0.01f;
         Transform = MathUtils.CreateTransformWithDelta(StageObj.Translation * 0.01f, DeltaTranslation * 0.01f, scale , StageObj.Rotation + DeltaRotation);
     }
+    public Matrix4x4 GetTransform(Vector3 sc, Vector3 rt, Vector3 tl)
+    {
+        return MathUtils.CreateTransformWithDelta((StageObj.Translation) * 0.01f, tl * 0.01f, (StageObj.Scale * sc) * 0.01f , StageObj.Rotation + rt + DeltaRotation);
+    }
 
     public void UpdateActor(LayeredFSHandler fsHandler, Scene scn, GLTaskScheduler scheduler)
     {
@@ -65,6 +70,8 @@ internal class ActorSceneObj : IStageSceneObj
         DeltaRotation = Vector3.Zero;
         SubActors.Clear();
         SubActorTransforms.Clear();
+        Shadows.Clear();
+
 
         fsHandler.ReadCreatorClassNameTable().TryGetValue(actorName, out string? actorClass);
 
@@ -112,6 +119,14 @@ internal class ActorSceneObj : IStageSceneObj
                 }
             }
         }
+        if (StageObj.Name == "ShadowObj")
+        {
+            Actor.IsShadowModel = true;
+        }
+        foreach (ActorShadow shadow in Actor.InitShadow)
+        {
+            Shadows.Add( fsHandler.ReadActor( shadow.GetShadowVolumeString(), scheduler));
+        }
 
         scheduler.EnqueueGLTask( gl => 
             {
@@ -119,7 +134,9 @@ internal class ActorSceneObj : IStageSceneObj
                 scn.Translucent.Remove(this);
                 scn.Subtractive.Remove(this);
                 scn.Additive.Remove(this);
+                scn.Shadows.Remove(this);
                 if (Actor.IsEmptyModel) scn.Opaque.Add(this);
+                else if (Actor.IsShadowModel) scn.Shadows.Add(this);
                 else
                 {
                     if (Actor.CountMeshesLayer(H3DMeshLayer.Opaque) > 0) scn.Opaque.Add(this);
@@ -260,13 +277,14 @@ internal class ActorSceneObj : IStageSceneObj
             case ArgType.ShadowType:
                 Actor? AddedMdl = (int)StageObj.Properties[arg]! switch
                     {
-                        1 => fsHandler.ReadActorExtrasArg("ShadowVolumePyramid", scheduler), // Pyramid
-                        2 => fsHandler.ReadActorExtrasArg("ShadowVolumeSphere", scheduler), //Sphere
-                        3 => fsHandler.ReadActorExtrasArg("ShadowVolumeCylinder", scheduler), // Cylinder
-                        4 => fsHandler.ReadActorExtrasArg("ShadowVolumeCone", scheduler), // Cone
-                        _ => fsHandler.ReadActorExtrasArg("ShadowVolumeCube", scheduler), // Cube
+                        1 => fsHandler.ReadActorExtrasArg(ActorShadow.GetShadowVolumeString(ActorShadow.VolumeType.Pyramid), scheduler), // Pyramid
+                        2 => fsHandler.ReadActorExtrasArg(ActorShadow.GetShadowVolumeString(ActorShadow.VolumeType.Sphere), scheduler), //Sphere
+                        3 => fsHandler.ReadActorExtrasArg(ActorShadow.GetShadowVolumeString(ActorShadow.VolumeType.Cylinder), scheduler), // Cylinder
+                        4 => fsHandler.ReadActorExtrasArg(ActorShadow.GetShadowVolumeString(ActorShadow.VolumeType.Cone), scheduler), // Cone
+                        _ => fsHandler.ReadActorExtrasArg(ActorShadow.GetShadowVolumeString(ActorShadow.VolumeType.Cube), scheduler), // Cube
                     };
                 if (AddedMdl is null) return;
+                Actor.ForceModelNotEmpty(); 
                 Actor = AddedMdl;
                 AABB = Actor.AABB * 0.01f;
                 UpdateTransform();

--- a/Autumn/Rendering/Storage/ActorSceneObj.cs
+++ b/Autumn/Rendering/Storage/ActorSceneObj.cs
@@ -1,4 +1,5 @@
 ﻿using System.Numerics;
+using System.Text.RegularExpressions;
 using Autumn.Background;
 using Autumn.Enums;
 using Autumn.FileSystems;
@@ -303,6 +304,49 @@ internal class ActorSceneObj : IStageSceneObj
                     case "Z":
                         DeltaScale.Z = (int)StageObj.Properties[arg]!;
                     break;
+                }
+                UpdateTransform();
+            break;
+
+            case ArgType.RotateCoreCount:
+            case ArgType.RotateCoreSides:
+                string sideCoreS = entry.Args![arg].ArgType == ArgType.RotateCoreSides ? arg : entry.ArgsRem!.First(x => x.Value is ClassModifiersWrapper.RotateCoreBars).Key;
+                var sideCore = (ClassModifiersWrapper.RotateCoreBars)entry.ArgsRem![sideCoreS];
+                int cnt = 1;
+                int sides = (int)(StageObj.Properties[sideCoreS] ?? 1);
+                if (sideCore.UseArgCount)
+                {
+                    cnt = (int)StageObj.Properties[entry.Args![arg].ArgType == ArgType.RotateCoreCount ? arg : entry.ArgsRem!.First(x => x.Value is ClassModifiersWrapper.RotateCoreCount).Key]!;
+                }
+                else
+                {
+                    // Temporary until we figure how to get the info from the Actor name
+                    cnt = int.Parse(Regex.Match(Actor.Name, @"-?\d+").Value);
+                }
+                cnt = cnt < 1 ? 1 : cnt;                
+                sides = sides < 1 ? 1 : sides;                
+                end = SubActors.Count + BaseSubActorCount;
+                for (int i = end-1; i >= BaseSubActorCount; i--)
+                {
+                    SubActors.RemoveAt(i);
+                    SubActorTransforms.RemoveAt(i);
+                }
+                
+                for (int i = 0; i < sides; i++)
+                {
+                    for (int s = 0; s < cnt; s++)
+                    {
+                        Actor? AddedModl = fsHandler.ReadActorExtrasArg(s < cnt -1 ? sideCore.MiddleModel : sideCore.PointModel, scheduler);
+                        if (AddedModl is null) continue;
+                        SubActors.Add(AddedModl);
+                        SubActorTransforms.Add( new() 
+                        {
+                            Translate = Vector3.Transform(new Vector3 (100 * (s+1), 50, 0), Matrix4x4.CreateRotationY(360 / sides * i *(float)Math.PI/180)),
+                            Rotate = new Vector3(0, 360 / sides * i + 90, 0)
+                        }
+                        );
+                        
+                    }
                 }
                 UpdateTransform();
             break;

--- a/Autumn/Rendering/Storage/ActorSceneObj.cs
+++ b/Autumn/Rendering/Storage/ActorSceneObj.cs
@@ -69,6 +69,7 @@ internal class ActorSceneObj : IStageSceneObj
         fsHandler.ReadCreatorClassNameTable().TryGetValue(actorName, out string? actorClass);
 
         Actor = fsHandler.ReadActorNew(actorName, actorClass, scheduler);
+        AABB = Actor.AABB;
 
         if (actorClass != null && ClassModifiersWrapper.ModifierEntries.ContainsKey(actorClass)) 
         {
@@ -100,10 +101,17 @@ internal class ActorSceneObj : IStageSceneObj
                         BaseSubActorCount += 1;
                     }
                 }
+
+                if (act.Value.Args != null)
+                foreach (string arg in act.Value.Args.Keys)
+                {
+                    if (StageObj.Properties.ContainsKey(arg))
+                    {
+                        UpdateActorFromArg(fsHandler, (ClassModifiersWrapper.ModifierEntry)act, arg, scheduler);
+                    }
+                }
             }
         }
-
-        
 
         scheduler.EnqueueGLTask( gl => 
             {
@@ -228,7 +236,7 @@ internal class ActorSceneObj : IStageSceneObj
                 end = SubActors.Count + BaseSubActorCount;
                 if ((int)StageObj.Properties[arg]! == -1)
                 {
-                    for (int i = BaseSubActorCount; i < end; i++)
+                    for (int i = end-1; i >= BaseSubActorCount; i--)
                     {
                         SubActors.RemoveAt(i);
                         SubActorTransforms.RemoveAt(i);

--- a/Autumn/Rendering/Storage/ActorSceneObj.cs
+++ b/Autumn/Rendering/Storage/ActorSceneObj.cs
@@ -347,6 +347,7 @@ internal class ActorSceneObj : IStageSceneObj
                         
                     }
                 }
+                AABB = Actor.AABB * cnt;
                 UpdateTransform();
             break;
 

--- a/Autumn/Rendering/Storage/ActorSceneObj.cs
+++ b/Autumn/Rendering/Storage/ActorSceneObj.cs
@@ -19,6 +19,9 @@ internal class ActorSceneObj : IStageSceneObj
     public bool Selected { get; set; }
     public bool Hovering { get; set; }
     public bool IsVisible { get; set; } = true;
+    public Vector3 DeltaTranslation;
+    public Vector3 DeltaScale = Vector3.One;
+    public Vector3 DeltaRotation;
 
     public ActorSceneObj(StageObj stageObj, Actor actorObj, uint pickingId)
     {
@@ -33,8 +36,8 @@ internal class ActorSceneObj : IStageSceneObj
 
     public void UpdateTransform()
     {
-        Vector3 scale = Actor.IsEmptyModel ? StageObj.Scale : StageObj.Scale * 0.01f;
-        Transform = MathUtils.CreateTransform(StageObj.Translation * 0.01f, scale, StageObj.Rotation);
+        Vector3 scale = Actor.IsEmptyModel ? StageObj.Scale : (StageObj.Scale * DeltaScale) * 0.01f;
+        Transform = MathUtils.CreateTransform(StageObj.Translation * 0.01f, DeltaTranslation * 0.01f, scale , StageObj.Rotation + DeltaRotation);
     }
 
     public void UpdateActor(LayeredFSHandler fsHandler, GLTaskScheduler scheduler)
@@ -58,6 +61,9 @@ internal class ActorSceneObj : IStageSceneObj
             Actor = fsHandler.ReadActor(actorName, ClassDatabaseWrapper.DatabaseEntries[actorName].ArchiveName, scheduler);
         else
             Actor = fsHandler.ReadActor(actorName, fallback, scheduler);
+        DeltaTranslation = Vector3.Zero;
+        DeltaScale = Vector3.One;
+        DeltaRotation = Vector3.Zero;
 
         UpdateTransform();
     }

--- a/Autumn/Rendering/Storage/ActorSceneObj.cs
+++ b/Autumn/Rendering/Storage/ActorSceneObj.cs
@@ -205,9 +205,8 @@ internal class ActorSceneObj : IStageSceneObj
                 // Update transforms to the current
                 for (int i = BaseSubActorCount; i < chainCount + BaseSubActorCount; i++)
                 {
-                    SubActorTransforms[i].Translate = - new Vector3(0,50,0) - Vector3.UnitY * ((argval - 300) / (chainCount+1)) + Vector3.UnitY * ((argval - 300) / (chainCount+1)) * -i;
+                    SubActorTransforms[i].Translate = new Vector3(0,(argval - 300) / (chainCount + 1) * (-i-1) - 50, 0);
                 }
-
 
                 // only once?
                 Actor? SubActBall = fsHandler.ReadActorExtrasArg(swLn.HeadModel, scheduler);
@@ -248,6 +247,38 @@ internal class ActorSceneObj : IStageSceneObj
                         }
                     }
                 }
+            break;
+
+            case ArgType.ShadowType:
+                Actor? AddedMdl = (int)StageObj.Properties[arg]! switch
+                    {
+                        1 => fsHandler.ReadActorExtrasArg("ShadowVolumePyramid", scheduler), // Pyramid
+                        2 => fsHandler.ReadActorExtrasArg("ShadowVolumeSphere", scheduler), //Sphere
+                        3 => fsHandler.ReadActorExtrasArg("ShadowVolumeCylinder", scheduler), // Cylinder
+                        4 => fsHandler.ReadActorExtrasArg("ShadowVolumeCone", scheduler), // Cone
+                        _ => fsHandler.ReadActorExtrasArg("ShadowVolumeCube", scheduler), // Cube
+                    };
+                if (AddedMdl is null) return;
+                Actor = AddedMdl;
+                AABB = Actor.AABB * 0.01f;
+                UpdateTransform();
+            break;
+
+            case ArgType.ScaleAxis:
+                var scAx = (ClassModifiersWrapper.ScaleAxis)entry.ArgsRem![arg];
+                switch (scAx.Axis)
+                {
+                    case "X":
+                        DeltaScale.X = (int)StageObj.Properties[arg]!;
+                    break;
+                    case "Y":
+                        DeltaScale.Y = (int)StageObj.Properties[arg]!;
+                    break;
+                    case "Z":
+                        DeltaScale.Z = (int)StageObj.Properties[arg]!;
+                    break;
+                }
+                UpdateTransform();
             break;
 
             default:

--- a/Autumn/Rendering/Storage/ActorSceneObj.cs
+++ b/Autumn/Rendering/Storage/ActorSceneObj.cs
@@ -322,7 +322,7 @@ internal class ActorSceneObj : IStageSceneObj
                 {
                     cnt = int.Parse(Regex.Match(Actor.Name, @"-?\d+").Value);
                 }
-                cnt = cnt < 1 ? 1 : cnt;                
+                cnt = cnt < 0 ? 4 : cnt;                
                 sides = sides < 1 ? 1 : sides;                
                 end = SubActors.Count - 1;
                 for (int i = end; i >= BaseSubActorCount; i--)
@@ -344,7 +344,6 @@ internal class ActorSceneObj : IStageSceneObj
                             Rotate = new Vector3(0, 360 / sides * i + 90, 0)
                         }
                         );
-                        
                     }
                 }
                 AABB = Actor.AABB * cnt;

--- a/Autumn/Rendering/Storage/ActorSceneObj.cs
+++ b/Autumn/Rendering/Storage/ActorSceneObj.cs
@@ -127,12 +127,12 @@ internal class ActorSceneObj : IStageSceneObj
     {
         switch (entry.Args![arg].ArgType)
         {
-            case ArgType.Tower:
+            case ArgType.Tower: // Add actors on top or below, if we add below we move the actor upwards
                 string baseModel = entry.Args![arg].RepeatModel ?? Actor.Name;
                 Vector3 offset = entry.Args![arg].Offset ?? Vector3.UnitY * 100;
-                int CountTop = (entry.Args![arg].CountTop != null && entry.Args![arg].CountTop!.Value) ? 1 : 0;
+                bool BottomUp = entry.Args![arg].CountTop != null && entry.Args![arg].CountTop!.Value;
                 int start = SubActors.Count - BaseSubActorCount;
-                int end = int.Clamp((int)StageObj.Properties[arg]!, CountTop, 10) - CountTop; // Default is 3 / -1 is 3, max is 10, min is 0 but let's not
+                int end = int.Clamp((int)StageObj.Properties[arg]!, BottomUp ? 1 : 0, 10) - (BottomUp ? 1 : 0); // Default is 3 / -1 is 3, max is 10, min is 0 but let's not
 
 
                 if (start > end)
@@ -141,7 +141,8 @@ internal class ActorSceneObj : IStageSceneObj
                     {
                         SubActors.RemoveAt(j);
                         SubActorTransforms.RemoveAt(j);
-                        DeltaTranslation = offset * (j);
+                        if (!BottomUp)
+                            DeltaTranslation = offset * (j);
                     }
                 }
                 else
@@ -152,8 +153,9 @@ internal class ActorSceneObj : IStageSceneObj
                         if (SubAct is null)
                             continue;
                         SubActors.Add(SubAct);
-                        SubActorTransforms.Add(new() { Translate = -offset * (j+1)});
-                        DeltaTranslation = offset * (j+1);
+                        SubActorTransforms.Add(new() { Translate = (BottomUp ? 1 : -1)* offset * (j+1)});
+                        if (!BottomUp)
+                            DeltaTranslation = offset * (j+1);
                     }
                 }
                 AABB = Actor.AABB * (end > 0 ? end : 1);

--- a/Autumn/Rendering/Storage/ActorSceneObj.cs
+++ b/Autumn/Rendering/Storage/ActorSceneObj.cs
@@ -126,15 +126,16 @@ internal class ActorSceneObj : IStageSceneObj
 
     public void UpdateActorFromArg(LayeredFSHandler fsHandler, ClassModifiersWrapper.ModifierEntry entry, string arg, GLTaskScheduler scheduler)
     {
+        int end;
         switch (entry.Args![arg].ArgType)
         {
             case ArgType.Tower: // Add actors on top or below, if we add below we move the actor upwards
-                var ag = (ClassModifiersWrapper.TowerArg)entry.ArgsRem![arg];
-                string baseModel = ag.RepeatModel ?? Actor.Name;
-                Vector3 offset = ag.Offset;
-                bool BottomUp = ag.CountTop != null && ag.CountTop!.Value;
+                var twAg = (ClassModifiersWrapper.TowerArg)entry.ArgsRem![arg];
+                string baseModel = twAg.RepeatModel ?? Actor.Name;
+                Vector3 offset = twAg.Offset;
+                bool BottomUp = twAg.CountTop != null && twAg.CountTop!.Value;
                 int start = SubActors.Count - BaseSubActorCount;
-                int end = int.Clamp((int)StageObj.Properties[arg]!, BottomUp ? 1 : 0, 10) - (BottomUp ? 1 : 0); // Default is 3 / -1 is 3, max is 10, min is 0 but let's not
+                end = int.Clamp((int)StageObj.Properties[arg]!, BottomUp ? 1 : 0, 10) - (BottomUp ? 1 : 0); // Default is 3 / -1 is 3, max is 10, min is 0 but let's not
 
 
                 if (start > end)
@@ -163,6 +164,90 @@ internal class ActorSceneObj : IStageSceneObj
                 AABB = Actor.AABB * (end > 0 ? end : 1);
                 UpdateTransform();
 
+            break;
+
+            case ArgType.SwingCoreLength:
+                var swLn = (ClassModifiersWrapper.SwingingCore)entry.ArgsRem![arg];
+                int argval = (int)StageObj.Properties[arg]!;
+                if (argval == -1) argval = 800; // Taken from game code
+                
+                int chainCount = (int)((argval - 250) * 0.01f) - 1; // Taken from game code
+                // chainCount = (int)((argval + 30) * 0.016666668f) - 1; // Taken from game code
+                if (chainCount < 1) chainCount = 1;
+
+                end = SubActors.Count - 1;
+                int oldcount = end-BaseSubActorCount;
+
+                // Check if the chain count changed to keep or remove
+                if (chainCount < oldcount)
+                    for (int j = end - 1; j >= BaseSubActorCount+ chainCount; j--)
+                    {
+                        SubActors.RemoveAt(j);
+                        SubActorTransforms.RemoveAt(j);
+                    }
+                else if (chainCount > oldcount)
+                    for (int i = int.Max(oldcount, 0); i < chainCount; i++)
+                    {
+                        Actor? SubAct = fsHandler.ReadActorExtrasArg(swLn.ChainModel, scheduler);
+                        if (SubAct is null)
+                            continue;
+                        if (SubActors.Count > 0)
+                        {
+                            SubActors.Insert(SubActors.Count-1, SubAct);
+                            SubActorTransforms.Insert(SubActors.Count-1, new());
+                        }
+                        else
+                        {
+                            SubActors.Add(SubAct);
+                            SubActorTransforms.Add(new());
+                        }
+                    }
+                // Update transforms to the current
+                for (int i = BaseSubActorCount; i < chainCount + BaseSubActorCount; i++)
+                {
+                    SubActorTransforms[i].Translate = - new Vector3(0,50,0) - Vector3.UnitY * ((argval - 300) / (chainCount+1)) + Vector3.UnitY * ((argval - 300) / (chainCount+1)) * -i;
+                }
+
+
+                // only once?
+                Actor? SubActBall = fsHandler.ReadActorExtrasArg(swLn.HeadModel, scheduler);
+                if (SubActBall != null)
+                {
+                    if (!SubActors.Contains(SubActBall))
+                    {
+                        SubActors.Add(SubActBall);
+                        SubActorTransforms.Add(new() { Translate = new Vector3(0, - argval + 100,0)});
+                    }
+                    else SubActorTransforms[^1].Translate = new Vector3(0, - argval + 100,0);
+                }
+                AABB = Actor.AABB * (argval / 100);
+                UpdateTransform();
+            break;
+
+            case ArgType.AddExtraModel:
+                var exMd = (ClassModifiersWrapper.ExtraArgModels)entry.ArgsRem![arg];
+                end = SubActors.Count + BaseSubActorCount;
+                if ((int)StageObj.Properties[arg]! == -1)
+                {
+                    for (int i = BaseSubActorCount; i < end; i++)
+                    {
+                        SubActors.RemoveAt(i);
+                        SubActorTransforms.RemoveAt(i);
+                    }
+                }
+                else
+                {
+                    foreach (string s in exMd.Models.Keys)
+                    {
+                        Actor? AddedModl = fsHandler.ReadActorExtrasArg(s, scheduler);
+                        if (AddedModl is null) continue;
+                        if (!SubActors.Contains(AddedModl))
+                        { 
+                            SubActors.Add(AddedModl);
+                            SubActorTransforms.Add(exMd.Models[s].GetTransform());
+                        }
+                    }
+                }
             break;
 
             default:

--- a/Autumn/Rendering/Storage/ActorSceneObj.cs
+++ b/Autumn/Rendering/Storage/ActorSceneObj.cs
@@ -129,9 +129,10 @@ internal class ActorSceneObj : IStageSceneObj
         switch (entry.Args![arg].ArgType)
         {
             case ArgType.Tower: // Add actors on top or below, if we add below we move the actor upwards
-                string baseModel = entry.Args![arg].RepeatModel ?? Actor.Name;
-                Vector3 offset = entry.Args![arg].Offset ?? Vector3.UnitY * 100;
-                bool BottomUp = entry.Args![arg].CountTop != null && entry.Args![arg].CountTop!.Value;
+                var ag = (ClassModifiersWrapper.TowerArg)entry.ArgsRem![arg];
+                string baseModel = ag.RepeatModel ?? Actor.Name;
+                Vector3 offset = ag.Offset;
+                bool BottomUp = ag.CountTop != null && ag.CountTop!.Value;
                 int start = SubActors.Count - BaseSubActorCount;
                 int end = int.Clamp((int)StageObj.Properties[arg]!, BottomUp ? 1 : 0, 10) - (BottomUp ? 1 : 0); // Default is 3 / -1 is 3, max is 10, min is 0 but let's not
 

--- a/Autumn/Rendering/Storage/ActorSceneObj.cs
+++ b/Autumn/Rendering/Storage/ActorSceneObj.cs
@@ -350,6 +350,11 @@ internal class ActorSceneObj : IStageSceneObj
                 UpdateTransform();
             break;
 
+            case ArgType.PicketHeight:
+                DeltaTranslation.Y = 70 * - ((int)StageObj.Properties[arg]! == -1 ? 0 : (int)StageObj.Properties[arg]!);
+                UpdateTransform();
+            break;
+
             default:
             
             break;

--- a/Autumn/Rendering/Storage/ActorSceneObj.cs
+++ b/Autumn/Rendering/Storage/ActorSceneObj.cs
@@ -24,6 +24,8 @@ internal class ActorSceneObj : IStageSceneObj
     public Vector3 DeltaScale = Vector3.One;
     public Vector3 DeltaRotation;
 
+    public Dictionary<string, Transform> ChildModelTransforms = new();
+
     public ActorSceneObj(StageObj stageObj, Actor actorObj, uint pickingId)
     {
         StageObj = stageObj;
@@ -55,6 +57,7 @@ internal class ActorSceneObj : IStageSceneObj
         DeltaTranslation = Vector3.Zero;
         DeltaScale = Vector3.One;
         DeltaRotation = Vector3.Zero;
+        ChildModelTransforms = new();
 
         fsHandler.ReadCreatorClassNameTable().TryGetValue(actorName, out string? actorClass);
 
@@ -81,6 +84,22 @@ internal class ActorSceneObj : IStageSceneObj
                     DeltaScale = act.Value.Scale.Value;
                 if (act.Value.Rotation != null) 
                     DeltaRotation = act.Value.Rotation.Value;
+                if (act.Value.ExtraModels != null)
+                {
+                    foreach(string m in act.Value.ExtraModels.Keys)
+                    {
+                        ChildModelTransforms.Add(m, new());
+                        if (act.Value.ExtraModels[m] != null)
+                        {
+                            if (act.Value.ExtraModels[m]!.Value.Translation != null) 
+                                ChildModelTransforms[m].Translate = act.Value.ExtraModels[m]!.Value.Translation!.Value;
+                            if (act.Value.ExtraModels[m]!.Value.Scale != null) 
+                                ChildModelTransforms[m].Scale = act.Value.ExtraModels[m]!.Value.Scale!.Value;
+                            if (act.Value.ExtraModels[m]!.Value.Rotation != null) 
+                                ChildModelTransforms[m].Rotate = act.Value.ExtraModels[m]!.Value.Rotation!.Value;
+                        }
+                    }
+                }
             }
         }
 

--- a/Autumn/Rendering/Storage/ActorSceneObj.cs
+++ b/Autumn/Rendering/Storage/ActorSceneObj.cs
@@ -123,7 +123,7 @@ internal class ActorSceneObj : IStageSceneObj
         UpdateTransform();
     }
 
-    public void UpdateActorFromArg(LayeredFSHandler fsHandler, ClassModifiersWrapper.ModifierEntry entry, string arg, Scene scn, GLTaskScheduler scheduler)
+    public void UpdateActorFromArg(LayeredFSHandler fsHandler, ClassModifiersWrapper.ModifierEntry entry, string arg, GLTaskScheduler scheduler)
     {
         switch (entry.Args![arg].ArgType)
         {

--- a/Autumn/Rendering/Storage/ActorSceneObj.cs
+++ b/Autumn/Rendering/Storage/ActorSceneObj.cs
@@ -2,6 +2,7 @@
 using Autumn.Background;
 using Autumn.Enums;
 using Autumn.FileSystems;
+using Autumn.Rendering.CtrH3D;
 using Autumn.Storage;
 using Autumn.Utils;
 using Autumn.Wrappers;
@@ -12,6 +13,12 @@ internal class ActorSceneObj : IStageSceneObj
 {
     public StageObj StageObj { get; }
     public Actor Actor { get; set; }
+    public List<Actor> SubActors = new(); // Flagpole top, Arg additions, etc
+    public List<Transform> SubActorTransforms = new(); //Transform
+    /// <summary>
+    /// Number of subactors this actor has by default, without args
+    /// </summary>
+    public int BaseSubActorCount = 0; 
 
     public Matrix4x4 Transform { get; set; }
     public AxisAlignedBoundingBox AABB { get; set; }
@@ -24,7 +31,6 @@ internal class ActorSceneObj : IStageSceneObj
     public Vector3 DeltaScale = Vector3.One;
     public Vector3 DeltaRotation;
 
-    public Dictionary<string, Transform> ChildModelTransforms = new();
 
     public ActorSceneObj(StageObj stageObj, Actor actorObj, uint pickingId)
     {
@@ -57,7 +63,7 @@ internal class ActorSceneObj : IStageSceneObj
         DeltaTranslation = Vector3.Zero;
         DeltaScale = Vector3.One;
         DeltaRotation = Vector3.Zero;
-        ChildModelTransforms = new();
+        SubActorTransforms = new();
 
         fsHandler.ReadCreatorClassNameTable().TryGetValue(actorName, out string? actorClass);
 
@@ -65,17 +71,9 @@ internal class ActorSceneObj : IStageSceneObj
 
         if (actorClass != null && ClassModifiersWrapper.ModifierEntries.ContainsKey(actorClass)) 
         {
-            fsHandler.ReadActorExtras(actorName, actorClass, Actor, scheduler);
+            fsHandler.ReadActorExtras(actorName, actorClass, this, scheduler);
         
-            ClassModifiersWrapper.ModifierEntry? act = null;
-            if (ClassModifiersWrapper.ModifierEntries[actorClass].Variants != null && ClassModifiersWrapper.ModifierEntries[actorClass].Variants.ContainsKey(actorName))
-            {
-                act = ClassModifiersWrapper.ModifierEntries[actorClass].Variants![actorName]!.Value;
-            }
-            else if (ClassModifiersWrapper.ModifierEntries[actorClass].Default != null)
-            {
-                act = ClassModifiersWrapper.ModifierEntries[actorClass].Default!.Value;
-            }
+            ClassModifiersWrapper.ModifierEntry? act = ClassModifiersWrapper.GetEntry(actorName, actorClass);
             if (act is not null)
             {
                 if (act.Value.Translation != null) 
@@ -86,18 +84,19 @@ internal class ActorSceneObj : IStageSceneObj
                     DeltaRotation = act.Value.Rotation.Value;
                 if (act.Value.ExtraModels != null)
                 {
-                    foreach(string m in act.Value.ExtraModels.Keys)
+                    foreach(Actor ac in SubActors)
                     {
-                        ChildModelTransforms.Add(m, new());
-                        if (act.Value.ExtraModels[m] != null)
+                        SubActorTransforms.Add(new());
+                        if (act.Value.ExtraModels[ac.Name] != null)
                         {
-                            if (act.Value.ExtraModels[m]!.Value.Translation != null) 
-                                ChildModelTransforms[m].Translate = act.Value.ExtraModels[m]!.Value.Translation!.Value;
-                            if (act.Value.ExtraModels[m]!.Value.Scale != null) 
-                                ChildModelTransforms[m].Scale = act.Value.ExtraModels[m]!.Value.Scale!.Value;
-                            if (act.Value.ExtraModels[m]!.Value.Rotation != null) 
-                                ChildModelTransforms[m].Rotate = act.Value.ExtraModels[m]!.Value.Rotation!.Value;
+                            if (act.Value.ExtraModels[ac.Name]!.Value.Translation != null) 
+                                SubActorTransforms[BaseSubActorCount].Translate = act.Value.ExtraModels[ac.Name]!.Value.Translation!.Value;
+                            if (act.Value.ExtraModels[ac.Name]!.Value.Scale != null) 
+                                SubActorTransforms[BaseSubActorCount].Scale = act.Value.ExtraModels[ac.Name]!.Value.Scale!.Value;
+                            if (act.Value.ExtraModels[ac.Name]!.Value.Rotation != null) 
+                                SubActorTransforms[BaseSubActorCount].Rotate = act.Value.ExtraModels[ac.Name]!.Value.Rotation!.Value;
                         }
+                        BaseSubActorCount += 1;
                     }
                 }
             }
@@ -122,5 +121,49 @@ internal class ActorSceneObj : IStageSceneObj
             }
         );
         UpdateTransform();
+    }
+
+    public void UpdateActorFromArg(LayeredFSHandler fsHandler, ClassModifiersWrapper.ModifierEntry entry, string arg, Scene scn, GLTaskScheduler scheduler)
+    {
+        switch (entry.Args![arg].ArgType)
+        {
+            case ArgType.Tower:
+                string baseModel = entry.Args![arg].RepeatModel ?? Actor.Name;
+                Vector3 offset = entry.Args![arg].Offset ?? Vector3.UnitY * 100;
+                int CountTop = (entry.Args![arg].CountTop != null && entry.Args![arg].CountTop!.Value) ? 1 : 0;
+                int start = SubActors.Count - BaseSubActorCount;
+                int end = int.Clamp((int)StageObj.Properties[arg]!, CountTop, 10) - CountTop; // Default is 3 / -1 is 3, max is 10, min is 0 but let's not
+
+
+                if (start > end)
+                {
+                    for (int j = start-1; j >= end; j--)
+                    {
+                        SubActors.RemoveAt(j);
+                        SubActorTransforms.RemoveAt(j);
+                        DeltaTranslation = offset * (j);
+                    }
+                }
+                else
+                {
+                    for (int j = start; j < end; j++)
+                    {
+                        Actor? SubAct = fsHandler.ReadActorExtrasArg(baseModel, scheduler);
+                        if (SubAct is null)
+                            continue;
+                        SubActors.Add(SubAct);
+                        SubActorTransforms.Add(new() { Translate = -offset * (j+1)});
+                        DeltaTranslation = offset * (j+1);
+                    }
+                }
+                AABB = Actor.AABB * (end > 0 ? end : 1);
+                UpdateTransform();
+
+            break;
+
+            default:
+            
+            break;
+        } 
     }
 }

--- a/Autumn/Rendering/Storage/ActorSceneObj.cs
+++ b/Autumn/Rendering/Storage/ActorSceneObj.cs
@@ -63,7 +63,8 @@ internal class ActorSceneObj : IStageSceneObj
         DeltaTranslation = Vector3.Zero;
         DeltaScale = Vector3.One;
         DeltaRotation = Vector3.Zero;
-        SubActorTransforms = new();
+        SubActors.Clear();
+        SubActorTransforms.Clear();
 
         fsHandler.ReadCreatorClassNameTable().TryGetValue(actorName, out string? actorClass);
 

--- a/Autumn/Rendering/Storage/ActorSceneObj.cs
+++ b/Autumn/Rendering/Storage/ActorSceneObj.cs
@@ -1,5 +1,6 @@
 ﻿using System.Numerics;
 using Autumn.Background;
+using Autumn.Enums;
 using Autumn.FileSystems;
 using Autumn.Storage;
 using Autumn.Utils;
@@ -37,10 +38,10 @@ internal class ActorSceneObj : IStageSceneObj
     public void UpdateTransform()
     {
         Vector3 scale = Actor.IsEmptyModel ? StageObj.Scale : (StageObj.Scale * DeltaScale) * 0.01f;
-        Transform = MathUtils.CreateTransform(StageObj.Translation * 0.01f, DeltaTranslation * 0.01f, scale , StageObj.Rotation + DeltaRotation);
+        Transform = MathUtils.CreateTransformWithDelta(StageObj.Translation * 0.01f, DeltaTranslation * 0.01f, scale , StageObj.Rotation + DeltaRotation);
     }
 
-    public void UpdateActor(LayeredFSHandler fsHandler, GLTaskScheduler scheduler)
+    public void UpdateActor(LayeredFSHandler fsHandler, Scene scn, GLTaskScheduler scheduler)
     {
         string actorName = StageObj.Name;
 
@@ -51,20 +52,56 @@ internal class ActorSceneObj : IStageSceneObj
         )
             actorName = modelNameString;
 
-        fsHandler.ReadCreatorClassNameTable().TryGetValue(actorName, out string? fallback);
-
-        if (fallback != null && ClassDatabaseWrapper.DatabaseEntries.ContainsKey(fallback) && ClassDatabaseWrapper.DatabaseEntries[fallback].ArchiveName != null)
-        {
-            Actor = fsHandler.ReadActor(actorName, ClassDatabaseWrapper.DatabaseEntries[fallback].ArchiveName, fallback, scheduler);
-        }
-        else if (ClassDatabaseWrapper.DatabaseEntries.ContainsKey(actorName) && ClassDatabaseWrapper.DatabaseEntries[actorName].ArchiveName != null)
-            Actor = fsHandler.ReadActor(actorName, ClassDatabaseWrapper.DatabaseEntries[actorName].ArchiveName, scheduler);
-        else
-            Actor = fsHandler.ReadActor(actorName, fallback, scheduler);
         DeltaTranslation = Vector3.Zero;
         DeltaScale = Vector3.One;
         DeltaRotation = Vector3.Zero;
 
+        fsHandler.ReadCreatorClassNameTable().TryGetValue(actorName, out string? actorClass);
+
+        Actor = fsHandler.ReadActorNew(actorName, actorClass, scheduler);
+
+        if (actorClass != null && ClassModifiersWrapper.ModifierEntries.ContainsKey(actorClass)) 
+        {
+            fsHandler.ReadActorExtras(actorName, actorClass, Actor, scheduler);
+        
+            ClassModifiersWrapper.ModifierEntry? act = null;
+            if (ClassModifiersWrapper.ModifierEntries[actorClass].Variants != null && ClassModifiersWrapper.ModifierEntries[actorClass].Variants.ContainsKey(actorName))
+            {
+                act = ClassModifiersWrapper.ModifierEntries[actorClass].Variants![actorName]!.Value;
+            }
+            else if (ClassModifiersWrapper.ModifierEntries[actorClass].Default != null)
+            {
+                act = ClassModifiersWrapper.ModifierEntries[actorClass].Default!.Value;
+            }
+            if (act is not null)
+            {
+                if (act.Value.Translation != null) 
+                    DeltaTranslation = act.Value.Translation.Value;
+                if (act.Value.Scale != null) 
+                    DeltaScale = act.Value.Scale.Value;
+                if (act.Value.Rotation != null) 
+                    DeltaRotation = act.Value.Rotation.Value;
+            }
+        }
+
+        
+
+        scheduler.EnqueueGLTask( gl => 
+            {
+                scn.Opaque.Remove(this);
+                scn.Translucent.Remove(this);
+                scn.Subtractive.Remove(this);
+                scn.Additive.Remove(this);
+                if (Actor.IsEmptyModel) scn.Opaque.Add(this);
+                else
+                {
+                    if (Actor.CountMeshesLayer(H3DMeshLayer.Opaque) > 0) scn.Opaque.Add(this);
+                    if (Actor.CountMeshesLayer(H3DMeshLayer.Translucent) > 0) scn.Translucent.Add(this);
+                    if (Actor.CountMeshesLayer(H3DMeshLayer.Subtractive) > 0) { scn.Subtractive.Add(this);}
+                    if (Actor.CountMeshesLayer(H3DMeshLayer.Additive) > 0) { scn.Additive.Add(this);}
+                }
+            }
+        );
         UpdateTransform();
     }
 }

--- a/Autumn/Rendering/Storage/ActorSceneObj.cs
+++ b/Autumn/Rendering/Storage/ActorSceneObj.cs
@@ -251,10 +251,10 @@ internal class ActorSceneObj : IStageSceneObj
 
             case ArgType.AddExtraModel:
                 var exMd = (ClassModifiersWrapper.ExtraArgModels)entry.ArgsRem![arg];
-                end = SubActors.Count + BaseSubActorCount;
+                end = SubActors.Count -1 ;
                 if ((int)StageObj.Properties[arg]! == -1)
                 {
-                    for (int i = end-1; i >= BaseSubActorCount; i--)
+                    for (int i = end; i >= BaseSubActorCount; i--)
                     {
                         SubActors.RemoveAt(i);
                         SubActorTransforms.RemoveAt(i);
@@ -320,13 +320,12 @@ internal class ActorSceneObj : IStageSceneObj
                 }
                 else
                 {
-                    // Temporary until we figure how to get the info from the Actor name
                     cnt = int.Parse(Regex.Match(Actor.Name, @"-?\d+").Value);
                 }
                 cnt = cnt < 1 ? 1 : cnt;                
                 sides = sides < 1 ? 1 : sides;                
-                end = SubActors.Count + BaseSubActorCount;
-                for (int i = end-1; i >= BaseSubActorCount; i--)
+                end = SubActors.Count - 1;
+                for (int i = end; i >= BaseSubActorCount; i--)
                 {
                     SubActors.RemoveAt(i);
                     SubActorTransforms.RemoveAt(i);

--- a/Autumn/Rendering/Storage/ActorSceneObj.cs
+++ b/Autumn/Rendering/Storage/ActorSceneObj.cs
@@ -71,7 +71,7 @@ internal class ActorSceneObj : IStageSceneObj
         SubActors.Clear();
         SubActorTransforms.Clear();
         Shadows.Clear();
-
+        BaseSubActorCount = 0;
 
         fsHandler.ReadCreatorClassNameTable().TryGetValue(actorName, out string? actorClass);
 

--- a/Autumn/Rendering/Storage/ActorSceneObj.cs
+++ b/Autumn/Rendering/Storage/ActorSceneObj.cs
@@ -75,7 +75,7 @@ internal class ActorSceneObj : IStageSceneObj
 
         fsHandler.ReadCreatorClassNameTable().TryGetValue(actorName, out string? actorClass);
 
-        Actor = fsHandler.ReadActorNew(actorName, actorClass, scheduler);
+        Actor = fsHandler.ReadActor(actorName, actorClass, scheduler);
         AABB = Actor.AABB;
 
         if (actorClass != null && ClassModifiersWrapper.ModifierEntries.ContainsKey(actorClass)) 
@@ -125,7 +125,7 @@ internal class ActorSceneObj : IStageSceneObj
         }
         foreach (ActorShadow shadow in Actor.InitShadow)
         {
-            Shadows.Add( fsHandler.ReadActor( shadow.GetShadowVolumeString(), scheduler));
+            Shadows.Add( fsHandler.ReadActorBasic( shadow.GetShadowVolumeString(), scheduler));
         }
 
         scheduler.EnqueueGLTask( gl => 

--- a/Autumn/Rendering/Storage/ActorSceneObj.cs
+++ b/Autumn/Rendering/Storage/ActorSceneObj.cs
@@ -39,8 +39,7 @@ internal class ActorSceneObj : IStageSceneObj
         StageObj = stageObj;
         Actor = actorObj;
         PickingId = pickingId;
-
-        AABB = actorObj.AABB;
+        AABB = stageObj.Name.Contains("TransparentWall") ? actorObj.AABB * 4 : actorObj.AABB;
 
         UpdateTransform();
     }

--- a/Autumn/Rendering/Storage/AxisAlignedBoundingBox.cs
+++ b/Autumn/Rendering/Storage/AxisAlignedBoundingBox.cs
@@ -6,6 +6,7 @@ internal class AxisAlignedBoundingBox
 {
     public Vector3 Max = new(50, 50, 50);
     public Vector3 Min = new(-50, -50, -50);
+    public Vector3 Center = new(0,0,0);
 
     public AxisAlignedBoundingBox() { }
 
@@ -28,12 +29,12 @@ internal class AxisAlignedBoundingBox
 
     public static AxisAlignedBoundingBox operator *(AxisAlignedBoundingBox _aabb, float t)
     {
-        return new AxisAlignedBoundingBox(_aabb.Max * t, _aabb.Min * t);
+        return new AxisAlignedBoundingBox(_aabb.Max * t, _aabb.Min * t) { Center = _aabb.Center };
     }
 
     public static AxisAlignedBoundingBox operator *(AxisAlignedBoundingBox _aabb, Vector3 v)
     {
-        AxisAlignedBoundingBox rAABB = new(_aabb.Max, _aabb.Min);
+        AxisAlignedBoundingBox rAABB = new(_aabb.Max, _aabb.Min) { Center = _aabb.Center };
         rAABB.Max.X *= v.X;
         rAABB.Min.X *= v.X;
         rAABB.Max.Y *= v.Y;

--- a/Autumn/Rendering/Storage/CommonParams.cs
+++ b/Autumn/Rendering/Storage/CommonParams.cs
@@ -72,6 +72,6 @@ internal sealed class CommonMaterialParameters
     public bool Selected
     {
         get => _buffer.Data.HighlightAlpha > 0;
-        set => _buffer.SetData(_buffer.Data with { HighlightAlpha = value ? 0.8f : 0 });
+        set => _buffer.SetData(_buffer.Data with { HighlightAlpha = value ? 0.4f : 0 });
     }
 }

--- a/Autumn/Rendering/TransparentWall/TrWallMaterial.cs
+++ b/Autumn/Rendering/TransparentWall/TrWallMaterial.cs
@@ -1,0 +1,114 @@
+using System.Numerics;
+using Autumn.Rendering.Storage;
+using SceneGL;
+using SceneGL.GLWrappers;
+using Silk.NET.OpenGL;
+
+namespace Autumn.Rendering;
+
+internal static class TransparentWallMaterial
+{
+    private static readonly ShaderSource s_WallVertex =
+        new(
+            "TransparentWall.vert",
+            ShaderType.VertexShader,
+            """
+            #version 330
+
+            layout(location = 0) in vec3 aPos;
+            layout(location = 1) in vec2 aUV;
+
+            layout(std140) uniform ubScene {
+                mat4x4 uViewProjection;
+                mat4x4 uTransform;
+            };
+
+            out vec3 vPos;
+            out vec2 vUV;
+            out mat4x4 vTrans;
+
+            void main() {
+                gl_Position = uViewProjection * uTransform * vec4(aPos.x, aPos.y, aPos.z, 2.0);
+                vPos = aPos;
+                vTrans = uTransform;
+                vUV = aUV;
+            }
+            """
+        );
+
+    private static readonly ShaderSource s_WallFragment =
+        new(
+            "TransparentWall.frag",
+            ShaderType.FragmentShader,
+            """
+            #version 330
+
+            float max3(float a, float b, float c) {
+                return max(max(a, b), c);
+            }
+
+            in vec3 vPos;
+            in vec2 vUV;
+            in mat4x4 vTrans;
+
+            layout(std140) uniform ubMaterial {
+                vec4 uColor;
+                vec4 uHighlightColor;
+            };
+
+            uniform uint uPickingId;
+
+            out vec4 oColor;
+            out uint oPickingId;
+            out vec4 oPostProc;
+
+            const float PI = 3.14159;
+
+            vec2 rotate(vec2 samplePosition, float rotation){
+                float angle = rotation * PI / 180;
+                return vec2(cos(angle) * samplePosition.x + sin(angle) * samplePosition.y, 
+                            cos(angle) * samplePosition.y - sin(angle) * samplePosition.x);
+            }
+
+            void main() {
+                vec3 scale = vec3(  length(vec3(vTrans[0][0], vTrans[1][0], vTrans[2][0])),
+                                    length(vec3(vTrans[0][1], vTrans[1][1], vTrans[2][1])), 
+                                    length(vec3(vTrans[0][2], vTrans[1][2], vTrans[2][2]))) * 100;
+                oColor.a = 1.0;
+                oPickingId = uPickingId;
+                oPostProc = vec4((uHighlightColor.a > 0.1 ? 1 : 0), 0, 0, 0);
+                oColor.rgb = vec3(vUV,0);//uColor.rgb;
+                float xMin = 0.3 / scale.x;
+                float yMin = 0.3 / scale.y;
+                float dist = length(vUV - 0.5);
+                vec3 col = vec3(0);
+                float sz = 0.45;
+
+                oColor.rgb = (vUV.x < xMin || vUV.x > 1.0 - xMin) ? vec3(1) : vec3(0);
+                oColor.rgb += (vUV.y < yMin || vUV.y > 1.0 - yMin) ? vec3(1) : vec3(0);
+                
+                float v = (scale.y + scale.x) / 2;
+                vec2 rUV = rotate((vUV - 0.5) * v, 45) + 0.5;
+                col = vec3(rUV.x > sz && rUV.x < 1-sz ? 1 : 0);
+                col += vec3(rUV.y > sz && rUV.y < 1-sz ? 1 : 0);
+                oColor.rgb += col;
+                oColor.rgb = clamp(oColor.rgb, vec3(0), vec3(1));
+                
+                if ((oColor.r < 0.1)) discard;
+
+                oColor.rgb = mix(uColor.rgb, uColor.rgb, oColor.rgb);
+                oColor.rgb = mix(oColor.rgb, uHighlightColor.rgb, uHighlightColor.a);
+                oColor.rgb = gl_FrontFacing ? oColor.rgb : oColor.rgb *0.80;
+            }
+            """
+        );
+
+    public static readonly ShaderProgram WallProgram = new(s_WallVertex, s_WallFragment);
+    public static bool TryUse(
+        GL gl,
+        CommonSceneParameters scene,
+        CommonMaterialParameters material,
+        out ProgramUniformScope scope
+    ) => WallProgram.TryUse(gl, null, [scene.ShaderParameters, material.ShaderParameters], out scope, out _);
+    
+}

--- a/Autumn/Rendering/TransparentWall/TrWallRenderer.cs
+++ b/Autumn/Rendering/TransparentWall/TrWallRenderer.cs
@@ -1,0 +1,95 @@
+﻿using System.Numerics;
+using Autumn.Rendering.Storage;
+using SceneGL;
+using SceneGL.Materials;
+using Silk.NET.OpenGL;
+
+namespace Autumn.Rendering;
+
+internal static class TransparentWallRenderer
+{
+    private struct Vertex
+    {
+        [VertexAttribute(CombinerMaterial.POSITION_LOC, 3, VertexAttribPointerType.Float, false)]
+        public Vector3 Position;
+        [VertexAttribute(AttributeShaderLoc.Loc1, 2, VertexAttribPointerType.Float, false)]
+        public Vector2 UV;
+    }
+    private static RenderableModel? s_WallModel;
+
+    public static void Initialize(GL gl) => s_WallModel = GenerateModel(gl);
+    
+    public static RenderableModel GenerateModel(GL gl, float scale = 10)
+    {
+        ModelBuilder<ushort, Vertex> builder = new();
+
+        Matrix4x4 mtx;
+        scale *= 100;
+        #region Transform Helpers
+        void Reset() => mtx = Matrix4x4.CreateScale(scale);
+
+        static void Rotate(ref float x, ref float y)
+        {
+            var _x = x;
+            x = y;
+            y = -_x;
+        }
+
+        void RotateOnX()
+        {
+            Rotate(ref mtx.M12, ref mtx.M13);
+            Rotate(ref mtx.M22, ref mtx.M23);
+            Rotate(ref mtx.M32, ref mtx.M33);
+        }
+
+        void RotateOnY()
+        {
+            Rotate(ref mtx.M11, ref mtx.M13);
+            Rotate(ref mtx.M21, ref mtx.M23);
+            Rotate(ref mtx.M31, ref mtx.M33);
+        }
+
+        #endregion
+
+        float w = 1;
+        
+        void Face()
+        {
+            builder!.AddPlane(
+                new Vertex { Position = Vector3.Transform(new Vector3(-w, 0, -w), mtx), UV = Vector2.Zero },
+                new Vertex { Position = Vector3.Transform(new Vector3(w, 0, -w), mtx), UV = Vector2.UnitX },
+                new Vertex { Position = Vector3.Transform(new Vector3(-w, 0, w), mtx), UV = Vector2.UnitY },
+                new Vertex { Position = Vector3.Transform(new Vector3(w, 0, w), mtx), UV = Vector2.One }
+            );
+        }
+        Reset();
+
+        RotateOnX();
+        Face();
+
+        Reset();
+
+
+        return builder.GetModel(gl);
+    }
+
+    public static void Render(GL gl, CommonSceneParameters scene, CommonMaterialParameters material, uint pickingId)
+    {
+        if (!TransparentWallMaterial.TryUse(gl, scene, material, out ProgramUniformScope scope))
+            return;
+
+        using (scope)
+        {
+            gl.Disable(EnableCap.CullFace);
+            int location = -1;
+            if (TransparentWallMaterial.WallProgram.TryGetUniformLoc("uPickingId", out location))
+                gl.Uniform1(location, pickingId);
+            s_WallModel!.Draw(gl);
+
+            gl.Enable(EnableCap.CullFace);
+        }
+    }
+
+    public static void CleanUp(GL gl) => s_WallModel?.CleanUp(gl);
+    
+}

--- a/Autumn/Resources/DefaultActions.yml
+++ b/Autumn/Resources/DefaultActions.yml
@@ -53,6 +53,11 @@ ShowAllObjs:
   Ctrl: false
   Key: H
   Shift: false
+ToggleSelectAll:
+  Alt: false
+  Ctrl: false
+  Key: A
+  Shift: false
 TranslateObj:
   Alt: false
   Ctrl: false

--- a/Autumn/Resources/DefaultActions.yml
+++ b/Autumn/Resources/DefaultActions.yml
@@ -3,7 +3,7 @@ OpenSettings:
   Ctrl: false
   Key: S
   Shift: true
-CloseScene:
+CloseCurrentStage:
   Alt: false
   Ctrl: true
   Key: W

--- a/Autumn/Resources/DefaultActions.yml
+++ b/Autumn/Resources/DefaultActions.yml
@@ -48,6 +48,11 @@ HideObj:
   Ctrl: false
   Key: H
   Shift: false
+ShowAllObjs:
+  Alt: true
+  Ctrl: false
+  Key: H
+  Shift: false
 TranslateObj:
   Alt: false
   Ctrl: false

--- a/Autumn/Resources/DefaultActions.yml
+++ b/Autumn/Resources/DefaultActions.yml
@@ -88,3 +88,13 @@ CamToObj:
   Ctrl: false
   Key: Space
   Shift: false
+Search:
+  Alt: false
+  Ctrl: true
+  Key: F
+  Shift: false
+FlyCamMode:
+  Alt: false
+  Ctrl: false
+  Key: F
+  Shift: true

--- a/Autumn/Storage/Actor.cs
+++ b/Autumn/Storage/Actor.cs
@@ -170,10 +170,14 @@ internal class Actor
         return true;
     }
 
-    public IEnumerable<(H3DRenderingMesh Mesh, H3DRenderingMaterial Material)> EnumerateMeshes(
-        H3DMeshLayer layer
-    )
+    public IEnumerable<(H3DRenderingMesh Mesh, H3DRenderingMaterial Material)> EnumerateMeshes(H3DMeshLayer layer)
     {
+        foreach (var tuple in _meshes[(int)layer])
+            yield return tuple;
+    }
+    public IEnumerable<(H3DRenderingMesh Mesh, H3DRenderingMaterial Material)> EnumerateMeshes()
+    {
+        for (int layer = 0; layer < 4; layer++)
         foreach (var tuple in _meshes[(int)layer])
             yield return tuple;
     }

--- a/Autumn/Storage/Actor.cs
+++ b/Autumn/Storage/Actor.cs
@@ -19,9 +19,11 @@ internal class Actor
 {
     public string Name { get; private set; }
     public bool IsEmptyModel { get; private set; }
+    public bool IsShadowModel { get; set; } = false;
 
     public AxisAlignedBoundingBox AABB { get; set; } = new(2);
     public ActorLight InitLight = new();
+    public List<ActorShadow> InitShadow = new();
 
     /// <summary>
     /// An array of mesh lists. Each entry in the array represents a mesh layer.

--- a/Autumn/Storage/Actor.cs
+++ b/Autumn/Storage/Actor.cs
@@ -74,6 +74,7 @@ internal class Actor
 
     public void AddTexture(GL gl, H3DTexture texture)
     {
+        if (_textures.ContainsKey(texture.Name)) return;
         byte[] textureData = texture.ToRGBA();
 
         uint glTexture = TextureHelper.CreateTexture2D<byte>(
@@ -176,6 +177,8 @@ internal class Actor
         foreach (var tuple in _meshes[(int)layer])
             yield return tuple;
     }
+
+    public int CountMeshesLayer(H3DMeshLayer l) => _meshes[(int)l].Count;
 
     public void ForceModelNotEmpty() => IsEmptyModel = false;
 }

--- a/Autumn/Storage/Actor.cs
+++ b/Autumn/Storage/Actor.cs
@@ -1,8 +1,11 @@
+using System.Text;
 using Autumn.Enums;
 using Autumn.Rendering;
 using Autumn.Rendering.CtrH3D;
 using Autumn.Rendering.CtrH3D.Animation;
 using Autumn.Rendering.Storage;
+using BYAMLSharp;
+using NARCSharp;
 using SceneGL.GLHelpers;
 using SceneGL.Materials.Common;
 using Silk.NET.OpenGL;
@@ -24,6 +27,7 @@ internal class Actor
     public AxisAlignedBoundingBox AABB { get; set; } = new(2);
     public ActorLight InitLight = new();
     public List<ActorShadow> InitShadow = new();
+    public ActorInfo Info;
 
     /// <summary>
     /// An array of mesh lists. Each entry in the array represents a mesh layer.
@@ -187,4 +191,86 @@ internal class Actor
     public int CountMeshesLayer(H3DMeshLayer l) => _meshes[(int)l].Count;
 
     public void ForceModelNotEmpty() => IsEmptyModel = false;
+
+
+    public void ReadActorInits(NARCFileSystem narc, Encoding enc)
+    {
+        if (narc.TryGetFile("InitLight.byml", out byte[] light))
+        {
+            BYAML act_lights = BYAMLParser.Read(light, enc);
+            if (act_lights.RootNode.NodeType == BYAMLNodeType.Dictionary)
+            {
+                var lrt = act_lights.RootNode.GetValueAs<Dictionary<string, BYAMLNode>>();
+                if (lrt!.ContainsKey("LightCalcType"))
+                    InitLight.GetCalcType((string)lrt["LightCalcType"].Value!);
+                if (lrt!.ContainsKey("LightType"))
+                    InitLight.GetType((string)lrt["LightType"].Value!);
+            }
+        }
+        if (narc.TryGetFile("InitShadow.byml", out byte[] shadows))
+        {
+            BYAML act_sh = BYAMLParser.Read(shadows, enc);
+            if (act_sh.RootNode.NodeType == BYAMLNodeType.Dictionary)
+            {
+                var srt = act_sh.RootNode.GetValueAs<Dictionary<string, BYAMLNode>>();
+                if (srt!.ContainsKey("Category") && srt["Category"].Value != null)
+                {
+                    if (srt["Category"].NodeType == BYAMLNodeType.String && !string.IsNullOrEmpty((string)srt["Category"].Value!))
+                        Console.WriteLine($"{Name} Shadows Contains actual category");
+                }
+                if (srt!.ContainsKey("Shadows"))
+                {
+                    //Console.WriteLine("Contains Shadows");
+                    var shArr = srt["Shadows"];
+                    if (shArr.NodeType == BYAMLNodeType.Array)
+                    {
+                        BYAMLNode[] shs = shArr.GetValueAs<BYAMLNode[]>()!;
+                        foreach (BYAMLNode shd in shs)
+                        {
+                            if (shd.NodeType is not BYAMLNodeType.Dictionary) continue;
+                            InitShadow.Add(new (shd.GetValueAs<Dictionary<string, BYAMLNode>>()!));
+                        }
+                    }
+                    //srt.TryGetValue("", out BYAMLNode SName)
+                }
+            }
+        }
+        if (narc.TryGetFile("InitActor.byml", out byte[] actInfo))
+        {
+            BYAML act_inf = BYAMLParser.Read(actInfo, enc);
+            if (act_inf.RootNode.NodeType == BYAMLNodeType.Dictionary)
+            {
+                Info = new();
+                var srt = act_inf.RootNode.GetValueAs<Dictionary<string, BYAMLNode>>();
+                if (srt!.ContainsKey("MaterialController"))
+                {
+                    // Info.ProjectionYOffset = ;
+                    var a = srt["MaterialController"].GetValueAs<Dictionary<string, BYAMLNode>>();
+                    if (a != null)
+                    {
+                        if (a.ContainsKey("ProjTex1dLocalTransY"))
+                        {
+                            if (a["ProjTex1dLocalTransY"].Value != null)
+                            {
+                                var b = a["ProjTex1dLocalTransY"].GetValueAs<Dictionary<string, BYAMLNode>>()!;
+                                Info.ProjectionYOffset = b["Offset"].GetValueAs<float>();
+                                if (b.ContainsKey("HeightScale")) Info.ProjectionYOffset *= b["HeightScale"].GetValueAs<float>();
+                            }
+                        }
+                        else if (a.ContainsKey("ProjTex1dRelTransY"))
+                        {
+                            if (a["ProjTex1dRelTransY"].Value != null)
+                            {
+                                var b = a["ProjTex1dRelTransY"].GetValueAs<Dictionary<string, BYAMLNode>>()!;
+                                Info.ProjectionYOffset = b["Offset"].GetValueAs<float>();
+                                if (b.ContainsKey("HeightScale")) Info.ProjectionYOffset *= b["HeightScale"].GetValueAs<float>();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
 }

--- a/Autumn/Storage/Actor.cs
+++ b/Autumn/Storage/Actor.cs
@@ -268,6 +268,10 @@ internal class Actor
                         }
                     }
                 }
+                if (srt!.ContainsKey("UseMaterialFogEnableFlag"))
+                {
+                    Info.UseFog = false;
+                }
             }
         }
     }

--- a/Autumn/Storage/Actor/ActorInfo.cs
+++ b/Autumn/Storage/Actor/ActorInfo.cs
@@ -1,0 +1,8 @@
+
+namespace Autumn.Storage;
+
+internal class ActorInfo
+{
+    public float? ProjectionYOffset;
+
+}

--- a/Autumn/Storage/Actor/ActorInfo.cs
+++ b/Autumn/Storage/Actor/ActorInfo.cs
@@ -4,5 +4,6 @@ namespace Autumn.Storage;
 internal class ActorInfo
 {
     public float? ProjectionYOffset;
+    public bool? UseFog;
 
 }

--- a/Autumn/Storage/Actor/ActorShadow.cs
+++ b/Autumn/Storage/Actor/ActorShadow.cs
@@ -1,0 +1,141 @@
+
+using System.Numerics;
+using BYAMLSharp;
+
+namespace Autumn.Storage;
+
+internal class ActorShadow
+{
+    public string Category = ""; // ?
+
+    public string? ActorJointName;// = "Dokan";
+    public ExCategory? ExecCategory;// = ExCategory.ShadowVolume;
+    public string? ModelArcName;// = "ObjectData/ShadowVolumeDokan";
+    public string Name = "Body";
+    public Vector3 Offset = Vector3.UnitY;
+    public Vector3 RotateOffset = Vector3.Zero;
+    public float? ShadowOffset = 0; // What, Kuribo
+    public Vector3 Size = Vector3.One * 100;
+    public VolumeType Type;// = VolumeType.Cube; // DEFAULT 
+    public string? VanishingPointShadowName;// = "Body"; // Ghostplayer, KuriboTailBig
+    public bool? UseActorTransRef;// = null; // GororiBig, KoopaSwitch
+
+
+    // Seen types 3 -> bunbun
+    // 6 ->  AssistItem
+    // 8 -> BlockNote
+    // 7 Coin, CoinRing
+    public enum VolumeType
+    {
+        Cube = -1 | 7,
+        Cone = 3,
+        Pyramid = 4,
+        Sphere = 5,
+        Cylinder = 6,
+        Block = 8,
+        /// <summary>
+        /// Gets the model from ModelArcName
+        /// </summary>
+        ArchiveModel
+    }
+    internal static string GetShadowVolumeString(VolumeType tp)
+    {
+        return tp switch 
+        {
+            VolumeType.Pyramid => "ShadowVolumePyramid",
+            VolumeType.Sphere => "ShadowVolumeSphere",
+            VolumeType.Cylinder => "ShadowVolumeCylinder",
+            VolumeType.Cone => "ShadowVolumeCone",
+            VolumeType.Block => "ShadowVolumeBlock",
+            _ => "ShadowVolumeCube",
+
+        };
+    }
+    public string GetShadowVolumeString()
+    {
+        return Type switch 
+        {
+            VolumeType.ArchiveModel => ModelArcName ?? "",
+            _ => GetShadowVolumeString(Type),
+
+        };
+    }
+    public enum ExCategory
+    {
+        ShadowVolume,
+        PlayerShadowVolume
+    }
+
+    public void GetVolumeType(string s)
+    {
+        try
+        {
+            Type = s switch
+            {
+                "四角柱" => VolumeType.Cube,
+                "円柱" => VolumeType.Cylinder,
+                "円錐" => VolumeType.Cone,
+                "球" => VolumeType.Sphere,
+                "四角錐" => VolumeType.Pyramid,
+                "ブロック用" => VolumeType.Block,
+                "任意モデル" => VolumeType.ArchiveModel,
+                _ => throw new NotImplementedException("Unknown VolumeType")
+            };
+        }
+        catch (NotImplementedException e) 
+        {
+            Console.WriteLine($"{e.Message}: {s}");
+        }
+    }
+    public void GetExecCategory(string s)
+    {
+        try
+        {
+            ExecCategory = s switch
+            {
+                "影ボリューム" => ExCategory.ShadowVolume,
+                "プレイヤー影ボリューム" => ExCategory.PlayerShadowVolume,
+                _ => throw new NotImplementedException("Unknown ExecCategory")
+            };
+        }
+        catch (NotImplementedException e)
+        {
+            Console.WriteLine($"{e.Message}: {s}");
+        }
+    }
+
+    public ActorShadow(Dictionary<string, BYAMLNode> prop)
+    {
+        if (prop.TryGetValue("TypeName", out BYAMLNode? BYMLVal))
+            GetVolumeType(BYMLVal.GetValueAs<string>()!);
+        else if (prop.TryGetValue("Type", out BYMLVal))
+            Type = (VolumeType)BYMLVal.GetValueAs<int>();
+
+
+        if (prop.TryGetValue("ExecCategory", out BYMLVal))
+            GetExecCategory(BYMLVal.GetValueAs<string>()!);
+
+        if (prop.TryGetValue("Name", out BYMLVal))
+            Name = BYMLVal.GetValueAs<string>()!;
+        if (prop.TryGetValue("ModelArcName", out BYMLVal))
+            ModelArcName = BYMLVal.GetValueAs<string>()!["ObjectData/".Length..];
+        if (prop.TryGetValue("Offset", out BYMLVal))
+            Offset = DictToVec3(BYMLVal.GetValueAs<Dictionary<string,BYAMLNode>>()) ?? Offset;
+        if (prop.TryGetValue("RotateOffset", out BYMLVal))
+            RotateOffset = DictToVec3(BYMLVal.GetValueAs<Dictionary<string,BYAMLNode>>()) ?? RotateOffset;
+        if (prop.TryGetValue("Size", out BYMLVal))
+            Size = DictToVec3(BYMLVal.GetValueAs<Dictionary<string,BYAMLNode>>()) ?? Size;
+
+    }
+    public static Vector3? DictToVec3(Dictionary<string, BYAMLNode>? dict)
+    {
+        if (dict is null) return null;
+        dict.TryGetValue("X", out BYAMLNode x);
+        dict.TryGetValue("Y", out BYAMLNode y);
+        dict.TryGetValue("Z", out BYAMLNode z);
+        return new(float.Round(x?.GetValueAs<float>() ?? 1, 2),
+        float.Round(y?.GetValueAs<float>() ?? 1, 2),
+        float.Round(z?.GetValueAs<float>() ?? 1, 2));
+    }
+
+}

--- a/Autumn/Storage/RailPoint.cs
+++ b/Autumn/Storage/RailPoint.cs
@@ -28,4 +28,14 @@ internal class RailPoint
         p.Point2Trans *= f;
         return p;
     }
+    public RailPoint Clone()
+    {
+        var r = new RailPoint() { Point0Trans = this.Point0Trans, Point1Trans = this.Point1Trans, Point2Trans = this.Point2Trans };
+        foreach (string s in this.Properties.Keys)
+        {
+            r.Properties.Add(s, this.Properties[s]);
+        }
+        return r;
+
+    }
 }

--- a/Autumn/Storage/StageCamera.cs
+++ b/Autumn/Storage/StageCamera.cs
@@ -439,9 +439,9 @@ internal class StageCamera
         dict.TryGetValue("X", out BYAMLNode x);
         dict.TryGetValue("Y", out BYAMLNode y);
         dict.TryGetValue("Z", out BYAMLNode z);
-        return new(float.Round(x?.GetValueAs<float>() ?? 1),
-        float.Round(y?.GetValueAs<float>() ?? 1),
-        float.Round(z?.GetValueAs<float>() ?? 1));
+        return new(float.Round(x?.GetValueAs<float>() ?? 1, 2),
+        float.Round(y?.GetValueAs<float>() ?? 1, 2),
+        float.Round(z?.GetValueAs<float>() ?? 1, 2));
     }
 
     public static Vector2? DictToVec2(Dictionary<string, BYAMLNode>? dict)

--- a/Autumn/Storage/StageFog.cs
+++ b/Autumn/Storage/StageFog.cs
@@ -11,9 +11,9 @@ internal class StageFog
     
     public enum FogTypes
     {
-        FOG_UPDATER_TYPE_LINEAR,
-        FOG_UPDATER_TYPE_EXPONENT,
-        FOG_UPDATER_TYPE_EXPONENT_SQUARE,
+        FOG_UPDATER_TYPE_LINEAR = 1,
+        FOG_UPDATER_TYPE_EXPONENT = 2,
+        FOG_UPDATER_TYPE_EXPONENT_SQUARE = 3,
     }
 
     public int InterpFrame = 0;

--- a/Autumn/Utils/MathUtils.cs
+++ b/Autumn/Utils/MathUtils.cs
@@ -301,3 +301,10 @@ internal static class MathUtils
         aabb.Max.Z = Math.Max(aabb.Max.Z, box.Size.Z);
     }
 }
+
+internal class Transform
+{
+    public Vector3 Translate = Vector3.Zero;
+    public Vector3 Rotate = Vector3.Zero;
+    public Vector3 Scale = Vector3.One;
+}

--- a/Autumn/Utils/MathUtils.cs
+++ b/Autumn/Utils/MathUtils.cs
@@ -75,6 +75,25 @@ internal static class MathUtils
 
         return mScale * (mRotationX * mRotationY * mRotationZ) * mTranslation;
     }
+    public static Matrix4x4 CreateTransformWithDelta(Vector3 translation, Vector3 deltatranslation, Vector3 scale, Vector3 rotation)
+    {
+        float rotX = (float)(Math.PI / 180 * rotation.X),
+            rotY = (float)(Math.PI / 180 * rotation.Y),
+            rotZ = (float)(Math.PI / 180 * rotation.Z);
+
+        // M = S * (Rx * Ry * Rz) * T
+        // Where T -> Translation, S -> Scale, R -> Rotation.
+
+        Matrix4x4 mTranslation = Matrix4x4.CreateTranslation(translation);
+        Matrix4x4 mScale = Matrix4x4.CreateScale(scale);
+
+        Matrix4x4 mRotationX = Matrix4x4.CreateRotationX(rotX);
+        Matrix4x4 mRotationY = Matrix4x4.CreateRotationY(rotY);
+        Matrix4x4 mRotationZ = Matrix4x4.CreateRotationZ(rotZ);
+        Matrix4x4 mDTranslation = Matrix4x4.CreateTranslation(deltatranslation);
+
+        return mScale * mDTranslation * (mRotationX * mRotationY * mRotationZ) * mTranslation;
+    }
 
     public static Matrix2X4<float> GetTextureTransform(
         Vector2 scale,

--- a/Autumn/Wrappers/ClassDatabaseWrapper.cs
+++ b/Autumn/Wrappers/ClassDatabaseWrapper.cs
@@ -43,7 +43,7 @@ internal static class ClassDatabaseWrapper
             if (s_DatabaseEntries is null || ReloadEntries)
             {
                 s_DatabaseEntries = new();
-                string path = Path.Join(Path.Join("Resources", "RedPepper-ClassDataBase"), "Data");
+                string path = Path.Join("Resources", "ClassDB");
 
                 foreach (string entryPath in Directory.EnumerateFiles(path))
                 {

--- a/Autumn/Wrappers/ClassModifiersWrapper.cs
+++ b/Autumn/Wrappers/ClassModifiersWrapper.cs
@@ -143,26 +143,32 @@ internal static class ClassModifiersWrapper
     /// Actor that has models (MiddleModel, PointModel) that rotate around it, one arg can set the amount of said RotateModel, another arg sets the number of lines of that
     /// Value of the arg -> number of balls
     /// </summary>
-    public class RotateCoreAmount : BaseArg
+    public class RotateCoreCount : BaseArg
     {
-        // public Vector3 Offset { get; set; } // Hardcoded
-        public string? PointModel { get; set; } // last repeated object
-        public string? MiddleModel { get; set; } // object to repeat in line
-        public RotateCoreAmount(Dictionary<string, object> props)
-        {
-            object? v;
-            if (props.TryGetValue("MiddleModel", out v))
-                MiddleModel = (string)v;
-            if (props.TryGetValue("PointModel", out v))
-                PointModel = (string)v;
-        }
     }
     /// <summary>
     /// Number of lines for this actor, they will be drawn as equal divisions of a circle (3 lines -> 120º between each)
     /// Value of the arg -> line count
     /// </summary>
-    public class RotateCoreSides : BaseArg
+    public class RotateCoreBars : BaseArg
     {
+        /// <summary>
+        /// if true,we check for the first arg that has RotateCoreCount when setting the bars,
+        /// otherwise we use the actor's name to guess the number of balls (8M -> 8 balls per bar)
+        /// </summary>
+        public bool UseArgCount { get; set; } 
+        public string PointModel { get; set; } // last repeated object
+        public string MiddleModel { get; set; } // object to repeat in line
+        public RotateCoreBars(Dictionary<string, object> props)
+        {
+            object? v;
+            if (props.TryGetValue("UseArgCount", out v))
+                UseArgCount = (bool)v;
+            if (props.TryGetValue("MiddleModel", out v))
+                MiddleModel = (string)v;
+            if (props.TryGetValue("PointModel", out v))
+                PointModel = (string)v;
+        }
         
     }
     /// <summary>
@@ -275,8 +281,8 @@ internal static class ClassModifiersWrapper
                 {
                     ArgType.Tower => new TowerArg(entry.Args[k].Properties),
                     ArgType.AnimChange => new AnimChangeArg(entry.Args[k].Properties),
-                    ArgType.RotateCoreCount => new RotateCoreAmount(entry.Args[k].Properties),
-                    ArgType.RotateCoreSides => new RotateCoreSides(),
+                    ArgType.RotateCoreCount => new RotateCoreCount(),
+                    ArgType.RotateCoreSides => new RotateCoreBars(entry.Args[k].Properties),
                     ArgType.SwingCoreLength => new SwingingCore(entry.Args[k].Properties),
                     ArgType.AddExtraModel => new ExtraArgModels(entry.Args[k].Properties),
                     ArgType.ShadowType => new ShadowType(),

--- a/Autumn/Wrappers/ClassModifiersWrapper.cs
+++ b/Autumn/Wrappers/ClassModifiersWrapper.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Autumn.Enums;
+using SharpYaml.Serialization;
 
 namespace Autumn.Wrappers;
 
@@ -8,7 +9,7 @@ internal static class ClassModifiersWrapper
     public struct ModifierBase
     {
         public ModifierEntry? Default { get; set; }
-        public Dictionary<string, ModifierEntry?>? Variants { get; set; }
+        public Dictionary<string, ModifierEntry>? Variants { get; set; }
     }
     public struct ModifierEntry
     {
@@ -19,7 +20,9 @@ internal static class ClassModifiersWrapper
         public Vector3? Rotation { get; set; } // Implemented
         public List<string>? HiddenMeshes { get; set; } // Implemented
         public Dictionary<string, byte>? MeshesPriority { get; set; }
-        public Dictionary<string, BaseArgChange>? Args { get; set; } // ArgID, Arg
+        public Dictionary<string, ArgChange>? Args { get; set; } // ArgID, Arg
+        [YamlIgnore]
+        public Dictionary<string, BaseArg>? ArgsRem { get; set; } // ArgID, Arg
     }
     public struct ExtraModel
     {
@@ -31,7 +34,7 @@ internal static class ClassModifiersWrapper
     /// Temporary replacement for args
     /// </summary>
     [Obsolete]
-    public struct BaseArgChange : ArgChange
+    public struct BaseArgChange
     {
         public ArgType ArgType { get; set; }
 
@@ -45,29 +48,61 @@ internal static class ClassModifiersWrapper
         public H3DAnimation? AnimType { get; set; } // type of the animation
     }
 
-    public interface ArgChange
+    public class ArgChange
     {
         public ArgType ArgType { get; set; }
+        public Dictionary<string, object> Properties { get; set; }
     }
-    public struct TowerArg : ArgChange
+    public interface BaseArg
     {
-        public ArgType ArgType { get; set; }
+
+    }
+    public class SimpleArg : BaseArg
+    {
+        public byte BasicTestValue = 0; 
+    }
+    public class TowerArg : BaseArg
+    {
         public string? RepeatModel { get; set; } // If no RepeatModel -> use basemodel
-        public bool StartAtZero { get; set; } // whether the top model disappears at 0 or not
+        public bool? CountTop { get; set; } // whether the top model disappears at 0 or not
         public Vector3 Offset { get; set; }
+        public TowerArg(Dictionary<string, object> props)
+        {
+            object? v;
+            if (props.TryGetValue("RepeatModel", out v))
+                RepeatModel = (string)v;
+            if (props.TryGetValue("CountTop", out v))
+                CountTop = (bool)v;
+            if (props.TryGetValue("Offset", out v))
+                Offset = FromDict((Dictionary<object,object>)v);
+        }
     }
     /// <summary>
     /// Plays the specific frame of an animation in the model file 
     /// Can be used for material and skeleton animations
     /// Uses value of the Arg as the frame
     /// </summary>
-    public struct AnimChangeArg : ArgChange
+    public class AnimChangeArg : BaseArg
     {
-        public ArgType ArgType { get; set; }
         public string AnimName { get; set; } // animation to use
         public H3DAnimation AnimType { get; set; } // type of the animation
         // public int Frame { get; set; } // animation frame to use
+        public AnimChangeArg(Dictionary<string, object> props)
+        {
+            object? v;
+            if (props.TryGetValue("AnimName", out v))
+                AnimName = (string)v;
+            if (props.TryGetValue("AnimType", out v))
+                AnimType = Enum.Parse<H3DAnimation>((string)v);
+        }
     }
+
+    /// <summary>
+    /// Converts the X Y Z dictionary to a Vector3, assumes the dictionary is formatted properly
+    /// </summary>
+    /// <param name="o"></param>
+    /// <returns></returns>
+    public static Vector3 FromDict(Dictionary<object, object> o) => new Vector3(Convert.ToSingle(o["X"]), Convert.ToSingle(o["Y"]), Convert.ToSingle(o["Z"])); 
 
     private static SortedDictionary<string, ModifierBase>? s_ModifierEntries = null;
 
@@ -88,6 +123,54 @@ internal static class ClassModifiersWrapper
                 foreach (string entryPath in Directory.EnumerateFiles(path))
                 {
                     ModifierBase entry = YAMLWrapper.Deserialize<ModifierBase>(entryPath);
+                    if (entry.Default != null && entry.Default.Value.Args != null)
+                    {
+                        var vl = entry.Default.Value;
+                        vl.ArgsRem = new();
+                        entry.Default = vl;
+                        foreach (string k in entry.Default.Value.Args.Keys)
+                        {
+                            BaseArg arg;
+                            switch (entry.Default.Value.Args[k].ArgType)
+                            {
+                                case ArgType.Tower:
+                                    arg = new TowerArg(entry.Default.Value.Args[k].Properties);
+                                break;
+                                case ArgType.AnimChange:
+                                    arg = new AnimChangeArg(entry.Default.Value.Args[k].Properties);
+                                break;
+                                default:
+                                    arg = new SimpleArg();
+                                break;
+                            }
+                            entry.Default.Value.ArgsRem.Add(k, arg);
+                        }
+                    }
+                    if (entry.Variants != null)
+                    foreach (string ent in entry.Variants.Keys)
+                    {           
+                        if (entry.Variants[ent]!.Args == null) continue;
+                        var vl = entry.Variants[ent]!;
+                        vl.ArgsRem = new();
+                        entry.Variants[ent] = vl;
+                        foreach (string k in entry.Variants[ent]!.Args!.Keys)
+                        {
+                            BaseArg arg;
+                            switch (entry.Variants[ent]!.Args![k].ArgType)
+                            {
+                                case ArgType.Tower:
+                                    arg = new TowerArg(entry.Variants[ent]!.Args![k].Properties);
+                                break;
+                                case ArgType.AnimChange:
+                                    arg = new AnimChangeArg(entry.Variants[ent]!.Args![k].Properties);
+                                break;
+                                default:
+                                    arg = new SimpleArg();
+                                break;
+                            }
+                            entry.Variants[ent]!.ArgsRem!.Add(k, arg);
+                        }
+                    }
                     s_ModifierEntries[Path.GetFileNameWithoutExtension(entryPath)] = entry;
                 }
                 ReloadEntries = false;

--- a/Autumn/Wrappers/ClassModifiersWrapper.cs
+++ b/Autumn/Wrappers/ClassModifiersWrapper.cs
@@ -187,6 +187,21 @@ internal static class ClassModifiersWrapper
                 TwoChains = (bool)v;
         }
     }
+    public class ShadowType : BaseArg
+    {
+
+    }
+    public class ScaleAxis : BaseArg
+    {
+        // public Vector3 HeadOffset { get; set; }
+        public string Axis { get; set; }
+        public ScaleAxis(Dictionary<string, object> props)
+        {
+            object? v;
+            if (props.TryGetValue("Axis", out v))
+                Axis = (string)v;
+        }
+    }
 
 
     /// <summary>
@@ -264,6 +279,8 @@ internal static class ClassModifiersWrapper
                     ArgType.RotateCoreSides => new RotateCoreSides(),
                     ArgType.SwingCoreLength => new SwingingCore(entry.Args[k].Properties),
                     ArgType.AddExtraModel => new ExtraArgModels(entry.Args[k].Properties),
+                    ArgType.ShadowType => new ShadowType(),
+                    ArgType.ScaleAxis => new ScaleAxis(entry.Args[k].Properties),
                     _ => new SimpleArg(),
                 };
                 entry.ArgsRem.Add(k, arg);

--- a/Autumn/Wrappers/ClassModifiersWrapper.cs
+++ b/Autumn/Wrappers/ClassModifiersWrapper.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Autumn.Enums;
 
 namespace Autumn.Wrappers;
 
@@ -11,14 +12,14 @@ internal static class ClassModifiersWrapper
     }
     public struct ModifierEntry
     {
-        public string? ModelReplace { get; set; }
-        public Dictionary<string, ExtraModel?>? ExtraModels { get; set; }
-        public Vector3? Translation { get; set; }
-        public Vector3? Scale { get; set; }
-        public Vector3? Rotation { get; set; }
-        public List<string>? HiddenMeshes { get; set; }
+        public string? ModelReplace { get; set; } // Implemented
+        public Dictionary<string, ExtraModel?>? ExtraModels { get; set; } // Implemented
+        public Vector3? Translation { get; set; } // Implemented
+        public Vector3? Scale { get; set; } // Implemented
+        public Vector3? Rotation { get; set; } // Implemented
+        public List<string>? HiddenMeshes { get; set; } // Implemented
         public Dictionary<string, byte>? MeshesPriority { get; set; }
-        public List<ArgChange>? Args { get; set; }
+        public Dictionary<string, BaseArgChange>? Args { get; set; } // ArgID, Arg
     }
     public struct ExtraModel
     {
@@ -26,20 +27,46 @@ internal static class ClassModifiersWrapper
         public Vector3? Scale { get; set; }
         public Vector3? Rotation { get; set; }
     }
+    /// <summary>
+    /// Temporary replacement for args
+    /// </summary>
+    [Obsolete]
+    public struct BaseArgChange : ArgChange
+    {
+        public ArgType ArgType { get; set; }
+
+        // Tower
+        public string? RepeatModel { get; set; } // If no RepeatModel -> use basemodel
+        public bool? CountTop { get; set; }
+        public Vector3? Offset { get; set; }
+
+        //Animation
+        public string? AnimName { get; set; } // animation to use
+        public H3DAnimation? AnimType { get; set; } // type of the animation
+    }
+
     public interface ArgChange
     {
-        public int ID { get; set; }
+        public ArgType ArgType { get; set; }
     }
     public struct TowerArg : ArgChange
     {
-        public int ID { get; set; }
-        public string? RepeatModel { get; set; }
+        public ArgType ArgType { get; set; }
+        public string? RepeatModel { get; set; } // If no RepeatModel -> use basemodel
+        public bool StartAtZero { get; set; } // whether the top model disappears at 0 or not
         public Vector3 Offset { get; set; }
     }
-    public struct MaterialChangeArg : ArgChange
+    /// <summary>
+    /// Plays the specific frame of an animation in the model file 
+    /// Can be used for material and skeleton animations
+    /// Uses value of the Arg as the frame
+    /// </summary>
+    public struct AnimChangeArg : ArgChange
     {
-        public int ID { get; set; }
-        public int Frame { get; set; } // animation frame to use
+        public ArgType ArgType { get; set; }
+        public string AnimName { get; set; } // animation to use
+        public H3DAnimation AnimType { get; set; } // type of the animation
+        // public int Frame { get; set; } // animation frame to use
     }
 
     private static SortedDictionary<string, ModifierBase>? s_ModifierEntries = null;
@@ -52,9 +79,11 @@ internal static class ClassModifiersWrapper
             {
                 s_ModifierEntries = new();
                 string path = Path.Join("Resources", "Modifiers");
-                // ModifierBase bbb = new() { Variants = new(), TEST = new Vector3(30, 20, 0)};
+                // ModifierBase bbb = new() { Variants = new() };
                 // bbb.Variants.Add("CoinCollect4", new());
-                // bbb.Variants["CoinCollect4"] = new(){ Translation = new() { X = 0, Y = 100, Z = 0}, HiddenMeshes = ["BlockQuestionEmpty", "BlockQuestionTest"]};
+                // bbb.Variants["CoinCollect4"] = new(){ Translation = new() { X = 0, Y = 100, Z = 0}, HiddenMeshes = ["BlockQuestionEmpty", "BlockQuestionTest"], 
+                // Args = [ new AnimChangeArg() { AnimName = "Color", AnimType = H3DAnimation.MaterialAnim, Frame = 0, ID = 0 } ]   };
+            
                 // YAMLWrapper.Serialize<ModifierBase>(Path.Join(path, "CoinCollect4.yml"), bbb);
                 foreach (string entryPath in Directory.EnumerateFiles(path))
                 {
@@ -69,4 +98,20 @@ internal static class ClassModifiersWrapper
     }
 
     public static bool ReloadEntries = false;
+
+    public static ModifierEntry? GetEntry(string actorName, string className)
+    {
+        if (s_ModifierEntries is null || !s_ModifierEntries.ContainsKey(className))
+        {
+            return null;
+        }
+
+        if (s_ModifierEntries[className].Variants != null && s_ModifierEntries[className].Variants!.ContainsKey(actorName))
+            return s_ModifierEntries[className].Variants![actorName];
+        else if (s_ModifierEntries[className].Default != null)
+            return s_ModifierEntries[className].Default;
+        else
+            return null;
+    }
+
 }

--- a/Autumn/Wrappers/ClassModifiersWrapper.cs
+++ b/Autumn/Wrappers/ClassModifiersWrapper.cs
@@ -1,0 +1,72 @@
+using System.Numerics;
+
+namespace Autumn.Wrappers;
+
+internal static class ClassModifiersWrapper
+{
+    public struct ModifierBase
+    {
+        public ModifierEntry? Default { get; set; }
+        public Dictionary<string, ModifierEntry?>? Variants { get; set; }
+    }
+    public struct ModifierEntry
+    {
+        public string? ModelReplace { get; set; }
+        public Dictionary<string, ExtraModel?>? ExtraModels { get; set; }
+        public Vector3? Translation { get; set; }
+        public Vector3? Scale { get; set; }
+        public Vector3? Rotation { get; set; }
+        public List<string>? HiddenMeshes { get; set; }
+        public Dictionary<string, byte>? MeshesPriority { get; set; }
+        public List<ArgChange>? Args { get; set; }
+    }
+    public struct ExtraModel
+    {
+        public Vector3? Translation { get; set; }
+        public Vector3? Scale { get; set; }
+        public Vector3? Rotation { get; set; }
+    }
+    public interface ArgChange
+    {
+        public int ID { get; set; }
+    }
+    public struct TowerArg : ArgChange
+    {
+        public int ID { get; set; }
+        public string? RepeatModel { get; set; }
+        public Vector3 Offset { get; set; }
+    }
+    public struct MaterialChangeArg : ArgChange
+    {
+        public int ID { get; set; }
+        public int Frame { get; set; } // animation frame to use
+    }
+
+    private static SortedDictionary<string, ModifierBase>? s_ModifierEntries = null;
+
+    public static SortedDictionary<string, ModifierBase> ModifierEntries
+    {
+        get
+        {
+            if (s_ModifierEntries is null || ReloadEntries)
+            {
+                s_ModifierEntries = new();
+                string path = Path.Join("Resources", "Modifiers");
+                // ModifierBase bbb = new() { Variants = new(), TEST = new Vector3(30, 20, 0)};
+                // bbb.Variants.Add("CoinCollect4", new());
+                // bbb.Variants["CoinCollect4"] = new(){ Translation = new() { X = 0, Y = 100, Z = 0}, HiddenMeshes = ["BlockQuestionEmpty", "BlockQuestionTest"]};
+                // YAMLWrapper.Serialize<ModifierBase>(Path.Join(path, "CoinCollect4.yml"), bbb);
+                foreach (string entryPath in Directory.EnumerateFiles(path))
+                {
+                    ModifierBase entry = YAMLWrapper.Deserialize<ModifierBase>(entryPath);
+                    s_ModifierEntries[Path.GetFileNameWithoutExtension(entryPath)] = entry;
+                }
+                ReloadEntries = false;
+            }
+
+            return s_ModifierEntries;
+        }
+    }
+
+    public static bool ReloadEntries = false;
+}

--- a/Autumn/Wrappers/ClassModifiersWrapper.cs
+++ b/Autumn/Wrappers/ClassModifiersWrapper.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Autumn.Enums;
+using Autumn.Utils;
 using SharpYaml.Serialization;
 
 namespace Autumn.Wrappers;
@@ -29,6 +30,17 @@ internal static class ClassModifiersWrapper
         public Vector3? Translation { get; set; }
         public Vector3? Scale { get; set; }
         public Vector3? Rotation { get; set; }
+        public Transform GetTransform()
+        {
+            Transform t = new();
+            if (Translation != null)
+                t.Translate = Translation.Value;
+            if (Scale != null)
+                t.Scale = Scale.Value;
+            if (Rotation != null)
+                t.Rotate = Rotation.Value;
+            return t;
+        }
     }
     /// <summary>
     /// Temporary replacement for args
@@ -77,6 +89,36 @@ internal static class ClassModifiersWrapper
                 Offset = FromDict((Dictionary<object,object>)v);
         }
     }
+    public class ExtraArgModels : BaseArg
+    {
+        public Dictionary<string, ExtraModel> Models { get; set; } // If no RepeatModel -> use basemodel
+        public ExtraArgModels(Dictionary<string, object> props)
+        {
+            object? v;
+            if (props.TryGetValue("Models", out v))
+                if (v is Dictionary<object, object>)
+                {
+                    Models = new();
+                    var dc = (Dictionary<object, object>)v;
+                    foreach (string s in dc.Keys)
+                    {
+                        if (dc[s] is not Dictionary<object, object>) 
+                        {
+                            Models.Add(s, new());
+                            continue;
+                        }
+                        var EM = new ExtraModel();
+                        if (((Dictionary<object, object>)dc[s]).TryGetValue("Translation", out v))
+                            EM.Translation = FromDict((Dictionary<object, object>)v);
+                        if (((Dictionary<object, object>)dc[s]).TryGetValue("Scale", out v))
+                            EM.Scale = FromDict((Dictionary<object, object>)v);
+                        if (((Dictionary<object, object>)dc[s]).TryGetValue("Rotation", out v))
+                            EM.Rotation = FromDict((Dictionary<object, object>)v);
+                        Models.Add(s, EM);
+                    }
+                }
+        }
+    }
     /// <summary>
     /// Plays the specific frame of an animation in the model file 
     /// Can be used for material and skeleton animations
@@ -98,14 +140,64 @@ internal static class ClassModifiersWrapper
     }
 
     /// <summary>
+    /// Actor that has models (MiddleModel, PointModel) that rotate around it, one arg can set the amount of said RotateModel, another arg sets the number of lines of that
+    /// Value of the arg -> number of balls
+    /// </summary>
+    public class RotateCoreAmount : BaseArg
+    {
+        // public Vector3 Offset { get; set; } // Hardcoded
+        public string? PointModel { get; set; } // last repeated object
+        public string? MiddleModel { get; set; } // object to repeat in line
+        public RotateCoreAmount(Dictionary<string, object> props)
+        {
+            object? v;
+            if (props.TryGetValue("MiddleModel", out v))
+                MiddleModel = (string)v;
+            if (props.TryGetValue("PointModel", out v))
+                PointModel = (string)v;
+        }
+    }
+    /// <summary>
+    /// Number of lines for this actor, they will be drawn as equal divisions of a circle (3 lines -> 120º between each)
+    /// Value of the arg -> line count
+    /// </summary>
+    public class RotateCoreSides : BaseArg
+    {
+        
+    }
+    /// <summary>
+    /// Actor that is separate from the origin by a given length
+    /// Arg value -> Length
+    /// </summary>
+    public class SwingingCore : BaseArg
+    {
+        // public Vector3 HeadOffset { get; set; }
+        public string HeadModel { get; set; }
+        public string ChainModel { get; set; }
+        public bool? TwoChains { get; set; }
+        public Vector3? ChainDistance { get; set; }
+        public SwingingCore(Dictionary<string, object> props)
+        {
+            object? v;
+            if (props.TryGetValue("HeadModel", out v))
+                HeadModel = (string)v;
+            if (props.TryGetValue("ChainModel", out v))
+                ChainModel = (string)v;
+            if (props.TryGetValue("TwoChains", out v))
+                TwoChains = (bool)v;
+        }
+    }
+
+
+    /// <summary>
     /// Converts the X Y Z dictionary to a Vector3, assumes the dictionary is formatted properly
     /// </summary>
     /// <param name="o"></param>
     /// <returns></returns>
     public static Vector3 FromDict(Dictionary<object, object> o) => new Vector3(Convert.ToSingle(o["X"]), Convert.ToSingle(o["Y"]), Convert.ToSingle(o["Z"])); 
 
-    private static SortedDictionary<string, ModifierBase>? s_ModifierEntries = null;
-
+    private static SortedDictionary<string, ModifierBase>? s_ModifierEntries = null; // ClassName / Entry 
+    public static bool ReloadEntries = false;
     public static SortedDictionary<string, ModifierBase> ModifierEntries
     {
         get
@@ -125,51 +217,13 @@ internal static class ClassModifiersWrapper
                     ModifierBase entry = YAMLWrapper.Deserialize<ModifierBase>(entryPath);
                     if (entry.Default != null && entry.Default.Value.Args != null)
                     {
-                        var vl = entry.Default.Value;
-                        vl.ArgsRem = new();
-                        entry.Default = vl;
-                        foreach (string k in entry.Default.Value.Args.Keys)
-                        {
-                            BaseArg arg;
-                            switch (entry.Default.Value.Args[k].ArgType)
-                            {
-                                case ArgType.Tower:
-                                    arg = new TowerArg(entry.Default.Value.Args[k].Properties);
-                                break;
-                                case ArgType.AnimChange:
-                                    arg = new AnimChangeArg(entry.Default.Value.Args[k].Properties);
-                                break;
-                                default:
-                                    arg = new SimpleArg();
-                                break;
-                            }
-                            entry.Default.Value.ArgsRem.Add(k, arg);
-                        }
+                        entry.Default = SetEntryArgs(entry.Default.Value, path);
                     }
                     if (entry.Variants != null)
                     foreach (string ent in entry.Variants.Keys)
                     {           
                         if (entry.Variants[ent]!.Args == null) continue;
-                        var vl = entry.Variants[ent]!;
-                        vl.ArgsRem = new();
-                        entry.Variants[ent] = vl;
-                        foreach (string k in entry.Variants[ent]!.Args!.Keys)
-                        {
-                            BaseArg arg;
-                            switch (entry.Variants[ent]!.Args![k].ArgType)
-                            {
-                                case ArgType.Tower:
-                                    arg = new TowerArg(entry.Variants[ent]!.Args![k].Properties);
-                                break;
-                                case ArgType.AnimChange:
-                                    arg = new AnimChangeArg(entry.Variants[ent]!.Args![k].Properties);
-                                break;
-                                default:
-                                    arg = new SimpleArg();
-                                break;
-                            }
-                            entry.Variants[ent]!.ArgsRem!.Add(k, arg);
-                        }
+                        entry.Variants[ent] = SetEntryArgs(entry.Variants[ent], path);
                     }
                     s_ModifierEntries[Path.GetFileNameWithoutExtension(entryPath)] = entry;
                 }
@@ -179,8 +233,6 @@ internal static class ClassModifiersWrapper
             return s_ModifierEntries;
         }
     }
-
-    public static bool ReloadEntries = false;
 
     public static ModifierEntry? GetEntry(string actorName, string className)
     {
@@ -196,5 +248,33 @@ internal static class ClassModifiersWrapper
         else
             return null;
     }
+
+    private static ModifierEntry SetEntryArgs(ModifierEntry entry, string path)
+    {
+        entry.ArgsRem = [];
+        foreach (string k in entry.Args!.Keys)
+        {
+            try
+            {
+                BaseArg arg = entry.Args[k].ArgType switch
+                {
+                    ArgType.Tower => new TowerArg(entry.Args[k].Properties),
+                    ArgType.AnimChange => new AnimChangeArg(entry.Args[k].Properties),
+                    ArgType.RotateCoreCount => new RotateCoreAmount(entry.Args[k].Properties),
+                    ArgType.RotateCoreSides => new RotateCoreSides(),
+                    ArgType.SwingCoreLength => new SwingingCore(entry.Args[k].Properties),
+                    ArgType.AddExtraModel => new ExtraArgModels(entry.Args[k].Properties),
+                    _ => new SimpleArg(),
+                };
+                entry.ArgsRem.Add(k, arg);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"{e.Message} while reading Arg ${k} of entry {Path.GetFileName(path)}");
+            }
+        }
+        return entry;
+    }
+
 
 }

--- a/Autumn/Wrappers/SZSWrapper.cs
+++ b/Autumn/Wrappers/SZSWrapper.cs
@@ -17,6 +17,7 @@ internal static class SZSWrapper
         }
         catch
         {
+            Console.WriteLine($"File in {path} was not a valid szs file");
             return null;
         }
 

--- a/Autumn/Wrappers/YAMLWrapper.cs
+++ b/Autumn/Wrappers/YAMLWrapper.cs
@@ -25,9 +25,9 @@ internal static class YAMLWrapper
             text = File.ReadAllText(path);
             result = serializer.Deserialize<T>(text);
         }
-        catch
+        catch (SharpYaml.YamlException y)
         {
-            Console.WriteLine($"File in {path} was incorrectly formatted");
+            Console.WriteLine($"File in {path} was incorrectly formatted: {y.Message}");
             return default;
         }
 

--- a/Autumn/Wrappers/YAMLWrapper.cs
+++ b/Autumn/Wrappers/YAMLWrapper.cs
@@ -27,6 +27,7 @@ internal static class YAMLWrapper
         }
         catch
         {
+            Console.WriteLine($"File in {path} was incorrectly formatted");
             return default;
         }
 

--- a/Autumn/Wrappers/YAMLWrapper.cs
+++ b/Autumn/Wrappers/YAMLWrapper.cs
@@ -25,7 +25,7 @@ internal static class YAMLWrapper
             text = File.ReadAllText(path);
             result = serializer.Deserialize<T>(text);
         }
-        catch (SharpYaml.YamlException y)
+        catch (Exception? y)
         {
             Console.WriteLine($"File in {path} was incorrectly formatted: {y.Message}");
             return default;


### PR DESCRIPTION
# Rendering
- Changed the rendering pipeline so objects meshes are rendered in order depending on their layers:
Opaque -> Transparent -> Subtractive -> Additive
This change to the rendering fixes A LOT of previous issues with transparency, but some objects will still render weird, since we're ultimately rendering in the object list order and not in a better way like distance t the camera.
- Implement mesh priority during object rendering, which is set during model creation for each mesh in a model
- Implemented proper rendering of objects that have projected textures, grabbing the information from the actor szs or using a default value. (Fixes actors like LavaFloater6x6 or LavaWheelLarge)
- Changed selection color to white
- Implemented models for all the area shapes:

| ShapeModelNo  | Type | Info |
| :--------: | :-------: | :-------: |
|  0  | Cube (Base) | Was already implemented, but has been changed to better match ingame proportions |
|  1  | Cube (Origin) | Same as the other cube, but has its center in the middle of the cube instead of the base |
|  2  | Sphere | Sphere centered in the middle of the model, this model is new |
|  3  | Cylinder |  Cylinder centered in the base of the model, this model is new  |
- Replaced the model for transparentwalls to be editor made, just like the areas
- Implement a system for per actor / object changes through [ClassModifiers](https://github.com/KirbysDarkNebula/Autumn-ClassModifiers), this allows for visual changes to the models that we couldn't get otherwise without hardcoding, and also allows for visual changes during arg editing. Some examples of changes currently implemented include:
_Changing position of objects like they would ingame, coins, star medals etc are all offset in the y position
Changing the model dynamically for objects depending on args, like how tall Goomba Tower or Pokey get to be._
- Changed the default LOD bias to be further away from the camera so mip maps in some models (GamaguchiKun, Punpun) became less noticeable
- Fixed issue with AlphaCompare not being obtained properly (dividing by 225 instead of 255)
- ### Changed how the viewport is rendered
- All the rendering we were doing prior is now rendered to a plane (canvas) and we apply post processing to the texture in that plane, allowing for:
- Implemented selection outlines
- Implemented Fog rendering
- Implemented ShadowObj and Shadow rendering (more on it down in the list)
- If post processing is disabled we won't have any of these features, but ShadowObj will still render, just opaque

- ShadowObj actor models are determined by Arg0, and the model change is controlled with Class Modifiers. these shadow models render the same as ingame with the new canvas rendering mentioned prior.
- Shadow rendering is marked as Experimental for now, as it's not fully accurate. The way it wrks is by grabbing the shadow model information from the actor szs if it exists and then render it in its own shadow pass along with ShadowObj actors. The biggest problem that arises is that the current method doesn't work well with self overlapping faces or when there's multiple (>5) shadows in the same line of sight, so these shadows are marked as experimental. Other problems with this at the moment would be managing multiple shadows in one object and shadow height through args (this one will be easy to implement, i just haven't gotten around it yet)

# General changes / improvements
- **Improved multiselect property editor, although it's still not great since there's no undo/redo**
- **Reimplemented the shortcuts dialog to use tabs and to allow modifying the shortcuts. Middle click t clear the shortcut, Escape to cancel editing. Allows Ctrl, Alt and Shift on top of any other key.**
- Made it so the editor uses SelectedObjCount to replace SelectedObjects.Count() & .Any(), since those called an Enumerable instead of the base List
- **As mentioned in the previous section, some args now visibly show the changes they produce to the objects in the scene, like changing the arg that adds a propellerbox to toad or the number of goombas in a tower, thanks to ClassModifiers**
- **Implemented save reminder dialog if the stage is pending saving and the user tries to close it**
- **Made it so stage tabs are placed in the scene window and not on the top bad**
- Added text to windows that previously had no text while awaiting operations ("Please open a stage")
- Modified the way external resources (class database and modifiers database) are stored after compilation, moving from the repo name + maintaining the same structure as it to only copying the folders we care about in the directory we want:
`Resources/ClassDB` & `Resources/Modifiers`
- Fixed oversight in InfiniteGrid picking
- Fix Add object dialog not setting rail point properties properly (they were always the same array, so when we multiadded, by shift clicking, the editor would crash)
- Added unhide all action, mapped to alt H
- Added "Toggle All" action, mapped to A, selects / deselects all objects
- Fixed issue with commands to open windows softlocking the editor if triggered while a window was already open
- That same issue made it so all actions could be triggered while extra popups were open, which could lead to unintended behaviour. The fix addresses this too.
- Improve transform axis text and usage for scale
- Scale transform action now scales equally on all axis if you input a number instead of needing an axis first
- Transforming on planes now shows you info on those planes instead of all X Y Z
- Inputting a number on the scale transform sets the value as opposed to adding to it (doesn't feel right for scales)
- **Implement [search window & fly cam](https://github.com/KirbysDarkNebula/Autumn/commit/856642a31387c32e4cf938618b51c0512816535f), mapped to Ctrl + F and Shift F respectively**
- ShapeModelNo in areas now has the 4 options mentioned in the rendering section as a ComboBox
- Set imgui.io.configDragClickToInputText to true on startup
- Add Quick access buttons to fog and light area, Arg 0 for light and fog areas has been replaced with a button that opens the respective editor
- Light area selector styling has been adapted to match the rest of the editor